### PR TITLE
CP-28093: unconditionally enable The Gator.

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -576,11 +576,7 @@ Otherwise, it will be the CloudZero API endpoint.
 
 */}}
 {{- define "cloudzero-agent.metricsDestination" -}}
-{{- if .Values.aggregator.enabled -}}
 'http://{{ include "cloudzero-agent.aggregator.name" . }}.{{ .Release.Namespace }}.svc.cluster.local/collector'
-{{- else -}}
-'{{ .Values.scheme }}://{{ include "cloudzero-agent.cleanString" .Values.host }}{{ .Values.endpoint }}'
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.aggregator.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -155,4 +154,3 @@ spec:
             name: {{ include "cloudzero-agent.aggregator.name" . }}
         - name: aggregator-persistent-storage
           emptyDir: {}
-{{- end }}

--- a/helm/templates/cm.yaml
+++ b/helm/templates/cm.yaml
@@ -142,7 +142,7 @@ data:
             regex: "^({{ join "|" (include "cloudzero-agent.defaults" . | fromYaml).insightsMetrics }})$"
             action: keep
       {{- end }}
-      {{- if and .Values.aggregator.enabled  .Values.prometheusConfig.scrapeJobs.aggregator.enabled }}
+      {{- if .Values.prometheusConfig.scrapeJobs.aggregator.enabled }}
       - job_name: cloudzero-aggregator-job
         scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.prometheus.scrapeInterval }}
         static_configs:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -330,7 +330,6 @@ configmapReload:
 # ensuring that there is no data loss in the event of any loss of communication with the CloudZero API,
 # even when a misconfiguration (such as an incorrect API key) prevents it.
 aggregator:
-  enabled: false
   replicas: 1
   logging:
     # Logging level that will be posted to stdout.


### PR DESCRIPTION
This removes the aggregator.enabled configuration option, and removes usage of it in checks, treating it as though it is always true.

Tested by checking that the output of a `helm template` before (w/ the value set to true) and after the change is identical.