### PR TITLE
CP-28376 added _ as a valid character for clusterName

### DIFF
--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -7,7 +7,7 @@
     },
     "clusterName": {
       "type": "string",
-      "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,251}[a-zA-Z0-9])?$"
+      "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,251}[a-zA-Z0-9])?$"
     },
     "cloudAccountId": {
       "type": "string"


### PR DESCRIPTION
## Why?

Improve validation for clusterName to support additional characters

## What

updated clusterName validation so we can accept _ as part of the clusterName

## How Tested

ran 2 tests 1 before with clusterName of "cluster_name" it failed (as expected)
ran again after change and it worked as expected