### PR TITLE
CP-28084: scrape all instances of collector and shipper

### DIFF
--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -22,7 +22,8 @@ spec:
         - name: {{ include "cloudzero-agent.aggregator.name" . }}-collector
           {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.aggregator.image) | nindent 10 }}
           ports:
-            - containerPort: {{ .Values.aggregator.collector.port }}
+            - name: port-collector
+              containerPort: {{ .Values.aggregator.collector.port }}
           command: ["/app/cloudzero-collector", "-config", "{{ .Values.aggregator.mountRoot }}/config/config.yml"]
           env:
             - name: SERVER_PORT
@@ -53,10 +54,13 @@ spec:
 
         - name: {{ include "cloudzero-agent.aggregator.name" . }}-shipper
           {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.aggregator.image) | nindent 10 }}
+          ports:
+            - name: port-shipper
+              containerPort: {{ .Values.aggregator.shipper.port }}
           command: ["/app/cloudzero-shipper", "-config", "{{ .Values.aggregator.mountRoot }}/config/config.yml"]
           env:
             - name: SERVER_PORT
-              value: "8081"
+              value: "{{ .Values.aggregator.shipper.port }}"
           volumeMounts:
             {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
             - name: aggregator-config-volume

--- a/helm/templates/cm.yaml
+++ b/helm/templates/cm.yaml
@@ -142,10 +142,21 @@ data:
       {{- if .Values.prometheusConfig.scrapeJobs.aggregator.enabled }}
       - job_name: cloudzero-aggregator-job
         scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.prometheus.scrapeInterval }}
-        static_configs:
-          - targets:
-            - {{ include "cloudzero-agent.aggregator.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
-        metrics_path: /metrics
+        kubernetes_sd_configs:
+          - role: endpoints
+            kubeconfig_file: ""
+            follow_redirects: true
+            enable_http2: true
+            namespaces:
+              names:
+                - {{ .Release.Namespace }}
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name]
+            action: keep
+            regex: {{ include "cloudzero-agent.aggregator.name" . }}
+          - source_labels: [__meta_kubernetes_pod_container_port_name]
+            action: keep
+            regex: port-(shipper|collector)
         metric_relabel_configs:
           - source_labels: [__name__]
             regex: "{{ include "cloudzero-agent.generateMetricNameFilterRegex" .Values }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -532,6 +532,7 @@ aggregator:
         memory: "1024Mi"
         cpu: "2000m"
   shipper:
+    port: 8081
     resources:
       requests:
         memory: "64Mi"


### PR DESCRIPTION
- Modification of the Prometheus agent config to use `kubernetes_sd_configs` to source all instances of the collector/shipper
- Add port configs to the containers in the aggregator pod
- Expose the Prometheus endpoint for the shipper

## Testing

Config:
```
host: dev-api.cloudzero.com
apiKey: ...
clusterName: jake-dev-cluster-aws
cloudAccountId: 3bf91910396d9cf94bd951095e1e1ca9
region: us-east-1

components:
  agent:
    image:
      repository: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent
      tag: t-2f55bbb5ea52fd11497bf81e6fcdeb0f

insightsController:
  server:
    replicaCount: 3
    logging:
      level: trace

aggregator:
  replicas: 2
  logging:
    level: trace
  database:
    purgeRules:
      lazy: false
    emptyDir:
      enabled: true
      sizeLimit: "15Gi"
```

Prometheus service:
![Screenshot 2025-04-17 at 10 30 35 AM](https://github.com/user-attachments/assets/28916401-fc7a-40f1-a3cf-e09f56aafed4)
