### PR TITLE
CP-22715: improve testing coverage

### DIFF
--- a/app/config/gator/settings.go
+++ b/app/config/gator/settings.go
@@ -303,7 +303,7 @@ func (s *Settings) GetAvailableSizeBytes() (uint64, error) {
 
 	quantity, err := resource.ParseQuantity(s.Database.AvailableStorage)
 	if err != nil {
-		log.Ctx(context.Background()).Warn().Err(err).Str("size_limit", s.Database.AvailableStorage).Msg("failed to parse the size_limit, using 0 as the default value (all available space)")
+		log.Ctx(context.Background()).Warn().Err(err).Str("sizeLimit", s.Database.AvailableStorage).Msg("failed to parse the size_limit, using 0 as the default value (all available space)")
 		return 0, nil
 	}
 

--- a/app/config/gator/settings_test.go
+++ b/app/config/gator/settings_test.go
@@ -8,8 +8,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/cloudzero/cloudzero-agent/app/config/gator"
+	config "github.com/cloudzero/cloudzero-agent/app/config/gator"
 )
 
 func TestCloudzeroSettings_Defaults(t *testing.T) {
@@ -294,4 +295,34 @@ func TestCloudzeroSettings_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnit_Settings_RemoteAPIBase(t *testing.T) {
+	s := config.Settings{
+		CloudAccountID: "123456789012",
+		Region:         "us-east-1",
+		ClusterName:    "test-cluster",
+		Server: config.Server{
+			Mode: "http",
+			Port: 8080,
+		},
+		Database: config.Database{
+			StoragePath:      "testdata",
+			MaxRecords:       1000000,
+			CompressionLevel: 7,
+		},
+		Cloudzero: config.Cloudzero{
+			APIKeyPath:   "testdata/api_key.txt",
+			SendInterval: 60 * time.Second,
+			SendTimeout:  10 * time.Second,
+			Host:         "api.cloudzero.com",
+		},
+	}
+
+	err := s.Validate()
+	require.NoError(t, err, "failed to validate")
+
+	u, err := s.GetRemoteAPIBase()
+	require.NoError(t, err, "failed to get the remote api base")
+	require.NotEmpty(t, u.String())
 }

--- a/app/config/validator/diagnostics_test.go
+++ b/app/config/validator/diagnostics_test.go
@@ -6,7 +6,7 @@ package config_test
 import (
 	"testing"
 
-	"github.com/cloudzero/cloudzero-agent/app/config/validator"
+	config "github.com/cloudzero/cloudzero-agent/app/config/validator"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/app/domain/backfiller/backfiller.go
+++ b/app/domain/backfiller/backfiller.go
@@ -55,7 +55,7 @@ func (s *Backfiller) Start(ctx context.Context) {
 	var _continue string
 	allNamespaces := []corev1.Namespace{}
 	log.Info().
-		Time("current_time", time.Now().UTC()).
+		Time("currentTime", time.Now().UTC()).
 		Msg("Starting backfill of existing resources")
 
 	// write all nodes in the cluster storage
@@ -163,8 +163,8 @@ func (s *Backfiller) Start(ctx context.Context) {
 		}
 		if namespaces.GetContinue() == "" {
 			log.Info().
-				Time("current_time", time.Now().UTC()).
-				Int("namespaces_count", len(allNamespaces)).
+				Time("currentTime", time.Now().UTC()).
+				Int("namespacesCount", len(allNamespaces)).
 				Msg("Backfill operation completed")
 			break
 		}

--- a/app/domain/housekeeper/housekeeper.go
+++ b/app/domain/housekeeper/housekeeper.go
@@ -105,7 +105,7 @@ func (h *HouseKeeper) Run() error {
 						}
 					}
 					log.Debug().
-						Int("deleted_count", expiredLen).
+						Int("deletedCount", expiredLen).
 						Msg("Deleted old records")
 					return nil // commit the transaction
 				}); err != nil {

--- a/app/domain/pusher/pusher.go
+++ b/app/domain/pusher/pusher.go
@@ -250,7 +250,7 @@ func (h *MetricsPusher) sendBatch(batch []*types.ResourceTags) error {
 
 	ts := h.formatMetrics(batch)
 	log.Ctx(h.ctx).Info().
-		Int("record_count", len(ts)).
+		Int("recordCount", len(ts)).
 		Msg("Pushing records to remote write endpoint")
 
 	if err := h.pushMetrics(h.settings.RemoteWrite.Host, apiToken, ts); err != nil {
@@ -285,7 +285,7 @@ func (h *MetricsPusher) Flush() error {
 		if next.Namespace != nil {
 			namespace = *next.Namespace
 		}
-		log.Ctx(h.ctx).Debug().Str("namespace", namespace).Str("name", next.Name).Str("resource_type", config.ResourceTypeToMetricName[next.Type]).Msg("Sending record for namespace")
+		log.Ctx(h.ctx).Debug().Str("namespace", namespace).Str("name", next.Name).Str("resourceType", config.ResourceTypeToMetricName[next.Type]).Msg("Sending record for namespace")
 		RemoteWriteBacklog.WithLabelValues(h.settings.RemoteWrite.Host).Set(float64(len(found)))
 
 		if next.Size+totalSize > h.sentMaxBytes && len(batch) > 0 {
@@ -441,8 +441,8 @@ func (h *MetricsPusher) pushMetrics(remoteWriteURL string, apiKey string, timeSe
 			RemoteWriteResponseCodes.WithLabelValues(endpoint, statusCode).Inc()
 			resp.Body.Close()
 			log.Ctx(h.ctx).Error().
-				Int("status_code", resp.StatusCode).
-				Str("status_text", resp.Status).
+				Int("statusCode", resp.StatusCode).
+				Str("statusText", resp.Status).
 				Msg("Received non-2xx response, retrying...")
 		} else {
 			// If resp is nil, we can track it as a failure as well

--- a/app/domain/shipper/errors_test.go
+++ b/app/domain/shipper/errors_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnit_Shipper_ErrorsBasicWrapping(t *testing.T) {
+func TestUnit_Shipper_Errors_BasicWrapping(t *testing.T) {
 	// test a basic case
 	err := errors.Join(shipper.ErrCreateDirectory, fmt.Errorf("this is a wrapped error: %w", errors.New("base error")))
 	statusCode := shipper.GetErrStatusCode(err)
@@ -21,7 +21,7 @@ func TestUnit_Shipper_ErrorsBasicWrapping(t *testing.T) {
 	require.Equal(t, shipper.ErrCreateDirectory.Code(), statusCode)
 }
 
-func TestUnit_Shipper_MultiWrapping(t *testing.T) {
+func TestUnit_Shipper_Errors_MultiWrapping(t *testing.T) {
 	err := errors.Join(errors.New("this is a basic error"), fmt.Errorf("this is a wrapped error: %w", shipper.ErrCreateDirectory))
 	err = errors.Join(shipper.ErrCreateLock, err)
 	err = errors.Join(errors.New("this is a bogus error"), err)

--- a/app/functions/insights-controller/main.go
+++ b/app/functions/insights-controller/main.go
@@ -46,15 +46,15 @@ func main() {
 
 	log.Info().
 		Str("version", build.GetVersion()).
-		Str("build_time", build.Time).
+		Str("buildTime", build.Time).
 		Str("rev", build.Rev).
 		Str("tag", build.Tag).
 		Str("author", build.AuthorName).
 		Str("copyright", build.Copyright).
-		Str("author_email", build.AuthorEmail).
-		Str("charts_repo", build.ChartsRepo).
-		Str("platform_endpoint", settings.Destination).
-		Interface("config_files", configFiles).
+		Str("authorEmail", build.AuthorEmail).
+		Str("chartsRepo", build.ChartsRepo).
+		Str("platformEndpoint", settings.Destination).
+		Interface("configFiles", configFiles).
 		Msg("Starting CloudZero Insights Controller")
 	if len(configFiles) == 0 {
 		log.Fatal().Msg("No configuration files provided")

--- a/app/handlers/profiling_test.go
+++ b/app/handlers/profiling_test.go
@@ -1,0 +1,60 @@
+package handlers_test
+
+import (
+	"testing"
+
+	"github.com/cloudzero/cloudzero-agent/app/handlers"
+	"github.com/go-obvious/server/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnit_Handlers_Profile(t *testing.T) {
+	profiling := handlers.NewProfilingAPI("/")
+
+	tests := []struct {
+		name               string
+		path               string
+		expectedStatusCode int
+	}{
+		{
+			name:               "QueryIndex",
+			path:               "/",
+			expectedStatusCode: 200,
+		},
+		{
+			name:               "QueryCMDLine",
+			path:               "/cmdline",
+			expectedStatusCode: 200,
+		},
+		{
+			name:               "QueryProfile",
+			path:               "/profile?seconds=1",
+			expectedStatusCode: 200,
+		},
+		{
+			name:               "QuerySymbol",
+			path:               "/symbol",
+			expectedStatusCode: 200,
+		},
+		{
+			name:               "QueryTrace",
+			path:               "/trace",
+			expectedStatusCode: 200,
+		},
+		{
+			name:               "QueryErr",
+			path:               "/does/not/exist",
+			expectedStatusCode: 404,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := createRequest("GET", tc.path, nil)
+			resp, err := test.InvokeService(profiling.Service, tc.path, *req)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, tc.expectedStatusCode, resp.StatusCode)
+		})
+	}
+}

--- a/app/handlers/prom_metrics_test.go
+++ b/app/handlers/prom_metrics_test.go
@@ -1,0 +1,40 @@
+package handlers_test
+
+import (
+	"testing"
+
+	"github.com/cloudzero/cloudzero-agent/app/handlers"
+	"github.com/go-obvious/server/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnit_Profile_PromMetrics(t *testing.T) {
+	promMetrics := handlers.NewPromMetricsAPI("/")
+
+	tests := []struct {
+		name               string
+		path               string
+		expectedStatusCode int
+	}{
+		{
+			name:               "QueryIndex",
+			path:               "/",
+			expectedStatusCode: 200,
+		},
+		{
+			name:               "QueryErr",
+			path:               "/does/not/exist",
+			expectedStatusCode: 404,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := createRequest("GET", tc.path, nil)
+			resp, err := test.InvokeService(promMetrics.Service, tc.path, *req)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, tc.expectedStatusCode, resp.StatusCode)
+		})
+	}
+}

--- a/app/http/middleware.go
+++ b/app/http/middleware.go
@@ -86,7 +86,7 @@ func LoggingMiddlewareWrapper(next http.Handler) http.Handler {
 		log.Ctx(r.Context()).Debug().
 			Str("method", method).
 			Str("route", route).
-			Int("status_code", statusCode).
+			Int("statusCode", statusCode).
 			Str("status", http.StatusText(statusCode)).
 			Dur("duration", duration).
 			Msg("HTTP request")

--- a/app/logging/filtered_writer_test.go
+++ b/app/logging/filtered_writer_test.go
@@ -1,0 +1,118 @@
+package logging_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/cloudzero/cloudzero-agent/app/logging"
+)
+
+func TestUnit_Logging_FilteredWriter_EmptyWrite(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := logging.NewFieldFilterWriter(buf, []string{"foo"})
+	n, err := w.Write([]byte{})
+	if wantN, wantErr := 0, error(nil); n != wantN || err != wantErr {
+		t.Fatalf("Write(empty) = (%d, %v), want (%d, %v)", n, err, wantN, wantErr)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("underlying buffer should be empty, got %q", buf.String())
+	}
+}
+
+func TestUnit_Logging_FilteredWriter_FilterRemovesFields(t *testing.T) {
+	var buf bytes.Buffer
+	orig := `{"keep":"yes","skip":"no"}`
+	w := logging.NewFieldFilterWriter(&buf, []string{"skip"})
+	n, err := w.Write([]byte(orig))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(orig) {
+		t.Fatalf("n = %d, want %d", n, len(orig))
+	}
+	out := buf.String()
+	// after filtering only "keep" should remain
+	const want = `{"keep":"yes"}`
+	if out != want {
+		t.Fatalf("filtered = %q, want %q", out, want)
+	}
+}
+
+func TestUnit_Logging_FilteredWriter_PreserveNewline(t *testing.T) {
+	var buf bytes.Buffer
+	orig := `{"a":1}` + "\n"
+	w := logging.NewFieldFilterWriter(&buf, nil)
+	n, err := w.Write([]byte(orig))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(orig) {
+		t.Fatalf("n = %d, want %d", n, len(orig))
+	}
+	out := buf.String()
+	const want = `{"a":1}` + "\n"
+	if out != want {
+		t.Fatalf("got %q, want %q", out, want)
+	}
+}
+
+func TestUnit_Logging_FilteredWriter_MalformedJSONWritesAsIs(t *testing.T) {
+	var buf bytes.Buffer
+	bad := `not a json`
+	w := logging.NewFieldFilterWriter(&buf, []string{"x"})
+	n, err := w.Write([]byte(bad))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(bad) {
+		t.Fatalf("n = %d, want %d", n, len(bad))
+	}
+	if buf.String() != bad {
+		t.Fatalf("buf = %q, want %q", buf.String(), bad)
+	}
+}
+
+func TestUnit_Logging_FilteredWriter_UnderlyingWriteError(t *testing.T) {
+	testErr := errors.New("boom")
+	ew := &errorWriter{err: testErr}
+	w := logging.NewFieldFilterWriter(ew, []string{"foo"})
+	data := []byte(`{"foo":"x"}`)
+	n, err := w.Write(data)
+	// since we filtered out "foo", marshal succeeds, but Write returns error
+	if err != testErr {
+		t.Fatalf("err = %v, want %v", err, testErr)
+	}
+	// errorWriter always returns written=0
+	if n != 0 {
+		t.Fatalf("n = %d, want 0", n)
+	}
+}
+
+func TestUnit_Logging_FilteredWriter_PartialWriteIgnored(t *testing.T) {
+	pw := &partialWriter{n: 0} // writes 0 bytes, no error
+	w := logging.NewFieldFilterWriter(pw, []string{"foo"})
+	data := []byte(`{"foo":"x","bar":"y"}`)
+	n, err := w.Write(data)
+	// no error, and we always return original length
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("n = %d, want %d", n, len(data))
+	}
+}
+
+// errorWriter always returns (0, err)
+type errorWriter struct{ err error }
+
+func (e *errorWriter) Write(p []byte) (int, error) {
+	return 0, e.err
+}
+
+// partialWriter returns a short write with no error
+type partialWriter struct{ n int }
+
+func (p *partialWriter) Write(b []byte) (int, error) {
+	return p.n, nil
+}

--- a/app/logging/instr/span_test.go
+++ b/app/logging/instr/span_test.go
@@ -6,6 +6,7 @@ package instr
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"testing"
@@ -128,4 +129,16 @@ func TestUnit_Instr_Span_ParentSpanID(t *testing.T) {
 	// Verify that the log output contains both span id and parent span id.
 	require.Contains(t, logOutput, `"spanId":"child-5678"`, "logger output should contain the child span id")
 	require.Contains(t, logOutput, `"parentSpanId":"parent-1234"`, "logger output should contain the parent span id")
+}
+
+func TestUnit_Instr_Span_RunSpan(t *testing.T) {
+	err := RunSpan(t.Context(), "test-noerror", func(ctx context.Context, span *Span) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = RunSpan(t.Context(), "test-error", func(ctx context.Context, span *Span) error {
+		return errors.New("err")
+	})
+	require.Error(t, err)
 }

--- a/app/storage/core/baseimpl_test.go
+++ b/app/storage/core/baseimpl_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
 	"github.com/cloudzero/cloudzero-agent/app/storage/core"
@@ -27,4 +29,32 @@ func TestBaseRepoImpl_Context(t *testing.T) {
 	from, found = core.FromContext(ctxTx)
 	assert.Same(t, from, db)
 	assert.True(t, found)
+}
+
+func TestUnit_Storage_Core_Raw(t *testing.T) {
+	// create the db
+	db, err := core.NewDriver(sqlite.Open("file:memory?mode=memory&cache=shared"))
+	require.NoError(t, err, "failed to get the new driver")
+	repo := core.NewRawBaseRepoImpl(db)
+	db2 := repo.DB(t.Context())
+	require.NotNil(t, db2, "failed to get the db")
+
+	err = repo.Tx(t.Context(), func(ctxTx context.Context) error {
+		return nil
+	})
+	require.NoError(t, err, "failed to run the context")
+}
+
+func TestUnit_Storage_Core_Base(t *testing.T) {
+	// create the db
+	db, err := core.NewDriver(sqlite.Open("file:memory?mode=memory&cache=shared"))
+	require.NoError(t, err, "failed to get the new driver")
+	repo := core.NewBaseRepoImpl(db, nil)
+	db2 := repo.DB(t.Context())
+	require.NotNil(t, db2, "failed to get the db")
+
+	err = repo.Tx(t.Context(), func(ctxTx context.Context) error {
+		return nil
+	})
+	require.NoError(t, err, "failed to run the context")
 }

--- a/app/storage/disk/metric_file_test.go
+++ b/app/storage/disk/metric_file_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMetricFile_ReadAll(t *testing.T) {
+func TestUnit_Storage_Disk_MetricFile_ReadAll(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	osFile, err := os.CreateTemp(tmpDir, "test-file-*.json.br")
@@ -36,7 +36,22 @@ func TestMetricFile_ReadAll(t *testing.T) {
 	file, err := disk.NewMetricFile(osFile.Name())
 	require.NoError(t, err)
 
+	// get a unique id
+	require.NotEmpty(t, file.UniqueID(), "failed to get the unique id")
+
+	// get the location
+	_, err = file.Location()
+	require.NoError(t, err, "failed to get the location")
+
+	// get the filesize
+	s, err := file.Size()
+	require.NoError(t, err, "failed to get the size")
+	require.NotEqual(t, 0, s)
+
 	// read the data
 	_, err = io.ReadAll(file)
 	require.NoError(t, err)
+
+	// close the file
+	require.NoError(t, file.Close(), "failed to close the file")
 }

--- a/app/types/metric_test.go
+++ b/app/types/metric_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var simpleMetric = types.Metric{
@@ -142,6 +143,28 @@ func TestMetric_ImportLabels(t *testing.T) {
 			if diff := cmp.Diff(tt.want, m); diff != "" {
 				t.Errorf("Metric.ImportLabels() mismatch (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestMetric_ToParquet_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		metric  types.Metric
+		wantErr bool
+	}{
+		{
+			name:    "basic",
+			metric:  simpleMetric,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.metric
+			pm := m.Parquet()
+			m2 := pm.Metric()
+			require.Equal(t, m.MetricName, m2.MetricName)
 		})
 	}
 }


### PR DESCRIPTION
A smaller PR to add some new tests to things that were not covered before. I think we should strive for 75% of code coverage as an arbitrary minimum, but this is not a good benchmark to die on. 

Also, a fair amount of our code is also tested in the `tests/smoke` directory, which is not going to report on go test coverages. This just addresses some of the more obvious scenarios and did a deeper dive into what is and not tested.

In addition, some log fields were converted from snake case to cammel case
