### PR TITLE
Save the image for 'workflow_run' support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,4 @@
 
 ## How Tested
 
-> Instructions to reproduce what I did to test achiving a brighter smile
+> Instructions to reproduce what I did to test this and achieve a brighter smile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,7 +52,7 @@ jobs:
           docker tag busybox ${{ env.REGISTRY_LOCAL_ADDR }}/localbusybox
           docker push ${{ env.REGISTRY_LOCAL_ADDR }}/localbusybox
 
-      # Format the image name to OCI compatable format
+      # Format the image name to OCI compatible format
       - name: INPUT PREP - image name formatting
         id: image_name
         run: |
@@ -82,7 +82,7 @@ jobs:
             org.opencontainers.image.vendor=CloudZero
             image.name=${{ env.REGISTRY_PROD_ADDR }}/${{ env.IMAGE_NAME }}
           # https://github.com/docker/metadata-action?tab=readme-ov-file#latest-tag
-          # should only occur whtn a semver or raw when we are on master
+          # should only occur when a semver or raw when we are on master
           flavor: |
             latest=false
 
@@ -115,6 +115,7 @@ jobs:
             BUILD_TIME=${{ env.BUILD_TIME }}
             REVISION=${{ env.REVISION }}
             TAG=${{ env.TAG }}
+
       - name: SECURITY - Grype Docker Image Scan
         uses: anchore/scan-action@v6
         with:
@@ -131,6 +132,23 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
+
+      - name: Save Image Location
+        env:
+          IMAGE_REPO: ${{ env.REGISTRY_LOCAL_ADDR }}/${{ env.IMAGE_NAME }}
+          IMAGE_TAG: ${{ steps.meta.outputs.version }}
+        run: |
+          mkdir -p ./image
+          docker image save ${{ env.REGISTRY_LOCAL_ADDR }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} | gzip > ./image/image.tar.gz
+          echo $IMAGE_REPO > ./image/image_repo.txt
+          echo $IMAGE_TAG > ./image/image_tag.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: container_image_info
+          path: ./image/
+          retention-days: 1
+          if-no-files-found: error
 
       ###########################################################################
       # PRODUCTION ONLY STEPS BEYOND THIS POINT

--- a/.github/workflows/test-matrix-k8s-k3s.yaml
+++ b/.github/workflows/test-matrix-k8s-k3s.yaml
@@ -1,11 +1,11 @@
 name: k8s+k3s-version-test-matrix
 on:
-  pull_request:
-    branches:
-      - "*"
-  push:
-    branches:
-      - develop
+  #pull_request:
+  #  branches:
+  #    - "*"
+  #push:
+  #  branches:
+  #    - develop
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Why?

> This awesome thing improves my smile brightness

This will make it possible for other workflows to reference the development image, even though it has not been pushed anywhere.

## What

> Outline the actions you took to achieve a brighter smile

Adds steps to create a build artifact from the docker image.

## How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile

It runs. However this has to get merged before it can be used by other workflows.
