### PR TITLE
Replicated test matrix workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,6 +14,12 @@ on:
       - published
       - released
 
+concurrency:
+  # This concurrency group ensures that only one job in the group runs at a time.
+  # If a new job is triggered, the previous one will be canceled.
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY_PROD_ADDR: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/cloudzero-agent
@@ -21,7 +27,14 @@ env:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-latest
+    name: Build Docker image for ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' }}
     permissions:
       contents: read
       packages: write
@@ -36,12 +49,25 @@ jobs:
         id: checkout_code
         uses: actions/checkout@v4
 
+      - name: Prepare environment for current platform
+        id: prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Set up Docker Context for Buildx
+        id: buildx-context
+        run: |
+          docker context create builders
+
       - # Install buildx for multi-platform builds
         name: SETUP - Docker Buildx
         id: install_buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
+          endpoint: builders
           driver-opts: network=host
+          platforms: ${{ matrix.platform }}
 
       - name: Get raw repo name
         run: |
@@ -57,6 +83,103 @@ jobs:
           echo "IMAGE_NAME=${IMAGE_NAME,,}" >>${GITHUB_ENV}
 
       # Extract metadata (tags, labels) the docker image build
+      # No tags  of other metadata at this stage, as we are pushing by digest
+      - name: INPUT PREP - Basic Docker metadata for initial build
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          # ONLY use the untested registry address for the image until it is tested
+          images: ${{ env.REGISTRY_PROD_ADDR }}/${{ env.UNTESTED_IMAGE_NAME }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: INPUT PREP - Set build time revision
+        run: |
+          REVISION=$(git rev-parse --short HEAD)
+          TAG=$(echo "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}")
+          BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "REVISION=${REVISION}" >>${GITHUB_ENV}
+          echo "TAG=${TAG}" >>${GITHUB_ENV}
+          echo "BUILD_TIME=${BUILD_TIME}" >>${GITHUB_ENV}
+
+      - name: TEST - Build image
+        id: build_image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        env:
+          VALIDATOR_DOCKERFILE: docker/Dockerfile
+          VALIDATOR_CONTEXT: .
+        with:
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY_PROD_ADDR }}/${{ env.UNTESTED_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
+          cache-from: type=gha,scope=${{ github.repository }}-${{ github.ref_name }}-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ github.repository }}-${{ github.ref_name }}-${{ matrix.platform }}
+          context: ${{ env.VALIDATOR_CONTEXT }}
+          file: ${{ env.VALIDATOR_DOCKERFILE }}
+          build-args: |
+            BUILD_TIME=${{ env.BUILD_TIME }}
+            REVISION=${{ env.REVISION }}
+            TAG=${{ env.TAG }}
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build_image.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-merge:
+    # This job merges the Docker manifests for the different platforms built in the previous job.
+    name: Merge Docker manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    needs: ["docker-build"]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      # Format the image names for OCI compliance (all lowercase)
+      - name: INPUT PREP - image name formatting
+        id: image_name
+        run: |
+          IMAGE_NAME=${{ env.IMAGE_NAME }}
+          echo "UNTESTED_IMAGE_NAME=${UNTESTED_IMAGE_NAME,,}" >>${GITHUB_ENV}
+          echo "IMAGE_NAME=${IMAGE_NAME,,}" >>${GITHUB_ENV}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          driver-opts: |
+            network=host
+
+      # Extract metadata (tags, labels) the docker image build
+      # This is the full metadata for the manifest
       - name: INPUT PREP - Extract Docker metadata from git repository
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
@@ -83,42 +206,51 @@ jobs:
           flavor: |
             latest=false
 
-      - name: INPUT PREP - Set build time revision
+      - name: Get execution timestamp with RFC3339 format
+        # This step gets the current execution timestamp in RFC3339 format.
+        # It uses the date command to get the current UTC time and formats it as a string.
+        # The timestamp is used for annotating the Docker manifest list.
+        id: timestamp
         run: |
-          REVISION=$(git rev-parse --short HEAD)
-          TAG=$(echo "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}")
-          BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo "REVISION=${REVISION}" >>${GITHUB_ENV}
-          echo "TAG=${TAG}" >>${GITHUB_ENV}
-          echo "BUILD_TIME=${BUILD_TIME}" >>${GITHUB_ENV}
+          echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        # This step creates a manifest list for the Docker images built for different platforms.
+        # It uses the docker buildx imagetools create command to create the manifest list.
+        # The manifest list is annotated with metadata such as description, creation timestamp, and source URL.
+        # The annotations are obtained from the metadata generated in the previous steps.
+        # The manifest list is pushed to the GitHub Container Registry (GHCR) with the specified tags.
+        working-directory: ${{ runner.temp }}/digests
+        id: manifest-annotate
+        continue-on-error: true
+        run: |
+          ls -lFa
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            --annotation='index:org.opencontainers.image.description=${{ github.event.repository.description }}' \
+            --annotation='index:org.opencontainers.image.created=${{ steps.timestamp.outputs.timestamp }}' \
+            --annotation='index:org.opencontainers.image.url=${{ github.event.repository.url }}' \
+            --annotation='index:org.opencontainers.image.source=${{ github.event.repository.url }}' \
+            $(printf '${{ env.REGISTRY_PROD_ADDR }}/${{ env.UNTESTED_IMAGE_NAME }}@sha256:%s ' *)
 
-      - name: TEST - Build image
-        id: build_image
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
-        env:
-          PLATFORMS: "linux/amd64,linux/arm64"
-          VALIDATOR_DOCKERFILE: docker/Dockerfile
-          VALIDATOR_CONTEXT: .
-        with:
-          push: true
-          context: ${{ env.VALIDATOR_CONTEXT }}
-          file: ${{ env.VALIDATOR_DOCKERFILE }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ env.PLATFORMS }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILD_TIME=${{ env.BUILD_TIME }}
-            REVISION=${{ env.REVISION }}
-            TAG=${{ env.TAG }}
+      - name: Create manifest list and push without annotations
+        # This step creates a manifest list for the Docker images built for different platforms.
+        # It uses the docker buildx imagetools create command to create the manifest list.
+        # The manifest list is created without annotations if the previous step fails.
+        # The manifest list is pushed to the GitHub Container Registry (GHCR) with the specified tags.
+        if: steps.manifest-annotate.outcome == 'failure'
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create  $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_PROD_ADDR }}/${{ env.UNTESTED_IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        # This step inspects the created manifest list to verify its contents.
+        # It uses the docker buildx imagetools inspect command to display information about the manifest list.
+        # The inspection output will show the platforms and tags associated with the manifest list.
+        id: inspect
+        run: |
+          docker buildx imagetools inspect '${{ env.REGISTRY_PROD_ADDR }}/${{ env.UNTESTED_IMAGE_NAME }}:${{ steps.meta.outputs.version }}'
 
       - name: SECURITY - Grype Docker Image Scan
         uses: anchore/scan-action@v6
@@ -150,7 +282,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    needs: ["docker-build"]
+    needs: ["docker-build", "docker-merge"]
     uses: ./.github/workflows/test-matrix-k8s-k3s.yaml
     with:
       image-repo: ${{ needs.docker-build.outputs.image-repo }}
@@ -158,7 +290,20 @@ jobs:
       image-tag: ${{ needs.docker-build.outputs.image-tag }}
     secrets: inherit
 
-  test-status-reporting:
+  replicated-compatibility-matrix-tests:
+    # These should match the permissions in the called workflow.
+    permissions:
+      contents: read
+      packages: read
+    needs: ["docker-build", "docker-merge"]
+    uses: ./.github/workflows/test-matrix-replicated-k8s-clusters.yaml
+    with:
+      image-repo: ${{ needs.docker-build.outputs.image-repo }}
+      image-path: ${{ needs.docker-build.outputs.image-path }}
+      image-tag: ${{ needs.docker-build.outputs.image-tag }}
+    secrets: inherit
+
+  test-versions-status-reporting:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -176,11 +321,35 @@ jobs:
           name: "k8s-version-matrix-tests"
           status: "failure"
 
+  test-replicated-status-reporting:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    needs: ["replicated-compatibility-matrix-tests"]
+    if: ${{ always() }}
+    steps:
+      - uses: ouzi-dev/commit-status-updater@v2
+        if: ${{ needs.replicated-compatibility-matrix-tests.outputs.cluster-test-status == 'success' }}
+        with:
+          name: "replicated-compatibility-matrix-tests"
+          status: "success"
+      - uses: ouzi-dev/commit-status-updater@v2
+        if: ${{ needs.replicated-compatibility-matrix-tests.outputs.cluster-test-status != 'success' }}
+        with:
+          name: "replicated-compatibility-matrix-tests"
+          status: "failure"
+
   ###########################################################################
   # PRODUCTION ONLY STEPS BEYOND THIS POINT
   #
   release-image:
-    needs: ["docker-build", "k8s-version-matrix-tests"]
+    needs:
+      [
+        "docker-build",
+        "docker-merge",
+        "k8s-version-matrix-tests",
+        "replicated-compatibility-matrix-tests",
+      ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -226,3 +395,31 @@ jobs:
               ${{ env.REGISTRY_PROD_ADDR }}/${{ env.UNTESTED_IMAGE_NAME }}:${{ needs.docker-build.outputs.image-tag }} \
               ${{ env.REGISTRY_PROD_ADDR }}/${{ env.IMAGE_NAME }}:latest
           fi
+
+  docker-build-status-reporting:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    needs: [
+        "docker-build",
+        "docker-merge",
+        "k8s-version-matrix-tests",
+        "replicated-compatibility-matrix-tests",
+        "release-image",
+      ]
+    if: ${{ always() }}
+    steps:
+      - uses: ouzi-dev/commit-status-updater@v2
+        if: |
+          !contains(needs.*.result, 'failure') &&
+          !contains(needs.*.result, 'cancelled')
+        with:
+          name: "docker-build"
+          status: "success"
+      - uses: ouzi-dev/commit-status-updater@v2
+        if: |
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled')
+        with:
+          name: "docker-build"
+          status: "failure"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -400,7 +400,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
-    needs: [
+    needs:
+      [
         "docker-build",
         "docker-merge",
         "k8s-version-matrix-tests",

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -107,6 +107,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "29.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install tools
         run: make install-tools
       - name: Generate code

--- a/.github/workflows/test-matrix-k8s-k3s.yaml
+++ b/.github/workflows/test-matrix-k8s-k3s.yaml
@@ -33,10 +33,16 @@ on:
         description: "The completion status of the k3s-version-test job"
         value: ${{ jobs.k3s-version-test.outputs.version-test-status }}
 
+concurrency:
+  # This concurrency group ensures that only one job in the group runs at a time.
+  # If a new job is triggered, the previous one will be canceled.
+  group: matrix-kver-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   k3s-version-test:
-    name: k3s-test-${{ matrix.kver.k3s }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.kver.platform }}-k3s-test-${{ matrix.kver.k3s }}
+    runs-on: ${{ matrix.kver.platform == 'linux/amd64' && 'ubuntu-latest' || matrix.kver.platform == 'linux/arm64' && 'ubuntu-24.04-arm' }}
     # These should match the permissions in the calling job.
     permissions:
       contents: read
@@ -46,22 +52,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Useful for finding versions: https://eduardominguez.es/k3s-versions/
+        # Useful for finding the current k3s versions: https://eduardominguez.es/k3s-versions/
         # From: https://github.com/e-minguez/k3s-versions
+        #
+        # NOTE: We also switch up the platforms, just to try and catch any image build issues early.
         kver:
           [
-            { k8s: v1.21.14, k3s: v1.21.14+k3s1 },
-            { k8s: v1.22.17, k3s: v1.22.17+k3s1 },
-            { k8s: v1.23.17, k3s: v1.23.17+k3s1 },
-            { k8s: v1.24.17, k3s: v1.24.17+k3s1 },
-            { k8s: v1.25.16, k3s: v1.25.16+k3s4 },
-            { k8s: v1.26.15, k3s: v1.26.15+k3s1 },
-            { k8s: v1.27.16, k3s: v1.27.16+k3s1 },
-            { k8s: v1.28.14, k3s: v1.28.14+k3s1 },
-            { k8s: v1.29.15, k3s: v1.29.15+k3s1 },
-            { k8s: v1.30.11, k3s: v1.30.11+k3s1 },
-            { k8s: v1.31.7, k3s: v1.31.7+k3s1 },
-            { k8s: v1.32.3, k3s: v1.32.3+k3s1 },
+            { k8s: v1.21.14, k3s: v1.21.14+k3s1, platform: linux/amd64 },
+            { k8s: v1.22.17, k3s: v1.22.17+k3s1, platform: linux/arm64 },
+            { k8s: v1.23.17, k3s: v1.23.17+k3s1, platform: linux/amd64 },
+            { k8s: v1.24.17, k3s: v1.24.17+k3s1, platform: linux/arm64 },
+            { k8s: v1.25.16, k3s: v1.25.16+k3s4, platform: linux/amd64 },
+            { k8s: v1.26.15, k3s: v1.26.15+k3s1, platform: linux/arm64 },
+            { k8s: v1.27.16, k3s: v1.27.16+k3s1, platform: linux/amd64 },
+            { k8s: v1.28.14, k3s: v1.28.14+k3s1, platform: linux/arm64 },
+            { k8s: v1.29.15, k3s: v1.29.15+k3s1, platform: linux/amd64 },
+            { k8s: v1.30.11, k3s: v1.30.11+k3s1, platform: linux/arm64 },
+            { k8s: v1.31.7, k3s: v1.31.7+k3s1, platform: linux/amd64 },
+            { k8s: v1.32.3, k3s: v1.32.3+k3s1, platform: linux/arm64 },
           ]
 
     steps:
@@ -72,46 +80,55 @@ jobs:
           version: ${{ matrix.kver.k8s }}
 
       - name: Install Krew and Plugins
-        run: |
-          (
-            set -x; cd "$(mktemp -d)" &&
-            OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
-            ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
-            KREW="krew-${OS}_${ARCH}" &&
-            curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
-            tar zxvf "${KREW}.tar.gz" &&
-            ./"${KREW}" install krew
-          )
-          echo "$HOME/.krew/bin" >> "$GITHUB_PATH"
-          export PATH="$HOME/.krew/bin:$PATH"
-          kubectl krew install stern
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 4
+          command: |
+            (
+              set -x; cd "$(mktemp -d)" &&
+              OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+              ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+              KREW="krew-${OS}_${ARCH}" &&
+              curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+              tar zxvf "${KREW}.tar.gz" &&
+              ./"${KREW}" install krew
+            )
+            echo "$HOME/.krew/bin" >> "$GITHUB_PATH"
+            export PATH="$HOME/.krew/bin:$PATH"
+            kubectl krew install stern
 
       - name: Install Helm
-        run: |
-          # Helm
-          curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-          sudo apt-get install apt-transport-https --yes
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-          sudo apt-get update
-          sudo apt-get install helm
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 4
+          command: |
+            # Helm
+            curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+            sudo apt-get install apt-transport-https --yes
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+            sudo apt-get update
+            sudo apt-get install helm
 
-      - name: Install SNAP Software
-        run: |
-          sudo snap install yq --channel=v4/stable
-
-      - name: Manual Software Installs
-        run: |
-          LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | grep tag_name | cut -d : -f2 | tr -d "v\", ")
-          curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign_${LATEST_VERSION}_amd64.deb"
-          sudo dpkg -i cosign_${LATEST_VERSION}_amd64.deb
-          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sudo sh -s -- -v -b /usr/local/bin
+      - name: Install Helm
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 4
+          command: |
+            sudo snap install yq --channel=v4/stable
 
       - name: Setup k3s ${{ matrix.kver.k3s }}
-        run: |
-          echo "Ensure UFW is disabled"
-          sudo ufw disable
-          echo "Setup k3s ${{ matrix.kver.k3s }}"
-          curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ matrix.kver.k3s }}" INSTALL_K3S_CHANNEL="stable" sh -s -
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 4
+          command: |
+            echo "Ensure UFW is disabled"
+            sudo ufw disable
+            echo "Setup k3s ${{ matrix.kver.k3s }}"
+            curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ matrix.kver.k3s }}" INSTALL_K3S_CHANNEL="stable" sh -s -
 
       - name: Prepare a kubeconfig in ~/.kube/config
         run: |
@@ -153,7 +170,7 @@ jobs:
             -n testkube \
             --all \
             --for condition=Available=True \
-            --timeout=500s
+            --timeout=600s
 
       # Install Testkube CLI
       - uses: kubeshop/setup-testkube@v1
@@ -189,7 +206,7 @@ jobs:
             -n cz-agent \
             --all \
             --for condition=Available=True \
-            --timeout=500s
+            --timeout=600s
 
       - name: Apply and Run TestKube Tests
         run: |
@@ -204,14 +221,18 @@ jobs:
         if: failure()
         continue-on-error: true
         run: |
-          rm -f /tmp/${{ matrix.kver.k3s }}.log
-          touch /tmp/${{ matrix.kver.k3s }}.log
-          echo "---Kubectl Events------------------------------------------------------" &>> /tmp/${{ matrix.kver.k3s }}.log
-          kubectl events -n cz-agent &>> /tmp/${{ matrix.kver.k3s }}.log || echo "[ERROR] Kubectl events command exited error." &>> /tmp/${{ matrix.kver.k3s }}.log
-          echo "---Stern Logs----------------------------------------------------------" &>> /tmp/${{ matrix.kver.k3s }}.log
-          kubectl stern -n cz-agent --since=3m --no-follow -t . | sort -k4 &>> /tmp/${{ matrix.kver.k3s }}.log || echo "[ERROR] Stern log command exited error." &>> /tmp/${{ matrix.kver.k3s }}.log
-          echo "---Testkube Logs-------------------------------------------------------" &>> /tmp/${{ matrix.kver.k3s }}.log
-          testkube get testworkflowexecution $(testkube get testworkflowexecution --limit 1 -o yaml | yq e .[0].id) &>> /tmp/${{ matrix.kver.k3s }}.log || echo "[ERROR] Testkube log command exited error." &>> /tmp/${{ matrix.kver.k3s }}.log
+          rm -f ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          touch ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          echo "---Kubectl Get All-----------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          kubectl get all -A &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log || echo "[ERROR] Kubectl get all command exited error." &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          echo "---Kubectl Events------------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          kubectl events -A &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log || echo "[ERROR] Kubectl events command exited error." &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          echo "---Stern Logs (testkube)------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          kubectl stern -n testkube --since=3m --no-follow -t . | sort -k4 &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log || echo "[ERROR] Stern log command exited error." &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          echo "---Stern Logs (cz-agent)------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          kubectl stern -n cz-agent --since=3m --no-follow -t . | sort -k4 &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log || echo "[ERROR] Stern log command exited error." &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          echo "---Testkube Logs--------------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
+          testkube get testworkflowexecution $(testkube get testworkflowexecution --limit 1 -o yaml | yq e .[0].id) &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log || echo "[ERROR] Testkube log command exited error." &>> ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
 
       # It wouldn't be a bad idea to do a security pattern scan of these logs and redact them if a
       # potential secret it detected, since they will be publicly available if uploaded.
@@ -221,7 +242,7 @@ jobs:
         if: always() && steps.logs.conclusion == 'success'
         with:
           name: ${{ matrix.kver.k3s }}.log
-          path: /tmp/${{ matrix.kver.k3s }}.log
+          path: ${{ runner.temp }}/${{ matrix.kver.k3s }}.log
           retention-days: 1
           if-no-files-found: warn
 

--- a/.github/workflows/test-matrix-replicated-k8s-clusters.yaml
+++ b/.github/workflows/test-matrix-replicated-k8s-clusters.yaml
@@ -1,0 +1,403 @@
+name: test-matrix-replicated-k8s-clusters
+
+# NOTE: There is a `replicated` CLI should anyone be interested:
+# https://docs.replicated.com/reference/replicated-cli-installing
+
+on:
+  workflow_dispatch:
+    inputs:
+      image-repo:
+        description: "The registry for the image"
+        default: "ghcr.io"
+        type: "string"
+      image-path:
+        description: "The path for the image (no registry, no tag)"
+        default: "cloudzero/cloudzero-agent/cloudzero-agent"
+        type: "string"
+      image-tag:
+        description: "The image tag"
+        default: "latest"
+        type: "string"
+  workflow_call:
+    inputs:
+      image-repo:
+        description: "The registry for the image"
+        default: "ghcr.io"
+        type: "string"
+      image-path:
+        description: "The path for the image (no registry, no tag)"
+        default: "cloudzero/cloudzero-agent/cloudzero-agent"
+        type: "string"
+      image-tag:
+        description: "The image tag"
+        default: "latest"
+        type: "string"
+    outputs:
+      cluster-test-status:
+        description: "The completion status of the replicated-test job"
+        value: ${{ jobs.compatibility-matrix.outputs.cluster-test-status }}
+
+concurrency:
+  # This concurrency group ensures that only one job in the group runs at a time.
+  # If a new job is triggered, the previous one will be canceled.
+  group: matrix-replicated-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compatibility-matrix:
+    name: replicated-test-${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}-${{ matrix.cluster.version }}
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      cluster-test-status: ${{ job.status }}
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster:
+          [
+            {
+              distribution: rke2,
+              version: v1.32.3,
+              instance-type: r1.large,
+              arch: amd64,
+            },
+            {
+              distribution: eks,
+              version: v1.32,
+              instance-type: m5.large,
+              arch: arm64,
+            },
+            {
+              distribution: eks,
+              version: v1.32,
+              instance-type: m7g.large,
+              arch: amd64,
+            },
+            {
+              distribution: aks,
+              version: v1.32,
+              instance-type: Standard_DS3_v2,
+              arch: amd64,
+            },
+            {
+              distribution: aks,
+              version: v1.32,
+              instance-type: Standard_D4ps_v5,
+              arch: arm64,
+            },
+            {
+              distribution: gke,
+              version: v1.32,
+              instance-type: e2-standard-2,
+              arch: amd64,
+            },
+            {
+              distribution: gke,
+              version: v1.32,
+              instance-type: t2a-standard-4,
+              arch: arm64,
+            },
+          ]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Krew and Plugins
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 4
+          command: |
+            (
+              set -x; cd "$(mktemp -d)" &&
+              OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+              ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+              KREW="krew-${OS}_${ARCH}" &&
+              curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+              tar zxvf "${KREW}.tar.gz" &&
+              ./"${KREW}" install krew
+            )
+            echo "$HOME/.krew/bin" >> "$GITHUB_PATH"
+            export PATH="$HOME/.krew/bin:$PATH"
+            kubectl krew install stern
+
+      - name: Generate Valid Cluster Name
+        run: |
+          CNAME=${{ github.ref_name }}-${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}-${{ matrix.cluster.version }}
+          CLUSTER_NAME="${CNAME//\//-}"
+          echo "CLUSTER_NAME=${CLUSTER_NAME}" >> $GITHUB_ENV
+
+      - name: Create Cluster
+        id: create-cluster
+        uses: replicatedhq/replicated-actions/create-cluster@v1
+        with:
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          kubernetes-distribution: ${{ matrix.cluster.distribution }}
+          kubernetes-version: ${{ matrix.cluster.version }}
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          timeout-minutes: 20 # Some clusters can take this long to spin up.
+          instance-type: ${{ matrix.cluster.instance-type }}
+          nodes: 1
+          ttl: 20m # How long they should stay up after they become available.
+          tags: |
+            - key: "team"
+              value: "cirrus"
+            - key: "purpose"
+              value: "testing"
+            - key: "lifespan"
+              value: "ephemeral"
+
+      - name: Setup kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ steps.create-cluster.outputs.cluster-kubeconfig }}" > ~/.kube/config
+
+      - name: Add TestKube Tolerations for GKE/ARM64
+        if: matrix.cluster.distribution == 'gke' && matrix.cluster.arch == 'arm64'
+        run: |
+          cat <<EOF > ${{ runner.temp }}/testkube-values.yaml
+          nats:
+            podTemplate:
+              merge:
+                spec:
+                  tolerations:
+                    - key: kubernetes.io/arch
+                      operator: Equal
+                      value: arm64
+                      effect: NoSchedule
+          mongodb:
+            tolerations:
+              - key: kubernetes.io/arch
+                operator: Equal
+                value: arm64
+                effect: NoSchedule
+          preUpgradeHook:
+            tolerations:
+              - key: kubernetes.io/arch
+                operator: Equal
+                value: arm64
+                effect: NoSchedule
+          preUpgradeHookNATS:
+            tolerations:
+              - key: kubernetes.io/arch
+                operator: Equal
+                value: arm64
+                effect: NoSchedule
+          testkube-api:
+            minio:
+              tolerations:
+                - key: kubernetes.io/arch
+                  operator: Equal
+                  value: arm64
+                  effect: NoSchedule
+            testConnection:
+              tolerations:
+                - key: kubernetes.io/arch
+                  operator: Equal
+                  value: arm64
+                  effect: NoSchedule
+            tolerations:
+              - key: kubernetes.io/arch
+                operator: Equal
+                value: arm64
+                effect: NoSchedule
+          testkube-operator:
+            preUpgrade:
+              tolerations:
+                - key: kubernetes.io/arch
+                  operator: Equal
+                  value: arm64
+                  effect: NoSchedule
+            testConnection:
+              tolerations:
+                - key: kubernetes.io/arch
+                  operator: Equal
+                  value: arm64
+                  effect: NoSchedule
+            tolerations:
+              - key: kubernetes.io/arch
+                operator: Equal
+                value: arm64
+                effect: NoSchedule
+            webhook:
+              patch:
+                tolerations:
+                  - key: kubernetes.io/arch
+                    operator: Equal
+                    value: arm64
+                    effect: NoSchedule
+          EOF
+
+      - name: Add CloudZero Agent Tolerations for GKE/ARM64
+        if: matrix.cluster.distribution == 'gke' && matrix.cluster.arch == 'arm64'
+        run: |
+          cat <<EOF > ${{ runner.temp }}/cz-agent-values.yaml
+          defaults:
+            tolerations:
+              - key: kubernetes.io/arch
+                operator: Equal
+                value: arm64
+                effect: NoSchedule
+          kubeStateMetrics:
+            tolerations:
+              - key: kubernetes.io/arch
+                operator: Equal
+                value: arm64
+                effect: NoSchedule
+          EOF
+
+      - name: Set default StorageClass in EKS
+        if: matrix.cluster.distribution == 'eks'
+        run: |
+          kubectl patch storageclass gp2 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+      # Note: When adding OpenShift support someday, both TestKube and the
+      # CloudZero Agent will likely need additional manifests due to the
+      # security setup in OpenShift.
+      # see: https://docs.testkube.io/articles/install/standalone-agent#deploying-on-openshift
+
+      # Install TestKube into Cluster
+      - name: Install TestKube
+        run: |
+          echo "Applying TestKube Helm Chart"
+          touch ${{ runner.temp }}/testkube-values.yaml
+          if [[ -f ${{ runner.temp }}/testkube-k8s-manifests.yaml ]]; then
+            kubectl apply -f ${{ runner.temp }}/testkube-k8s-manifests.yaml
+          else
+            kubectl create namespace testkube
+          fi
+          helm repo add kubeshop https://kubeshop.github.io/helm-charts
+          helm install testkube kubeshop/testkube \
+            --version=v2.1.137 \
+            -n testkube \
+            --values ${{ runner.temp }}/testkube-values.yaml
+          echo "Wait for testkube deployments"
+          kubectl wait deployment \
+            -n testkube \
+            --all \
+            --for condition=Available=True \
+            --timeout=600s
+
+      # Install Testkube CLI
+      - uses: kubeshop/setup-testkube@v1
+        with:
+          namespace: testkube
+          version: 2.1.137
+
+      - name: Setup imagePullSecrets
+        run: |
+          kubectl create ns cz-agent
+          kubectl create secret \
+            docker-registry \
+            ghcr-registry \
+            -n cz-agent \
+            --docker-server=https://ghcr.io \
+            --docker-username=${{ github.actor }} \
+            --docker-password=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare for helm install
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 4
+          command: |
+            helm repo add prom https://prometheus-community.github.io/helm-charts
+            helm dependency build ./helm
+
+      # Install CloudZero Agent into Cluster
+      - name: Install CloudZero Agent
+        run: |
+          echo "Applying CloudZero Agent Helm Chart"
+          touch ${{ runner.temp }}/cz-agent-values.yaml
+          # Be aware that this logic could lead to some values duplication.
+          cat <<EOF >> ${{ runner.temp }}/cz-agent-values.yaml
+          cloudAccountId: ID12345
+          clusterName: ${{ env.CLUSTER_NAME }}
+          region: us-east-1
+          apiKey: ${{ secrets.CLOUDZERO_DEV_API_KEY }}
+          host: dev-api.cloudzero.com
+          imagePullSecrets:
+            - name: ghcr-registry
+          insightsController:
+            server:
+              replicaCount: 1
+          components:
+            agent:
+              image:
+                repository: ${{ inputs.image-repo }}/${{ inputs.image-path }}
+                tag: ${{ inputs.image-tag }}
+          EOF
+          helm install cz-agent ./helm \
+            -n cz-agent \
+            --values ${{ runner.temp }}/cz-agent-values.yaml
+          echo "Wait for CloudZero Agent deployments"
+          kubectl wait deployment \
+            -n cz-agent \
+            --all \
+            --for condition=Available=True \
+            --timeout=600s
+
+      - name: Apply and Run TestKube Tests
+        run: |
+          kubectl apply -f ./tests/testkube/tests.yaml
+          testkube run testworkflow agent-basic-test -f
+
+      # Many more testkube based tests could be added in here as desired.
+      # Testkube support Postman, K6, simple scripts and much more.
+
+      - name: Collect Logs
+        id: logs
+        if: failure()
+        continue-on-error: true
+        run: |
+          rm -f ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          touch ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          #echo "---Kubectl Nodes-------------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          #kubectl get nodes -o json &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Kubectl get nodes command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          #echo "---Kubectl Storage Info------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          #kubectl get storageclasses &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Kubectl get storageclasses command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          #kubectl describe pv -A &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Kubectl get pv command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          #kubectl describe pvc -A &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Kubectl get pvc command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          echo "---Kubectl Get All-----------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          kubectl get all -A &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Kubectl get all command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          echo "---Kubectl Describe Pods (testkube)------------------------------------" &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          kubectl describe pods -n testkube &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Kubectl describe pods (testkube) command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          echo "---Kubectl Describe Pods (cz-agent)------------------------------------" &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          kubectl describe pods -n cz-agent &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Kubectl describe pods (cz-agent) command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          echo "---Kubectl Events------------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          kubectl events -A &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Kubectl events command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          echo "---Stern Logs (testkube)------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          kubectl stern -n testkube --since=3m --no-follow -t . | sort -k4 &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Stern log command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          echo "---Stern Logs (cz-agent)------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          kubectl stern -n cz-agent --since=3m --no-follow -t . | sort -k4 &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Stern log command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          echo "---Testkube Logs--------------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          testkube get testworkflowexecution $(testkube get testworkflowexecution --limit 1 -o yaml | yq e .[0].id) &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log || echo "[ERROR] Testkube log command exited error." &>> ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+
+      # It wouldn't be a bad idea to do a security pattern scan of these logs and redact them if a
+      # potential secret it detected, since they will be publicly available if uploaded.
+
+      - name: Upload Failure Logs
+        uses: actions/upload-artifact@v4
+        if: always() && steps.logs.conclusion == 'success'
+        with:
+          name: ${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          path: ${{ runner.temp }}/${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}.log
+          retention-days: 1
+          if-no-files-found: warn
+
+      - name: Remove Cluster
+        if: ${{ always() }}
+        id: remove-cluster
+        uses: replicatedhq/replicated-actions/remove-cluster@v1
+        continue-on-error: true # It could be that the cluster is already removed
+        with:
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
+
+      - name: Cleanup
+        if: ${{ always() }}
+        id: cleanup
+        continue-on-error: true
+        run: |
+          rm -f ~/.kube/config

--- a/tests/testkube/tests.yaml
+++ b/tests/testkube/tests.yaml
@@ -5,6 +5,12 @@ metadata:
   name: agent-basic-test
   namespace: testkube
 spec:
+  pod:
+    tolerations:
+      - key: kubernetes.io/arch
+        operator: Equal
+        value: arm64
+        effect: NoSchedule
   steps:
     - run:
         image: "curlimages/curl:8.13.0"


### PR DESCRIPTION
## Why?

> This awesome thing improves my smile brightness

- This tests a bunch of different types of Kubernetes cluster, including `eks`, `gke`, `aks`, and `rke2` (Rancher - which should be useful since people do run Rancher clusters in these cloud providers).
  -  Today, it is also possible to add support for `oks` (Oracle), `okd` (OpenShift) , `k3s`, and `kind`, but these do not really do us any good, so let's not waste the money.
- It also adds tests for `arm64` based systems, in addition to the default `amd64` based systems.
- And it also refactors the Docker build workflow to speed it up by using native runners for `arm64` images.

## What

> Outline the actions you took to achieve a brighter smile

A new github workflow.

## How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile

Iteration...