### PR TITLE
CP-27962: webhook server and aggregator deploys roll on config change

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
 version: 1.1.0-dev
-kubeVersion: ">= 1.23.0"
+kubeVersion: ">= 1.23.0-0"
 
 maintainers:
   - name: CloudZero

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -7,34 +7,34 @@ region: {{ .Values.region }}
 cluster_name: {{ .Values.clusterName }}
 destination: {{ include "cloudzero-agent.metricsDestination" . }}
 logging:
-    level: {{ .Values.insightsController.server.logging.level }}
+  level: {{ .Values.insightsController.server.logging.level }}
 remote_write:
-    send_interval: {{ .Values.insightsController.server.send_interval }}
-    max_bytes_per_send: 500000
-    send_timeout: {{ .Values.insightsController.server.send_timeout }}
-    max_retries: 3
+  send_interval: {{ .Values.insightsController.server.send_interval }}
+  max_bytes_per_send: 500000
+  send_timeout: {{ .Values.insightsController.server.send_timeout }}
+  max_retries: 3
 k8s_client:
-    timeout: 30s
+  timeout: 30s
 database:
-    retention_time: 24h
-    cleanup_interval: 3h
-    batch_update_size: 500
+  retention_time: 24h
+  cleanup_interval: 3h
+  batch_update_size: 500
 api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}
 {{- with .Values.insightsController }}
 certificate:
-    key: {{ .tls.mountPath }}/tls.key
-    cert: {{ .tls.mountPath }}/tls.crt
+  key: {{ .tls.mountPath }}/tls.key
+  cert: {{ .tls.mountPath }}/tls.crt
 server:
-    port: {{ .server.port }}
-    read_timeout: {{ .server.read_timeout }}
-    write_timeout: {{ .server.write_timeout }}
-    idle_timeout: {{ .server.idle_timeout }}
+  port: {{ .server.port }}
+  read_timeout: {{ .server.read_timeout }}
+  write_timeout: {{ .server.write_timeout }}
+  idle_timeout: {{ .server.idle_timeout }}
 {{- end }}
 filters:
-    labels:
-    {{- .Values.insightsController.labels | toYaml | nindent 8 }}
-    annotations:
-    {{- .Values.insightsController.annotations | toYaml | nindent 8 }}
+  labels:
+  {{- .Values.insightsController.labels | toYaml | nindent 4 }}
+  annotations:
+  {{- .Values.insightsController.annotations | toYaml | nindent 4 }}
 {{- end}}
 
 
@@ -47,10 +47,10 @@ region: "{{ .Values.region }}"
 cluster_name: "{{ .Values.clusterName }}"
 
 metrics:
-  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost" "filters"                 (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.name) | nindent 6 }}
-  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost_labels" "filters"          (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.labels) | nindent 6 }}
-  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability" "filters"        (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.name) | nindent 6 }}
-  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability_labels" "filters" (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.labels) | nindent 6 }}
+  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost" "filters"                 (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.name) | nindent 2 }}
+  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost_labels" "filters"          (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.labels) | nindent 2 }}
+  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability" "filters"        (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.name) | nindent 2 }}
+  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability_labels" "filters" (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.labels) | nindent 2 }}
 server:
   mode: http
   port: {{ .Values.aggregator.collector.port }}

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -1,0 +1,75 @@
+{{/*
+Configuration for the webhook-server Deployment. Configuration is defined in this tpl so that we can roll Deployment pods based on a checksum of these values
+*/}}
+{{ define "cloudzero-agent.insightsController.configuration" -}}
+cloud_account_id: {{ .Values.cloudAccountId }}
+region: {{ .Values.region }}
+cluster_name: {{ .Values.clusterName }}
+destination: {{ include "cloudzero-agent.metricsDestination" . }}
+logging:
+    level: {{ .Values.insightsController.server.logging.level }}
+remote_write:
+    send_interval: {{ .Values.insightsController.server.send_interval }}
+    max_bytes_per_send: 500000
+    send_timeout: {{ .Values.insightsController.server.send_timeout }}
+    max_retries: 3
+k8s_client:
+    timeout: 30s
+database:
+    retention_time: 24h
+    cleanup_interval: 3h
+    batch_update_size: 500
+api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}
+{{- with .Values.insightsController }}
+certificate:
+    key: {{ .tls.mountPath }}/tls.key
+    cert: {{ .tls.mountPath }}/tls.crt
+server:
+    port: {{ .server.port }}
+    read_timeout: {{ .server.read_timeout }}
+    write_timeout: {{ .server.write_timeout }}
+    idle_timeout: {{ .server.idle_timeout }}
+{{- end }}
+filters:
+    labels:
+    {{- .Values.insightsController.labels | toYaml | nindent 8 }}
+    annotations:
+    {{- .Values.insightsController.annotations | toYaml | nindent 8 }}
+{{- end}}
+
+
+{{/*
+Configuration for the aggregator Deployment. Configuration is defined in this tpl so that we can roll Deployment pods based on a checksum of these values
+*/}}
+{{ define "cloudzero-agent.aggregator.configuration" -}}
+cloud_account_id: "{{ .Values.cloudAccountId }}"
+region: "{{ .Values.region }}"
+cluster_name: "{{ .Values.clusterName }}"
+
+metrics:
+  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost" "filters"                 (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.name) | nindent 6 }}
+  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost_labels" "filters"          (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.labels) | nindent 6 }}
+  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability" "filters"        (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.name) | nindent 6 }}
+  {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability_labels" "filters" (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.labels) | nindent 6 }}
+server:
+  mode: http
+  port: {{ .Values.aggregator.collector.port }}
+  profiling: {{ .Values.aggregator.profiling }}
+logging:
+  level: "{{ .Values.aggregator.logging.level }}"
+database:
+  storage_path: {{ .Values.aggregator.mountRoot }}/data
+  max_records: {{ .Values.aggregator.database.maxRecords }}
+  max_interval: {{ .Values.aggregator.database.maxInterval }}
+  compression_level: {{ .Values.aggregator.database.compressionLevel }}
+  purge_rules:
+    metrics_older_than: {{ .Values.aggregator.database.purgeRules.metricsOlderThan }}
+    lazy: {{ .Values.aggregator.database.purgeRules.lazy }}
+    percent: {{ .Values.aggregator.database.purgeRules.percent }}
+cloudzero:
+  api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}
+  send_interval: {{ .Values.aggregator.cloudzero.sendInterval }}
+  send_timeout: {{ .Values.aggregator.cloudzero.sendTimeout }}
+  rotate_interval: {{ .Values.aggregator.cloudzero.rotateInterval }}
+  host: {{ .Values.host }}
+{{- end}}

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -2,9 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    checksum/config: {{ include "cloudzero-agent.aggregator.configuration" . | sha256sum }}
 {{- if .Values.aggregator.deploymentAnnotations }}
+  annotations:
     {{- toYaml .Values.aggregator.deploymentAnnotations | nindent 4 }}
 {{- end }}
   name: {{ include "cloudzero-agent.aggregator.name" . }}
@@ -18,8 +17,9 @@ spec:
   replicas: {{ .Values.aggregator.replicas }}
   template:
     metadata:
-      {{- with .Values.aggregator.podAnnotations }}
       annotations:
+        checksum/config: {{ include "cloudzero-agent.aggregator.configuration" . | sha256sum }}
+      {{- with .Values.aggregator.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    checksum/config: {{ include "cloudzero-agent.insightsController.configuration" . | sha256sum }}
+    checksum/config: {{ include "cloudzero-agent.aggregator.configuration" . | sha256sum }}
 {{- if .Values.aggregator.deploymentAnnotations }}
     {{- toYaml .Values.aggregator.deploymentAnnotations | nindent 4 }}
 {{- end }}

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -2,8 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-{{- if .Values.aggregator.deploymentAnnotations }}
   annotations:
+    checksum/config: {{ include "cloudzero-agent.insightsController.configuration" . | sha256sum }}
+{{- if .Values.aggregator.deploymentAnnotations }}
     {{- toYaml .Values.aggregator.deploymentAnnotations | nindent 4 }}
 {{- end }}
   name: {{ include "cloudzero-agent.aggregator.name" . }}

--- a/helm/templates/cm.yaml
+++ b/helm/templates/cm.yaml
@@ -210,7 +210,7 @@ metadata:
   {{- end }}
 data:
   server-config.yaml: |-
-    {{ include "cloudzero-agent.insightsController.configuration" . | nindent 4 }}
+{{- include "cloudzero-agent.insightsController.configuration" . | nindent 4 -}}
 {{- end }}
 ---
 apiVersion: v1
@@ -220,4 +220,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   config.yml: |-
-    {{ include "cloudzero-agent.aggregator.configuration" . | nindent 4 }}
+{{- include "cloudzero-agent.aggregator.configuration" . | nindent 4 -}}

--- a/helm/templates/cm.yaml
+++ b/helm/templates/cm.yaml
@@ -210,39 +210,7 @@ metadata:
   {{- end }}
 data:
   server-config.yaml: |-
-    cloud_account_id: {{ .Values.cloudAccountId }}
-    region: {{ .Values.region }}
-    cluster_name: {{ .Values.clusterName }}
-    destination: {{ include "cloudzero-agent.metricsDestination" . }}
-    logging:
-      level: {{ .Values.insightsController.server.logging.level }}
-    remote_write:
-      send_interval: {{ .Values.insightsController.server.send_interval }}
-      max_bytes_per_send: 500000
-      send_timeout: {{ .Values.insightsController.server.send_timeout }}
-      max_retries: 3
-    k8s_client:
-      timeout: 30s
-    database:
-      retention_time: 24h
-      cleanup_interval: 3h
-      batch_update_size: 500
-    api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}
-    {{- with .Values.insightsController }}
-    certificate:
-      key: {{ .tls.mountPath }}/tls.key
-      cert: {{ .tls.mountPath }}/tls.crt
-    server:
-      port: {{ .server.port }}
-      read_timeout: {{ .server.read_timeout }}
-      write_timeout: {{ .server.write_timeout }}
-      idle_timeout: {{ .server.idle_timeout }}
-    {{- end }}
-    filters:
-      labels:
-        {{- .Values.insightsController.labels | toYaml | nindent 8 }}
-      annotations:
-        {{- .Values.insightsController.annotations | toYaml | nindent 8 }}
+    {{ include "cloudzero-agent.insightsController.configuration" . | nindent 4 }}
 {{- end }}
 ---
 apiVersion: v1
@@ -252,37 +220,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   config.yml: |-
-    cloud_account_id: "{{ .Values.cloudAccountId }}"
-    region: "{{ .Values.region }}"
-    cluster_name: "{{ .Values.clusterName }}"
-
-    metrics:
-      {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost" "filters"                 (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.name) | nindent 6 }}
-      {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost_labels" "filters"          (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.labels) | nindent 6 }}
-      {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability" "filters"        (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.name) | nindent 6 }}
-      {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability_labels" "filters" (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.labels) | nindent 6 }}
-
-    server:
-      mode: http
-      port: {{ .Values.aggregator.collector.port }}
-      profiling: {{ .Values.aggregator.profiling }}
-
-    logging:
-      level: "{{ .Values.aggregator.logging.level }}"
-
-    database:
-      storage_path: {{ .Values.aggregator.mountRoot }}/data
-      max_records: {{ .Values.aggregator.database.maxRecords }}
-      max_interval: {{ .Values.aggregator.database.maxInterval }}
-      compression_level: {{ .Values.aggregator.database.compressionLevel }}
-      purge_rules:
-        metrics_older_than: {{ .Values.aggregator.database.purgeRules.metricsOlderThan }}
-        lazy: {{ .Values.aggregator.database.purgeRules.lazy }}
-        percent: {{ .Values.aggregator.database.purgeRules.percent }}
-
-    cloudzero:
-      api_key_path: {{ include "cloudzero-agent.secretFileFullPath" . }}
-      send_interval: {{ .Values.aggregator.cloudzero.sendInterval }}
-      send_timeout: {{ .Values.aggregator.cloudzero.sendTimeout }}
-      rotate_interval: {{ .Values.aggregator.cloudzero.rotateInterval }}
-      host: {{ .Values.host }}
+    {{ include "cloudzero-agent.aggregator.configuration" . | nindent 4 }}

--- a/helm/templates/insights-deploy.yaml
+++ b/helm/templates/insights-deploy.yaml
@@ -2,11 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+{{- if .Values.insightsController.server.deploymentAnnotations }}
   annotations:
-    checksum/config: {{ include "cloudzero-agent.insightsController.configuration" . | sha256sum }}
-    {{- if .Values.insightsController.server.deploymentAnnotations }}
     {{- toYaml .Values.insightsController.server.deploymentAnnotations | nindent 4 }}
-    {{- end }}
+{{- end }}
   name: {{ include "cloudzero-agent.insightsController.deploymentName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
@@ -18,8 +17,9 @@ spec:
       {{- include "cloudzero-agent.insightsController.server.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.insightsController.server.podAnnotations }}
       annotations:
+        checksum/config: {{ include "cloudzero-agent.insightsController.configuration" . | sha256sum }}
+      {{- with .Values.insightsController.server.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/helm/templates/insights-deploy.yaml
+++ b/helm/templates/insights-deploy.yaml
@@ -2,10 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-{{- if .Values.insightsController.server.deploymentAnnotations }}
   annotations:
+    checksum/config: {{ include "cloudzero-agent.insightsController.configuration" . | sha256sum }}
+    {{- if .Values.insightsController.server.deploymentAnnotations }}
     {{- toYaml .Values.insightsController.server.deploymentAnnotations | nindent 4 }}
-{{- end }}
+    {{- end }}
   name: {{ include "cloudzero-agent.insightsController.deploymentName" . }}
   namespace: {{ .Release.Namespace }}
   labels:


### PR DESCRIPTION
testing:
1. asserted that changing a shared config (region) rolls both aggregator and webhook server pods
2. asserted that changing only an insightController setting only rolls the webhook-server pod
3. asserted that changing only an aggregator setting only rolls the aggregator pod
4. asserted that changing a non insightsController or aggregator config does not roll pods
5. asserted that additional pod annotations can still be added