### PR TITLE
OCI compliant release image names

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -169,6 +169,14 @@ jobs:
       packages: write
       id-token: write
     steps:
+      # Format the image names for OCI compliance (all lowercase)
+      - name: INPUT PREP - image name formatting
+        id: image_name
+        run: |
+          IMAGE_NAME=${{ env.IMAGE_NAME }}
+          echo "UNTESTED_IMAGE_NAME=${UNTESTED_IMAGE_NAME,,}" >>${GITHUB_ENV}
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >>${GITHUB_ENV}
+
       # install regctl for registry management operations
       - name: PRODUCTION STEP - Install Regctl for registry management
         if: github.event_name == 'release' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Why?

> This awesome thing improves my smile brightness

The refactor broke the image naming for prod images and this should fix it.

## What

> Outline the actions you took to achieve a brighter smile

We just need to lowercase the repo name.

## How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile

It will be tested when it is merged, since this is a merge to 'develop' action.
