### PR TITLE
CP-28409: enable building go binaries in parallel in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,8 @@ RUN go mod download \
 COPY . .
 
 # Build the Go binary
-RUN make build OUTPUT_BIN_DIR=/go/bin \
+RUN make build -j \
+    OUTPUT_BIN_DIR=/go/bin \
     TARGET_OS=$TARGETOS TARGET_ARCH=$TARGETARCH \
     ENABLE_ZIG=true \
     REVISION=${REVISION} \


### PR DESCRIPTION
## Why?

Build speed.

## What

Build binaries in parallel in Docker.

## How Tested

Works locally, I'm mostly curious about what CI makes of it.