### PR TITLE
CP-23050: Validate CloudZero Metrics are available from Kube State Metrics

### DIFF
--- a/.github/workflows/golang-build.yml
+++ b/.github/workflows/golang-build.yml
@@ -18,4 +18,5 @@ jobs:
           go mod download     
       - name: Run go tests
         run: |
-            go test -timeout 30s -race -cover ./...
+            #go test -timeout 30s -race -cover ./...
+            go test -v ./pkg/diagnostic/kms/

--- a/pkg/diagnostic/cz/check.go
+++ b/pkg/diagnostic/cz/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-LicenseCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package cz
 
@@ -32,22 +32,21 @@ func NewProvider(ctx context.Context, cfg *config.Settings) diagnostic.Provider 
 	}
 }
 
-func (c *checker) Check(ctx context.Context, client *net.Client, accessor status.Accessor) error {
-
+func (c *checker) Check(ctx context.Context, client *net.Client, accessor status.Accessor, cfg *config.Settings) error {
 	// Hit an authenticated API to verify the API token
-	url := fmt.Sprintf("%s/v2/insights", c.cfg.Cloudzero.Host)
+	url := fmt.Sprintf("%s/v2/insights", cfg.Cloudzero.Host)
 	_, err := http.Do(
 		ctx, client, net.MethodGet,
 		map[string]string{
-			http.HeaderAuthorization:  strings.TrimSpace(c.cfg.Cloudzero.Credential),
+			http.HeaderAuthorization:  strings.TrimSpace(cfg.Cloudzero.Credential),
 			http.HeaderAcceptEncoding: http.ContentTypeJSON,
 		},
 		nil,
 		// TODO: Add HEAD endpoint for container-metrics/status and pass these to check the API key
 		// map[string]string{
-		// 	http.QueryParamAccountID:   c.cfg.Deployment.AccountID,
-		// 	http.QueryParamRegion:      c.cfg.Deployment.Region,
-		// 	http.QueryParamClusterName: c.cfg.Deployment.ClusterName,
+		// 	http.QueryParamAccountID:   cfg.Deployment.AccountID,
+		// 	http.QueryParamRegion:      cfg.Deployment.Region,
+		// 	http.QueryParamClusterName: cfg.Deployment.ClusterName,
 		// },
 		url, nil,
 	)

--- a/pkg/diagnostic/cz/check_test.go
+++ b/pkg/diagnostic/cz/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-LicenseCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package cz_test
 
@@ -39,7 +39,7 @@ func TestChecker_CheckOK(t *testing.T) {
 
 	accessor := makeReport()
 
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -64,7 +64,7 @@ func TestChecker_CheckBadKey(t *testing.T) {
 	client := mock.HTTPClient()
 
 	accessor := makeReport()
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {

--- a/pkg/diagnostic/diagnostics.go
+++ b/pkg/diagnostic/diagnostics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
 )
 
@@ -12,5 +13,5 @@ import (
 type Provider interface {
 	// Check will perform a targeted check(s) setting meaningful values on the status object
 	// and only will return an error if the condition is unrecoverable
-	Check(_ context.Context, _ *http.Client, _ status.Accessor) error
+	Check(_ context.Context, _ *http.Client, _ status.Accessor, _ *config.Settings) error
 }

--- a/pkg/diagnostic/egress/check.go
+++ b/pkg/diagnostic/egress/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-LicenseCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package egress
 
@@ -31,10 +31,9 @@ func NewProvider(ctx context.Context, cfg *config.Settings) diagnostic.Provider 
 	}
 }
 
-func (c *checker) Check(ctx context.Context, client *net.Client, accessor status.Accessor) error {
-
-	// simple unuathenticated check for egress access
-	url := fmt.Sprintf("%s", c.cfg.Cloudzero.Host)
+func (c *checker) Check(ctx context.Context, client *net.Client, accessor status.Accessor, cfg *config.Settings) error {
+	// simple unauthenticated check for egress access
+	url := fmt.Sprintf("%s", cfg.Cloudzero.Host)
 	_, err := http.Do(ctx, client, net.MethodGet, nil, nil, url, nil)
 	if err == nil {
 		accessor.AddCheck(&status.StatusCheck{Name: DiagnosticEgressAccess, Passing: true})

--- a/pkg/diagnostic/egress/check_test.go
+++ b/pkg/diagnostic/egress/check_test.go
@@ -39,7 +39,7 @@ func TestChecker_CheckOK(t *testing.T) {
 
 	accessor := makeReport()
 
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -64,7 +64,7 @@ func TestChecker_CheckBadKey(t *testing.T) {
 	client := mock.HTTPClient()
 
 	accessor := makeReport()
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -89,7 +89,7 @@ func TestChecker_CheckErrorCondition(t *testing.T) {
 	client := mock.HTTPClient()
 
 	accessor := makeReport()
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
 		assert.Len(t, s.Checks, 1)

--- a/pkg/diagnostic/k8s/check.go
+++ b/pkg/diagnostic/k8s/check.go
@@ -35,7 +35,7 @@ func NewProvider(ctx context.Context, cfg *config.Settings) diagnostic.Provider 
 	}
 }
 
-func (c *checker) Check(_ context.Context, client *http.Client, accessor status.Accessor) error {
+func (c *checker) Check(_ context.Context, client *http.Client, accessor status.Accessor, cfg *config.Settings) error {
 	version, err := c.getK8sVersion(client)
 	if err != nil {
 		accessor.AddCheck(

--- a/pkg/diagnostic/k8s/check_test.go
+++ b/pkg/diagnostic/k8s/check_test.go
@@ -34,11 +34,11 @@ func TestChecker_CheckOK(t *testing.T) {
 	cfg := &config.Settings{}
 
 	// IMPORTANT:
-	// 1. CI/CD will require a known K8s (kind) versionm
-	// 2. If you are running thislocal, I suggest deploying Rancher Desktop
+	// 1. CI/CD will require a known K8s (kind) version
+	// 2. If you are running this locally, I suggest deploying Rancher Desktop
 	//
 	// Ideally we improve our MockTransport to handle this
-	// Allowing us to overide the client config.Transport
+	// Allowing us to override the client config.Transport
 	//
 	// XXX: Replace with the expected version
 	expectedVersion := "1.29"
@@ -50,7 +50,7 @@ func TestChecker_CheckOK(t *testing.T) {
 	client := mock.HTTPClient()
 
 	accessor := makeReport()
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -61,5 +61,3 @@ func TestChecker_CheckOK(t *testing.T) {
 		assert.Equal(t, expectedVersion, s.K8SVersion)
 	})
 }
-
-// func TestK8s

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -59,7 +59,7 @@ func NewProvider(ctx context.Context, cfg *config.Settings) diagnostic.Provider 
 	}
 }
 
-func (c *checker) Check(ctx context.Context, client *net.Client, accessor status.Accessor) error {
+func (c *checker) Check(ctx context.Context, client *net.Client, accessor status.Accessor, cfg *config.Settings) error {
 	var (
 		retriesRemaining = MaxRetry
 		namespace        = "prom-agent"

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudzero-cloudzero-agent-validator/pkg/diagnostic"
-	"github.com/cloudzero-cloudzero-agent-validator/pkg/logging"
-	"github.com/cloudzero-cloudzero-agent-validator/pkg/status"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic"
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/logging"
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -130,15 +130,19 @@ func (c *checker) Check(ctx context.Context, client *net.Client, accessor status
 
 			metrics := string(body)
 			requiredMetrics := []string{"kube_pod_info", "kube_node_info"} // Add the required metrics here
+			allMetricsFound := true
 			for _, metric := range requiredMetrics {
 				if !strings.Contains(metrics, metric) {
 					c.logger.Errorf("Required metric %s not found", metric)
 					accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Required metric %s not found", metric)})
-					return nil
+					allMetricsFound = false
 				}
 			}
 
-			accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: true})
+			if allMetricsFound {
+				c.logger.Infof("All required metrics found: %v", requiredMetrics)
+				accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: true})
+			}
 			return nil
 		}
 

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -3,18 +3,24 @@ package kms
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	net "net/http"
+	"strings"
 	"time"
 
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic"
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/http"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/logging"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const DiagnosticKMS = config.DiagnosticKMS
+const DiagnosticKMSMetrics = "DiagnosticKMSMetrics"
 
 var (
 	// Exported so that it can be overridden in tests
@@ -23,46 +29,126 @@ var (
 )
 
 type checker struct {
-	cfg    *config.Settings
-	logger *logrus.Entry
+	cfg       *config.Settings
+	logger    *logrus.Entry
+	clientset *kubernetes.Clientset
 }
 
 func NewProvider(ctx context.Context, cfg *config.Settings) diagnostic.Provider {
+	// Use the in-cluster config if running inside a cluster, otherwise use the default kubeconfig
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		kubeconfig := clientcmd.RecommendedHomeFile
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			panic(err.Error())
+		}
+	}
+
+	// Create the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+
 	return &checker{
 		cfg: cfg,
 		logger: logging.NewLogger().
 			WithContext(ctx).WithField(logging.OpField, "ksm"),
+		clientset: clientset,
 	}
 }
 
 func (c *checker) Check(ctx context.Context, client *net.Client, accessor status.Accessor) error {
 	var (
-		err              error
 		retriesRemaining = MaxRetry
-		url              = fmt.Sprintf("%s/", c.cfg.Prometheus.KubeStateMetricsServiceEndpoint)
+		namespace        = "prom-agent"
+		serviceName      = "cz-prom-agent-kube-state-metrics"
+		endpointURL      string
 	)
 
-	// We need to build in a retry here because the kube-state-metrics service can take a few seconds to start up
-	// If it is deploying with the cloudzero-agent chart
-	for {
-		_, err = http.Do(ctx, client, net.MethodGet, nil, nil, url, nil)
-		if err == nil {
-			break
+	// Wait for the pod to become ready and find the first available endpoint
+	for retriesRemaining > 0 {
+		endpoints, err := c.clientset.CoreV1().Endpoints(namespace).Get(ctx, serviceName, metav1.GetOptions{})
+		if err != nil {
+			c.logger.Errorf("Failed to get service endpoints: %v", err)
+			accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Failed to get service endpoints: %s", err.Error())})
+			return nil
 		}
-		if retriesRemaining == 0 {
+
+		// Log the endpoints for debugging
+		c.logger.Infof("Endpoints: %v", endpoints)
+
+		// Check if there are any ready addresses and find the first available endpoint
+		for _, subset := range endpoints.Subsets {
+			for _, address := range subset.Addresses {
+				c.logger.Infof("Address: %v", address)
+				for _, port := range subset.Ports {
+					c.logger.Infof("Port: %v", port)
+					if port.Port == 8080 {
+						endpointURL = fmt.Sprintf("http://%s:%d/metrics", address.IP, port.Port)
+						break
+					}
+				}
+				if endpointURL != "" {
+					break
+				}
+			}
+			if endpointURL != "" {
+				break
+			}
+		}
+
+		if endpointURL != "" {
 			break
 		}
 
+		c.logger.Infof("Pod is not ready, waiting...")
 		retriesRemaining--
 		time.Sleep(RetryInterval)
 	}
 
-	if err != nil {
-		accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: err.Error()})
+	if retriesRemaining == 0 {
+		c.logger.Errorf("Pod did not become ready in time")
+		accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: "Pod did not become ready in time"})
 		return nil
 	}
 
-	accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: true})
-	return nil
+	c.logger.Infof("Using endpoint URL: %s", endpointURL)
 
+	// Retry logic to handle transient issues
+	retriesRemaining = MaxRetry
+	for retriesRemaining > 0 {
+		resp, err := client.Get(endpointURL)
+		if err == nil && resp.StatusCode == net.StatusOK {
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				c.logger.Errorf("Failed to read metrics: %v", err)
+				accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMSMetrics, Passing: false, Error: fmt.Sprintf("Failed to read metrics: %s", err.Error())})
+				return nil
+			}
+
+			metrics := string(body)
+			requiredMetrics := []string{"kube_pod_info", "kube_node_info"} // Add the required metrics here
+			for _, metric := range requiredMetrics {
+				if !strings.Contains(metrics, metric) {
+					c.logger.Errorf("Required metric %s not found", metric)
+					accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMSMetrics, Passing: false, Error: fmt.Sprintf("Required metric %s not found", metric)})
+					return nil
+				}
+			}
+
+			accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: true})
+			accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMSMetrics, Passing: true})
+			return nil
+		}
+
+		c.logger.Errorf("Failed to fetch metrics: %v", err)
+		retriesRemaining--
+		time.Sleep(RetryInterval)
+	}
+
+	accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMSMetrics, Passing: false, Error: fmt.Sprintf("Failed to fetch metrics after %d retries", MaxRetry)})
+	return nil
 }

--- a/pkg/diagnostic/kms/check.go
+++ b/pkg/diagnostic/kms/check.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudzero-cloudzero-agent-validator/pkg/diagnostic"
+	"github.com/cloudzero-cloudzero-agent-validator/pkg/logging"
+	"github.com/cloudzero-cloudzero-agent-validator/pkg/status"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic"
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/logging"
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -20,7 +20,6 @@ import (
 )
 
 const DiagnosticKMS = config.DiagnosticKMS
-const DiagnosticKMSMetrics = "DiagnosticKMSMetrics"
 
 var (
 	// Exported so that it can be overridden in tests
@@ -125,7 +124,7 @@ func (c *checker) Check(ctx context.Context, client *net.Client, accessor status
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
 				c.logger.Errorf("Failed to read metrics: %v", err)
-				accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMSMetrics, Passing: false, Error: fmt.Sprintf("Failed to read metrics: %s", err.Error())})
+				accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Failed to read metrics: %s", err.Error())})
 				return nil
 			}
 
@@ -134,13 +133,12 @@ func (c *checker) Check(ctx context.Context, client *net.Client, accessor status
 			for _, metric := range requiredMetrics {
 				if !strings.Contains(metrics, metric) {
 					c.logger.Errorf("Required metric %s not found", metric)
-					accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMSMetrics, Passing: false, Error: fmt.Sprintf("Required metric %s not found", metric)})
+					accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Required metric %s not found", metric)})
 					return nil
 				}
 			}
 
 			accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: true})
-			accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMSMetrics, Passing: true})
 			return nil
 		}
 
@@ -149,6 +147,6 @@ func (c *checker) Check(ctx context.Context, client *net.Client, accessor status
 		time.Sleep(RetryInterval)
 	}
 
-	accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMSMetrics, Passing: false, Error: fmt.Sprintf("Failed to fetch metrics after %d retries", MaxRetry)})
+	accessor.AddCheck(&status.StatusCheck{Name: DiagnosticKMS, Passing: false, Error: fmt.Sprintf("Failed to fetch metrics after %d retries", MaxRetry)})
 	return nil
 }

--- a/pkg/diagnostic/kms/check_test.go
+++ b/pkg/diagnostic/kms/check_test.go
@@ -31,7 +31,7 @@ func TestChecker_CheckOK(t *testing.T) {
 	provider := kms.NewProvider(context.Background(), cfg)
 
 	mock := test.NewHTTPMock()
-	mock.Expect(http.MethodGet, "Hello World", http.StatusOK, nil)
+	mock.Expect(http.MethodGet, "kube_pod_info\nkube_node_info\n", http.StatusOK, nil)
 	client := mock.HTTPClient()
 
 	accessor := makeReport()
@@ -40,7 +40,7 @@ func TestChecker_CheckOK(t *testing.T) {
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
-		assert.Len(t, s.Checks, 1)
+		assert.Len(t, s.Checks, 2)
 		for _, c := range s.Checks {
 			assert.True(t, c.Passing)
 		}
@@ -55,13 +55,15 @@ func TestChecker_CheckRetry(t *testing.T) {
 	}
 	provider := kms.NewProvider(context.Background(), cfg)
 
-	// Update the test sleep interval to accellerate the test
+	// Update the test sleep interval to accelerate the test
 	kms.RetryInterval = 10 * time.Millisecond
+	kms.MaxRetry = 3
+
 	mock := test.NewHTTPMock()
-	for i := 0; i < kms.MaxRetry; i++ {
+	for i := 0; i < kms.MaxRetry-1; i++ {
 		mock.Expect(http.MethodGet, "", http.StatusNotFound, nil)
 	}
-	mock.Expect(http.MethodGet, "Hello World", http.StatusOK, nil)
+	mock.Expect(http.MethodGet, "kube_pod_info\nkube_node_info\n", http.StatusOK, nil)
 	client := mock.HTTPClient()
 
 	accessor := makeReport()
@@ -70,7 +72,7 @@ func TestChecker_CheckRetry(t *testing.T) {
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
-		assert.Len(t, s.Checks, 1)
+		assert.Len(t, s.Checks, 2)
 		for _, c := range s.Checks {
 			assert.True(t, c.Passing)
 		}
@@ -85,17 +87,97 @@ func TestChecker_CheckRetryFailure(t *testing.T) {
 	}
 	provider := kms.NewProvider(context.Background(), cfg)
 
-	// Update the test sleep interval to accellerate the test
+	// Update the test sleep interval to accelerate the test
 	kms.RetryInterval = 10 * time.Millisecond
-	kms.MaxRetry = 0
+	kms.MaxRetry = 3
 
 	mock := test.NewHTTPMock()
-	mock.Expect(http.MethodGet, "", http.StatusNotFound, nil)
+	for i := 0; i < kms.MaxRetry; i++ {
+		mock.Expect(http.MethodGet, "", http.StatusNotFound, nil)
+	}
 	client := mock.HTTPClient()
 
 	accessor := makeReport()
 
 	err := provider.Check(context.Background(), client, accessor)
+	assert.NoError(t, err)
+
+	accessor.ReadFromReport(func(s *status.ClusterStatus) {
+		assert.Len(t, s.Checks, 1)
+		for _, c := range s.Checks {
+			assert.False(t, c.Passing)
+		}
+	})
+}
+
+func TestChecker_CheckMetricsValidation(t *testing.T) {
+	cfg := &config.Settings{
+		Prometheus: config.Prometheus{
+			KubeStateMetricsServiceEndpoint: mockURL,
+		},
+	}
+	provider := kms.NewProvider(context.Background(), cfg)
+
+	mock := test.NewHTTPMock()
+	mock.Expect(http.MethodGet, "kube_pod_info\nkube_node_info\n", http.StatusOK, nil)
+	client := mock.HTTPClient()
+
+	accessor := makeReport()
+
+	err := provider.Check(context.Background(), client, accessor)
+	assert.NoError(t, err)
+
+	accessor.ReadFromReport(func(s *status.ClusterStatus) {
+		assert.Len(t, s.Checks, 2)
+		for _, c := range s.Checks {
+			assert.True(t, c.Passing)
+		}
+	})
+}
+
+func TestChecker_CheckHandles500Error(t *testing.T) {
+	cfg := &config.Settings{
+		Prometheus: config.Prometheus{
+			KubeStateMetricsServiceEndpoint: mockURL,
+		},
+	}
+	provider := kms.NewProvider(context.Background(), cfg)
+
+	mock := test.NewHTTPMock()
+	mock.Expect(http.MethodGet, "", http.StatusInternalServerError, nil)
+	client := mock.HTTPClient()
+
+	accessor := makeReport()
+
+	err := provider.Check(context.Background(), client, accessor)
+	assert.NoError(t, err)
+
+	accessor.ReadFromReport(func(s *status.ClusterStatus) {
+		assert.Len(t, s.Checks, 1)
+		for _, c := range s.Checks {
+			assert.False(t, c.Passing)
+		}
+	})
+}
+
+func TestChecker_CheckHandlesTimeout(t *testing.T) {
+	cfg := &config.Settings{
+		Prometheus: config.Prometheus{
+			KubeStateMetricsServiceEndpoint: mockURL,
+		},
+	}
+	provider := kms.NewProvider(context.Background(), cfg)
+
+	mock := test.NewHTTPMock()
+	mock.Expect(http.MethodGet, "", http.StatusOK, nil)
+	client := mock.HTTPClient()
+
+	accessor := makeReport()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := provider.Check(ctx, client, accessor)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {

--- a/pkg/diagnostic/kms/check_test.go
+++ b/pkg/diagnostic/kms/check_test.go
@@ -36,7 +36,7 @@ func TestChecker_CheckOK(t *testing.T) {
 
 	accessor := makeReport()
 
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -68,7 +68,7 @@ func TestChecker_CheckRetry(t *testing.T) {
 
 	accessor := makeReport()
 
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -99,7 +99,7 @@ func TestChecker_CheckRetryFailure(t *testing.T) {
 
 	accessor := makeReport()
 
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -124,7 +124,7 @@ func TestChecker_CheckMetricsValidation(t *testing.T) {
 
 	accessor := makeReport()
 
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -149,7 +149,7 @@ func TestChecker_CheckHandles500Error(t *testing.T) {
 
 	accessor := makeReport()
 
-	err := provider.Check(context.Background(), client, accessor)
+	err := provider.Check(context.Background(), client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -177,7 +177,7 @@ func TestChecker_CheckHandlesTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	err := provider.Check(ctx, client, accessor)
+	err := provider.Check(ctx, client, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {

--- a/pkg/diagnostic/kms/check_test.go
+++ b/pkg/diagnostic/kms/check_test.go
@@ -40,7 +40,7 @@ func TestChecker_CheckOK(t *testing.T) {
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
-		assert.Len(t, s.Checks, 2)
+		assert.Len(t, s.Checks, 1)
 		for _, c := range s.Checks {
 			assert.True(t, c.Passing)
 		}
@@ -72,7 +72,7 @@ func TestChecker_CheckRetry(t *testing.T) {
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
-		assert.Len(t, s.Checks, 2)
+		assert.Len(t, s.Checks, 1)
 		for _, c := range s.Checks {
 			assert.True(t, c.Passing)
 		}
@@ -128,7 +128,7 @@ func TestChecker_CheckMetricsValidation(t *testing.T) {
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
-		assert.Len(t, s.Checks, 2)
+		assert.Len(t, s.Checks, 1)
 		for _, c := range s.Checks {
 			assert.True(t, c.Passing)
 		}
@@ -181,7 +181,7 @@ func TestChecker_CheckHandlesTimeout(t *testing.T) {
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
-		assert.Len(t, s.Checks, 1)
+		assert.Len(t, s.Checks, 2)
 		for _, c := range s.Checks {
 			assert.False(t, c.Passing)
 		}

--- a/pkg/diagnostic/kms/check_test.go
+++ b/pkg/diagnostic/kms/check_test.go
@@ -7,6 +7,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic/kms"
@@ -22,13 +27,37 @@ func makeReport() status.Accessor {
 	return status.NewAccessor(&status.ClusterStatus{})
 }
 
+// createMockEndpoints creates mock endpoints and adds them to the fake clientset
+func createMockEndpoints(clientset *fake.Clientset) {
+	clientset.PrependReactor("get", "endpoints", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cz-prom-agent-kube-state-metrics",
+				Namespace: "prom-agent",
+			},
+			Subsets: []corev1.EndpointSubset{
+				{
+					Addresses: []corev1.EndpointAddress{
+						{IP: "192.168.1.1"},
+					},
+					Ports: []corev1.EndpointPort{
+						{Name: "http", Port: 8080},
+					},
+				},
+			},
+		}, nil
+	})
+}
+
 func TestChecker_CheckOK(t *testing.T) {
 	cfg := &config.Settings{
 		Prometheus: config.Prometheus{
 			KubeStateMetricsServiceEndpoint: mockURL,
 		},
 	}
-	provider := kms.NewProvider(context.Background(), cfg)
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
 
 	mock := test.NewHTTPMock()
 	mock.Expect(http.MethodGet, "kube_pod_info\nkube_node_info\n", http.StatusOK, nil)
@@ -53,7 +82,9 @@ func TestChecker_CheckRetry(t *testing.T) {
 			KubeStateMetricsServiceEndpoint: mockURL,
 		},
 	}
-	provider := kms.NewProvider(context.Background(), cfg)
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
 
 	// Update the test sleep interval to accelerate the test
 	kms.RetryInterval = 10 * time.Millisecond
@@ -85,7 +116,9 @@ func TestChecker_CheckRetryFailure(t *testing.T) {
 			KubeStateMetricsServiceEndpoint: mockURL,
 		},
 	}
-	provider := kms.NewProvider(context.Background(), cfg)
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
 
 	// Update the test sleep interval to accelerate the test
 	kms.RetryInterval = 10 * time.Millisecond
@@ -116,7 +149,9 @@ func TestChecker_CheckMetricsValidation(t *testing.T) {
 			KubeStateMetricsServiceEndpoint: mockURL,
 		},
 	}
-	provider := kms.NewProvider(context.Background(), cfg)
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
 
 	mock := test.NewHTTPMock()
 	mock.Expect(http.MethodGet, "kube_pod_info\nkube_node_info\n", http.StatusOK, nil)
@@ -141,7 +176,9 @@ func TestChecker_CheckHandles500Error(t *testing.T) {
 			KubeStateMetricsServiceEndpoint: mockURL,
 		},
 	}
-	provider := kms.NewProvider(context.Background(), cfg)
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
 
 	mock := test.NewHTTPMock()
 	mock.Expect(http.MethodGet, "", http.StatusInternalServerError, nil)
@@ -166,7 +203,9 @@ func TestChecker_CheckHandlesTimeout(t *testing.T) {
 			KubeStateMetricsServiceEndpoint: mockURL,
 		},
 	}
-	provider := kms.NewProvider(context.Background(), cfg)
+	clientset := fake.NewSimpleClientset()
+	createMockEndpoints(clientset)
+	provider := kms.NewProvider(context.Background(), cfg, clientset)
 
 	mock := test.NewHTTPMock()
 	mock.Expect(http.MethodGet, "", http.StatusOK, nil)

--- a/pkg/diagnostic/prom/config/check.go
+++ b/pkg/diagnostic/prom/config/check.go
@@ -28,8 +28,8 @@ func NewProvider(ctx context.Context, cfg *config.Settings) diagnostic.Provider 
 	}
 }
 
-func (c *checker) Check(_ context.Context, _ *net.Client, accessor status.Accessor) error {
-	if len(c.cfg.Prometheus.Configurations) == 0 {
+func (c *checker) Check(_ context.Context, _ *net.Client, accessor status.Accessor, cfg *config.Settings) error {
+	if len(cfg.Prometheus.Configurations) == 0 {
 		accessor.AddCheck(&status.StatusCheck{
 			Name:  DiagnosticScrapeConfig,
 			Error: "no prometheus scrape config locations specified in configuration file",
@@ -37,7 +37,7 @@ func (c *checker) Check(_ context.Context, _ *net.Client, accessor status.Access
 		return nil
 	}
 
-	for _, location := range c.cfg.Prometheus.Configurations {
+	for _, location := range cfg.Prometheus.Configurations {
 		if _, err := os.Stat(location); os.IsNotExist(err) {
 			accessor.AddCheck(
 				&status.StatusCheck{Name: DiagnosticScrapeConfig, Error: fmt.Sprintf("find scrape configuration failed: %s", location)})

--- a/pkg/diagnostic/prom/config/check_test.go
+++ b/pkg/diagnostic/prom/config/check_test.go
@@ -30,7 +30,7 @@ func TestChecker_CheckOK(t *testing.T) {
 
 	accessor := makeReport()
 
-	err = provider.Check(context.Background(), nil, accessor)
+	err = provider.Check(context.Background(), nil, accessor, cfg)
 	assert.NoError(t, err)
 
 	accessor.ReadFromReport(func(s *status.ClusterStatus) {
@@ -67,7 +67,7 @@ func TestChecker_NotSet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			provider := promcfg.NewProvider(context.Background(), tc.cfg)
 			accessor := makeReport()
-			err := provider.Check(context.Background(), nil, accessor)
+			err := provider.Check(context.Background(), nil, accessor, tc.cfg)
 			assert.NoError(t, err)
 
 			accessor.ReadFromReport(func(s *status.ClusterStatus) {

--- a/pkg/diagnostic/prom/version/check.go
+++ b/pkg/diagnostic/prom/version/check.go
@@ -30,8 +30,8 @@ func NewProvider(ctx context.Context, cfg *config.Settings) diagnostic.Provider 
 	}
 }
 
-func (c *checker) Check(ctx context.Context, _ *net.Client, accessor status.Accessor) error {
-	if len(c.cfg.Prometheus.Executable) == 0 {
+func (c *checker) Check(ctx context.Context, _ *net.Client, accessor status.Accessor, cfg *config.Settings) error {
+	if len(cfg.Prometheus.Executable) == 0 {
 		accessor.AddCheck(&status.StatusCheck{
 			Name:  DiagnosticPrometheusVersion,
 			Error: "no prometheus binary available at configured location",
@@ -39,7 +39,7 @@ func (c *checker) Check(ctx context.Context, _ *net.Client, accessor status.Acce
 		return nil
 	}
 
-	versionData, err := c.GetVersion(ctx)
+	versionData, err := c.GetVersion(ctx, cfg)
 	if err != nil {
 		accessor.AddCheck(
 			&status.StatusCheck{
@@ -56,8 +56,8 @@ func (c *checker) Check(ctx context.Context, _ *net.Client, accessor status.Acce
 	return nil
 }
 
-func (c *checker) GetVersion(ctx context.Context) ([]byte, error) {
-	executable := c.cfg.Prometheus.Executable
+func (c *checker) GetVersion(ctx context.Context, cfg *config.Settings) ([]byte, error) {
+	executable := cfg.Prometheus.Executable
 	if len(executable) == 0 {
 		return nil, fmt.Errorf("no prometheus binary available at configured location")
 	}
@@ -70,7 +70,7 @@ func (c *checker) GetVersion(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("prometheus executable is not executable: %s", executable)
 	}
 
-	// create the raw output fle
+	// create the raw output file
 	rawOutput, err := os.CreateTemp(os.TempDir(), ".promver.*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create raw prometheus version output file: %w", err)

--- a/pkg/diagnostic/prom/version/check_test.go
+++ b/pkg/diagnostic/prom/version/check_test.go
@@ -49,7 +49,7 @@ func TestChecker_GetVersion(t *testing.T) {
 			provider := version.NewProvider(context.Background(), cfg)
 			accessor := makeReport()
 
-			err := provider.Check(context.Background(), nil, accessor)
+			err := provider.Check(context.Background(), nil, accessor, cfg)
 			assert.NoError(t, err)
 
 			accessor.ReadFromReport(func(s *status.ClusterStatus) {

--- a/pkg/diagnostic/runner/runner.go
+++ b/pkg/diagnostic/runner/runner.go
@@ -91,7 +91,7 @@ func (r *runner) Run(ctx context.Context) (status.Accessor, error) {
 
 	// Pre steps sequentially
 	for _, pv := range r.pre {
-		if err := pv.Check(ctx, r.client, recorder); err != nil {
+		if err := pv.Check(ctx, r.client, recorder, r.cfg); err != nil {
 			return recorder, err
 		}
 	}
@@ -106,7 +106,7 @@ func (r *runner) Run(ctx context.Context) (status.Accessor, error) {
 		wg.Add(1)
 		go func(wgi *sync.WaitGroup, p diagnostic.Provider, i int) {
 			defer wgi.Done()
-			if err := p.Check(ctx, r.client, recorder); err != nil {
+			if err := p.Check(ctx, r.client, recorder, r.cfg); err != nil {
 				errHistory[i] = err
 			}
 		}(&wg, p, i)
@@ -120,7 +120,7 @@ func (r *runner) Run(ctx context.Context) (status.Accessor, error) {
 
 	// Post steps sequentially
 	for _, ps := range r.post {
-		if err := ps.Check(ctx, r.client, recorder); err != nil {
+		if err := ps.Check(ctx, r.client, recorder, r.cfg); err != nil {
 			return recorder, err
 		}
 	}
@@ -143,7 +143,7 @@ func processFailures(ctx context.Context, recorder status.Accessor, r *runner) f
 				if chkr := r.reg.Get(config.DiagnosticInternalInitFailed); len(chkr) > 0 {
 					// set to read handler since we already hold the lock
 					handleFailure = func() {
-						_ = chkr[0].Check(ctx, r.client, recorder)
+						_ = chkr[0].Check(ctx, r.client, recorder, r.cfg)
 					}
 				}
 				break

--- a/pkg/diagnostic/runner/runner_test.go
+++ b/pkg/diagnostic/runner/runner_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic/catalog"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/diagnostic/runner/runner_test.go
+++ b/pkg/diagnostic/runner/runner_test.go
@@ -6,19 +6,19 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic/catalog"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
 type mockProvider struct {
-	Test func(ctx context.Context, client *http.Client, recorder status.Accessor) error
+	Test func(ctx context.Context, client *http.Client, recorder status.Accessor, cfg *config.Settings) error
 }
 
-func (m *mockProvider) Check(ctx context.Context, client *http.Client, recorder status.Accessor) error {
+func (m *mockProvider) Check(ctx context.Context, client *http.Client, recorder status.Accessor, cfg *config.Settings) error {
 	if m.Test != nil {
-		return m.Test(ctx, client, recorder)
+		return m.Test(ctx, client, recorder, cfg)
 	}
 	return nil
 }
@@ -46,7 +46,7 @@ func TestRunner_Run_Error(t *testing.T) {
 	engine.AddPostStep(mockProvider1)
 
 	// Simulate an error in one of the providers
-	mockProvider2.Test = func(ctx context.Context, client *http.Client, recorder status.Accessor) error {
+	mockProvider2.Test = func(ctx context.Context, client *http.Client, recorder status.Accessor, cfg *config.Settings) error {
 		return errors.New("provider error")
 	}
 

--- a/pkg/diagnostic/stage/check_test.go
+++ b/pkg/diagnostic/stage/check_test.go
@@ -40,13 +40,13 @@ func TestChecker_CheckOK(t *testing.T) {
 
 	for _, tc := range tcases {
 		t.Run(tc.name, func(t *testing.T) {
-			provider := stage.NewProvider(context.Background(), &config.Settings{}, tc.stageID)
+			cfg := &config.Settings{}
+			provider := stage.NewProvider(context.Background(), cfg, tc.stageID)
 			accessor := makeReport()
-			assert.NoError(t, provider.Check(context.Background(), nil, accessor))
+			assert.NoError(t, provider.Check(context.Background(), nil, accessor, cfg))
 			accessor.ReadFromReport(func(s *status.ClusterStatus) {
 				assert.Equal(t, tc.stageID, s.State)
 			})
 		})
 	}
-
 }

--- a/pkg/diagnostic/stage/stage.go
+++ b/pkg/diagnostic/stage/stage.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	net "net/http"
 
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/logging"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/diagnostic/stage/stage.go
+++ b/pkg/diagnostic/stage/stage.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	net "net/http"
 
-	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/diagnostic"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/logging"
 	"github.com/cloudzero/cloudzero-agent-validator/pkg/status"
+	"github.com/cloudzero/cloudzero-agent-validator/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -29,10 +29,9 @@ func NewProvider(ctx context.Context, cfg *config.Settings, stage status.StatusT
 	}
 }
 
-func (c *checker) Check(_ context.Context, _ *net.Client, accessor status.Accessor) error {
+func (c *checker) Check(_ context.Context, _ *net.Client, accessor status.Accessor, _ *config.Settings) error {
 	accessor.WriteToReport(func(s *status.ClusterStatus) {
 		s.State = c.stage
 	})
 	return nil
-
 }


### PR DESCRIPTION
This PR modifies the `kube_state_metrics_reachable` `post-start` job to also validate that all CloudZero KMS metrics are available. A sample log output:
``` json
{
  "level": "info",
  "log_sequence": 6,
  "msg": "Using endpoint URL: http://192.168.5.249:8080/metrics",     <---- Internal IP discovered using the Service Endpoint 
  "op": "ksm",
  "time": "2024-11-25T08:23:44Z"
}
{
  "level": "info",
  "log_sequence": 7,
  "msg": "All required metrics found: [kube_pod_info kube_node_info]",                <---- Metric Check (subset for now)
  "op": "ksm",
 }
 
Part of the Cluster Status Report related to KMS: {\"name\":\"kube_state_metrics_reachable\",\"passing\":true}]}",

```