### PR TITLE
CP-28409: enable building go binaries in parallel in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,8 @@ RUN go mod download \
 COPY . .
 
 # Build the Go binary
-RUN make build OUTPUT_BIN_DIR=/go/bin \
+RUN make build -j4 \
+    OUTPUT_BIN_DIR=/go/bin \
     TARGET_OS=$TARGETOS TARGET_ARCH=$TARGETARCH \
     ENABLE_ZIG=true \
     REVISION=${REVISION} \


### PR DESCRIPTION
## Why?

Build speed.

First attempt, with just `-j` actually slowed things down (by about 3 minutes). I'm trying this time with `-j4` since the GitHub docs say we get 4 vcpus... Unfortunately I closed the previous PR just before I had this idea...

## What

Build binaries in parallel in Docker.

## How Tested

Works locally, I'm mostly curious about what CI makes of it.