### PR TITLE
[helm] Expose prometheus service

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
-version: 1.1.0-dev
+version: 1.1.1-dev
 maintainers:
   - name: CloudZero
     email: support@cloudzero.com

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -29,3 +29,19 @@ spec:
       port: 80
       targetPort: {{ .Values.aggregator.collector.port }}
   type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "cloudzero-agent.server.fullname" . }}
+  labels:
+    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "cloudzero-agent.server.matchLabels" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      port: 9090
+      targetPort: 9090
+      name: metrics


### PR DESCRIPTION
Operators of the Cloudzero Agent service may be interested to know what Prometheus is doing under the covers (e.g. storage, networking, etc) to help administrators of the service debug client-side things. One way to do that is to expose the underlying Prometheus service and let users roll their own monitoring.

I would have also made a ServiceMonitor object to go along with this (locked behind a flag) but I don't know if you want to commit the project to any one particular monitoring tool.