### PR TITLE
CP-26601: users should be able to disable default on webhooks

### DIFF
--- a/helm/templates/cm.yaml
+++ b/helm/templates/cm.yaml
@@ -183,7 +183,7 @@ data:
 
 {{- if .Values.insightsController.enabled }}
 {{- with .Values.insightsController }}
-{{- if not (and .labels.enabled .labels.patterns) }}
+{{- if and .labels.enabled (not .labels.patterns) }}
 {{- $msg := "\n\nThe required field(s) 'insightsController.labels.enabled' and/or 'insightsController.labels.patterns' is not set! See the README.md for more information." }}
 {{- $enabledMsg:=""}}
 {{- $patternMsg:=""}}

--- a/helm/templates/init-job.yaml
+++ b/helm/templates/init-job.yaml
@@ -134,7 +134,9 @@ spec:
               caBundles=()
               {{- range $configType, $configs := .Values.insightsController.webhooks.configurations }}
               {{- $webhookName := printf "%s-%s" (include "cloudzero-agent.validatingWebhookConfigName" $) $configType }}
-              {{- if or (index $.Values.insightsController.labels.resources $configType) (index $.Values.insightsController.annotations.resources $configType) }}
+              {{ $labelsEnabled := and $.Values.insightsController.labels.enabled (ne (index $.Values.insightsController.labels.resources $configType) false)}}
+              {{ $annotationEnabled := and $.Values.insightsController.annotations.enabled (ne (index $.Values.insightsController.annotations.resources $configType) false)}}
+              {{- if or $labelsEnabled $annotationEnabled }}
               wh_{{ $configType }}_caBundle=($(kubectl get validatingwebhookconfiguration {{ $webhookName }} -o jsonpath='{.webhooks[0].clientConfig.caBundle}'))
               caBundles+=("${wh_{{ $configType }}_caBundle:-missing }")
               {{- end }}
@@ -194,7 +196,9 @@ spec:
 
               {{- range $configType, $configs := .Values.insightsController.webhooks.configurations }}
               {{- $webhookName := printf "%s-%s" (include "cloudzero-agent.validatingWebhookConfigName" $) $configType }}
-              {{- if or (index $.Values.insightsController.labels.resources $configType) (index $.Values.insightsController.annotations.resources $configType) }}
+              {{ $labelsEnabled := and $.Values.insightsController.labels.enabled (ne (index $.Values.insightsController.labels.resources $configType) false)}}
+              {{ $annotationEnabled := and $.Values.insightsController.annotations.enabled (ne (index $.Values.insightsController.annotations.resources $configType) false)}}
+              {{- if or $labelsEnabled $annotationEnabled }}
               # Patch the ValidatingWebhookConfiguration {{ $webhookName }} with the caBundle
               kubectl patch validatingwebhookconfiguration  {{ $webhookName }} \
                 --type='json' \

--- a/helm/templates/webhooks.yaml
+++ b/helm/templates/webhooks.yaml
@@ -1,6 +1,8 @@
 {{- if .Values.insightsController.enabled }}
 {{- range $configType, $configs := .Values.insightsController.webhooks.configurations }}
-{{- if or (index $.Values.insightsController.labels.resources $configType) (index $.Values.insightsController.annotations.resources $configType) }}
+{{ $labelsEnabled := and $.Values.insightsController.labels.enabled (ne (index $.Values.insightsController.labels.resources $configType) false)}}
+{{ $annotationEnabled := and $.Values.insightsController.annotations.enabled (ne (index $.Values.insightsController.annotations.resources $configType) false)}}
+{{- if or $labelsEnabled $annotationEnabled }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
testing:
1. disabling labels and annotations results in no webhooks
```yaml
  labels:  
    enabled: false
  annotations:  
    enabled: false  
```
```bash
helm template cloudzero-agent -n cloudzero-agent --create-namespace ./ --set foo=bat -f ~/dmepham/testing/integration-test-cluster.yaml   | grep 'kind: ValidatingWebhookConfiguration' || echo 'test passed'
test passed
```
also asserted that installing brought up resource correctly, including the init-cert job

2. default true resources (namespaces) are not created when set to false
```yaml
  labels:  
    enabled: true
    resources:
      pods: true 
      namespaces: false
      deployments: true
  annotations:  
    enabled: false  
```
```bash
helm template cloudzero-agent -n cloudzero-agent --create-namespace ./ --set foo=bat -f ~/dmepham/testing/integration-test-cluster.yaml  | grep 'kind: ValidatingWebhookConfiguration' -A 4
kind: ValidatingWebhookConfiguration
metadata:
  name: cloudzero-agent-webhook-server-webhook-deployments
  namespace: cloudzero-agent
  labels:
--
kind: ValidatingWebhookConfiguration
metadata:
  name: cloudzero-agent-webhook-server-webhook-pods
  namespace: cloudzero-agent
  labels:
```
also asserted that installing brought up resource correctly, including the init-cert job, and webhook requests are handled

3. webhooks for resources should be created if enabled for either labels or annotations:
```yaml
  labels:  
    enabled: true
    resources:
      pods: true 
      namespaces: false
      deployments: true
  annotations:  
    enabled: true  
    resources:  
      pods: false
      namespaces: true
```

```bash
helm template cloudzero-agent -n cloudzero-agent --create-namespace ./ --set foo=bat -f ~/dmepham/testing/integration-test-cluster.yaml  | grep 'kind: ValidatingWebhookConfiguration' -A 4
kind: ValidatingWebhookConfiguration
metadata:
  name: cloudzero-agent-webhook-server-webhook-deployments
  namespace: cloudzero-agent
  labels:
--
kind: ValidatingWebhookConfiguration
metadata:
  name: cloudzero-agent-webhook-server-webhook-namespaces
  namespace: cloudzero-agent
  labels:
--
kind: ValidatingWebhookConfiguration
metadata:
  name: cloudzero-agent-webhook-server-webhook-pods
  namespace: cloudzero-agent
  labels:
```