### PR TITLE
CP-28103: treat RCs as pre-releases in release-to-main workflow

### DIFF
--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -57,5 +57,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ github.event.inputs.version }}
           body_path: docs/releases/${{ github.event.inputs.version }}.md
-          prerelease: ${{ contains(github.event.inputs.version, '-beta-') }}
+          prerelease: ${{ contains(github.event.inputs.version, '-beta-') || contains(github.event.inputs.version, '-rc-') }}
           draft: true


### PR DESCRIPTION
This is pretty straightforward; in the release-to-main workflow we check for "-beta-" in the name to look for prereleases. This just makes it also check for "-rc-".