### PR TITLE
CP-27884: fix agent-validator initialization

### DIFF
--- a/cmd/agent-validator/main.go
+++ b/cmd/agent-validator/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cloudzero/cloudzero-agent/pkg/build"
 	configcmd "github.com/cloudzero/cloudzero-agent/pkg/cmd/config"
 	diagcmd "github.com/cloudzero/cloudzero-agent/pkg/cmd/diagnose"
+	"github.com/cloudzero/cloudzero-agent/pkg/cmd/install"
 	"github.com/cloudzero/cloudzero-agent/pkg/logging"
 )
 
@@ -42,6 +43,7 @@ func main() {
 	app.Commands = append(app.Commands,
 		configcmd.NewCommand(ctx),
 		diagcmd.NewCommand(),
+		install.NewCommand(),
 	)
 
 	err := app.Run(os.Args)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
+ARG DEPLOY_IMAGE=scratch
+
 # Stage 1: Build the Go binary
 FROM --platform=$BUILDPLATFORM golang:1.24.2-alpine AS builder
 ARG TARGETPLATFORM
@@ -31,9 +33,10 @@ RUN make build OUTPUT_BIN_DIR=/go/bin \
 # Stage 2: Access current certs
 FROM gcr.io/distroless/static-debian12:debug@sha256:5c474275684bbf271ec40502ab50158b2f9826de5877d8feec27e22e8d6ee3d2 AS certs
 
-# TODO: use busybox for development - switch to "scratch" before release
-#FROM busybox:1.36.1-uclibc
-FROM scratch
+# Note: For debugging, you can temporarily change the image used
+# for building by passing in something like this to 'docker build':
+#--build-arg DEPLOY_IMAGE=busybox:1.36.1-uclibc
+FROM ${DEPLOY_IMAGE}
 
 # Ensure we have certs for HTTPS requests
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,9 +33,12 @@ RUN make build OUTPUT_BIN_DIR=/go/bin \
 # Stage 2: Access current certs
 FROM gcr.io/distroless/static-debian12:debug@sha256:5c474275684bbf271ec40502ab50158b2f9826de5877d8feec27e22e8d6ee3d2 AS certs
 
-# Note: For debugging, you can temporarily change the image used
-# for building by passing in something like this to 'docker build':
-#--build-arg DEPLOY_IMAGE=busybox:1.36.1-uclibc
+# Note: For debugging, you can temporarily change the image used for building by
+# passing in something like this to 'docker build':
+#
+#   --build-arg DEPLOY_IMAGE=busybox:latest-uclibc
+#
+# This is what the `package-debug` and `package-build-debug` Make targets do.
 FROM ${DEPLOY_IMAGE}
 
 # Ensure we have certs for HTTPS requests

--- a/helm/templates/deploy.yaml
+++ b/helm/templates/deploy.yaml
@@ -31,12 +31,31 @@ spec:
 {{- end }}
       serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}
       initContainers:
-        - name: {{ .Values.validator.name }}
+        - name: {{ .Values.validator.name }}-copy
           {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.agent.image "image" .Values.validator.image) | nindent 10 }}
           command:
-            - /bin/sh
-            - -c
-            - cp -r /app /checks/bin/ && cloudzero-agent-validator d pre-start -f /checks/config/validator.yml
+            - /app/cloudzero-agent-validator
+            - install
+            - --destination
+            - /checks/bin/cloudzero-agent-validator
+          {{- with .Values.validator.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
+            - name: lifecycle-volume
+              mountPath: /checks/bin/
+            - name: validator-config-volume
+              mountPath: /checks/config/
+        - name: {{ .Values.validator.name }}-run
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.agent.image "image" .Values.validator.image) | nindent 10 }}
+          command:
+            - /checks/bin/cloudzero-agent-validator
+            - diagnose
+            - pre-start
+            - -f
+            - /checks/config/validator.yml
           {{- with .Values.validator.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -74,15 +93,19 @@ spec:
             postStart:
               exec:
                 command:
-                  - /bin/sh
-                  - -c
-                  - /check/app/cloudzero-agent-validator d post-start -f /check/app/config/validator.yml
+                  - /check/app/cloudzero-agent-validator
+                  - diagnose
+                  - post-start
+                  - -f
+                  - /checks/app/config/validator.yml
             preStop:
               exec:
                 command:
-                  - /bin/sh
-                  - -c
-                  - /check/app/cloudzero-agent-validator d pre-stop -f /check/app/config/validator.yml
+                  - /check/app/cloudzero-agent-validator
+                  - diagnose
+                  - pre-stop
+                  - -f
+                  - /check/app/config/validator.yml
           args:
             {{ toYaml .Values.server.args | nindent 12}}
             {{- if .Values.server.agentMode }}
@@ -121,9 +144,9 @@ spec:
               mountPath: {{ .Values.server.persistentVolume.mountPath }}
               subPath: "{{ .Values.server.persistentVolume.subPath }}"
             - name: lifecycle-volume
-              mountPath: /check/
+              mountPath: /checks/
             - name: validator-config-volume
-              mountPath: /check/app/config/
+              mountPath: /checks/app/config/
             {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
       securityContext:
         runAsUser: 65534

--- a/helm/templates/deploy.yaml
+++ b/helm/templates/deploy.yaml
@@ -93,7 +93,7 @@ spec:
             postStart:
               exec:
                 command:
-                  - /check/app/cloudzero-agent-validator
+                  - /checks/cloudzero-agent-validator
                   - diagnose
                   - post-start
                   - -f
@@ -101,7 +101,7 @@ spec:
             preStop:
               exec:
                 command:
-                  - /check/app/cloudzero-agent-validator
+                  - /checks/cloudzero-agent-validator
                   - diagnose
                   - pre-stop
                   - -f

--- a/helm/templates/insights-deploy.yaml
+++ b/helm/templates/insights-deploy.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       containers:
         - name: webhook-server
-          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.agent.image "image" (dict "repository" .Values.insightsController.server.image.repository "tag" (.Values.insightsController.server.image.tag | default .Chart.AppVersion) "pullPolicy" .Values.insightsController.server.image.pullPolicy)) | nindent 10 }}
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.agent.image "image" .Values.insightsController.server.image) | nindent 10 }}
           command:
             - /app/cloudzero-insights-controller
           args:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -127,7 +127,7 @@ agent:
   # The container image used for most CloudZero components.
   image:
     repository: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent
-    tag: 1.1.0-beta-3  # <- Software release corresponding to this chart version.
+    tag: 0.10.0  # <- Software release corresponding to this chart version.
     digest:
     pullPolicy: IfNotPresent
 

--- a/pkg/cmd/install/command.go
+++ b/pkg/cmd/install/command.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package install contains a CLI for copying the executable to a destination.
+package install
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	parentDirectoryMode = 0o755
+)
+
+func NewCommand() *cli.Command {
+	cmd := &cli.Command{
+		Name:    "install",
+		Usage:   "install executable",
+		Aliases: []string{"i"},
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "destination", Usage: "destination", Required: true},
+		},
+		Action: func(c *cli.Context) error {
+			return installExecutable(c.String("destination"))
+		},
+	}
+	return cmd
+}
+
+func installExecutable(destination string) error {
+	fmt.Printf("Installing executable from %s to %s\n", os.Args[0], destination)
+
+	source := os.Args[0]
+	sourceFile, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	sourceInfo, err := sourceFile.Stat()
+	if err != nil {
+		return err
+	}
+
+	destinationDirectory := filepath.Dir(destination)
+	if _, err = os.Stat(destinationDirectory); os.IsNotExist(err) {
+		if err = os.MkdirAll(destinationDirectory, parentDirectoryMode); err != nil {
+			return err
+		}
+	}
+
+	destinationFile, err := os.Create(destination)
+	if err != nil {
+		return err
+	}
+	defer destinationFile.Close()
+
+	if err = os.Chmod(destination, sourceInfo.Mode()); err != nil {
+		return err
+	}
+
+	_, err = io.Copy(destinationFile, sourceFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -38,6 +38,18 @@ function check_go_version() {
 }
 check_go_version
 
+# Check that Helm chart contains expected pattern(s) for version bump
+function check_helm_chart_version_bump() {
+    # This is the pattern we use in .github/workflows/release-to-main.yml to
+    # update the version of the CloudZero Agent container in the Helm chart.
+    # This just exists to make sure we don't accidentally break it by tweaking
+    # the comment or something.
+    if ! grep -Eq '^( +tag): +[^ ]+  (# <- Software release corresponding to this chart version.)$' helm/values.yaml; then
+        echo "Helm chart does not contain expected pattern for version bump" >&2
+        FAILED=true
+    fi
+}
+check_helm_chart_version_bump
 if [ "$FAILED" = true ]; then
     exit 1
 fi


### PR DESCRIPTION
Previously, we were relying on a bit of scripting to copy the agent-validator over to an emptyDir that could be used in the Prometheus image. However, since we are now basing everything off a scratch image that doesn't have a shell (or `cp` for that matter) installed that no longer works.

This adds an `install` command to the `cloudzero-agent-validator` image, which will copy itself to the provided destination, and alters the Helm chart to use that instead of `/bin/sh` and `cp`.

This also sneaks in a few other useful bits:

* Adds `package-debug` and `package-build-debug` make targets to build debug images (which do contain /bin/sh and cp)
* Adds a check to `scripts/ci-checks.sh` to make sure there is somewhere in the Helm chart that we know how to update for releases in order to ensure we don't break the release-to-main workflow.
* Rolls back the automated bump to 1.1.0-beta-3 so the workflow has something to do when we re-release it.