### PR TITLE
CP-28054: add option for setting pod disruption budgets

### DIFF
--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -4,17 +4,24 @@ metadata:
   name: {{ include "cloudzero-agent.aggregator.name" . }}
   namespace: {{ .Release.Namespace }}
   {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
-  labels:
-    {{- include "cloudzero-agent.aggregator.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "globals" .
+      "labels" (merge (include "cloudzero-agent.aggregator.matchLabels" . | fromYaml) .Values.commonMetaLabels)
+      "component" "aggregator"
+    ) | nindent 2 }}
 spec:
   selector:
     matchLabels:
       {{- include "cloudzero-agent.aggregator.matchLabels" . | nindent 6 }}
-  replicas: {{ .Values.aggregator.replicas }}
+  replicas: {{ .Values.components.aggregator.replicas }}
   template:
     metadata:
       {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations (dict "checksum/config" (include "cloudzero-agent.aggregator.configuration" . | sha256sum))) | nindent 6 }}
-      {{- include "cloudzero-agent.generateLabels" (dict "globals" . "labels" (merge (include "cloudzero-agent.aggregator.matchLabels" . | fromYaml) .Values.commonMetaLabels)) | nindent 6 }}
+      {{- include "cloudzero-agent.generateLabels" (dict
+          "globals" .
+          "labels" (merge (include "cloudzero-agent.aggregator.matchLabels" . | fromYaml) .Values.commonMetaLabels)
+          "component" "aggregator"
+        ) | nindent 6 }}
     spec:
       serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}
       {{- include "cloudzero-agent.generatePriorityClassName" (.Values.defaults.priorityClassName | default .Values.server.priorityClassName) | nindent 6 }}
@@ -139,3 +146,8 @@ spec:
             {}
         {{- end }}
 {{- end }}
+{{ include "cloudzero-agent.generatePodDisruptionBudget" (dict
+    "component" .Values.components.aggregator
+    "name" (include "cloudzero-agent.aggregator.name" .)
+    "matchLabels" (include "cloudzero-agent.aggregator.matchLabels" .)
+  ) }}

--- a/helm/templates/deploy.yaml
+++ b/helm/templates/deploy.yaml
@@ -188,3 +188,8 @@ spec:
             {}
           {{- end }}
         {{- end }}
+{{ include "cloudzero-agent.generatePodDisruptionBudget" (dict
+    "component" .Values.components.agent
+    "name" (include "cloudzero-agent.server.fullname" .)
+    "matchLabels" (include "cloudzero-agent.server.matchLabels" .)
+  ) }}

--- a/helm/templates/insights-deploy.yaml
+++ b/helm/templates/insights-deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
   {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.insightsController.server.deploymentAnnotations) | nindent 2 }}
 spec:
-  replicas: {{ .Values.insightsController.server.replicaCount }}
+  replicas: {{ .Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas }}
   selector:
     matchLabels:
       {{- include "cloudzero-agent.insightsController.server.matchLabels" . | nindent 6 }}
@@ -107,3 +107,9 @@ spec:
         {{- end }}
       {{- end }}
 {{- end }}
+{{ include "cloudzero-agent.generatePodDisruptionBudget" (dict
+    "component" .Values.components.webhookServer
+    "name" (include "cloudzero-agent.insightsController.deploymentName" .)
+    "matchLabels" (include "cloudzero-agent.insightsController.server.matchLabels" .)
+    "replicas" .Values.insightsController.server.replicaCount
+  ) }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -137,20 +137,26 @@ defaults:
 
 # Component-specific configuration settings.
 components:
-  # The agent here refers to the CloudZero Agent, which contains most of the
-  # code that makes this chart work. Since 1.1, CloudZero uses a single
-  # container image, with multiple executables, to provide CloudZero
-  # functionality.
+  # The agent here refers to the CloudZero Agent, which is the component that
+  # collects metrics from the cluster and sends them to the aggregator.
   agent:
+    # This is the image which contains most of the code that makes this chart
+    # work. Since 1.1, CloudZero uses a single container image, with multiple
+    # executables, to provide CloudZero functionality.
     image:
       repository: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent
       tag: 1.1.0-rc-1  # <- Software release corresponding to this chart version.
+    podDisruptionBudget:
+      minAvailable:
+      maxUnavailable:
+
   # kubectl contains details about where to find the kubectl image.  This chart
   # uses the kubectl image as part of the job to initialize certificates.
   kubectl:
     image:
       repository: docker.io/bitnami/kubectl
       tag: "1.32.0"
+
   # prometheus contains details about where to find the Prometheus image.
   # Prometheus is critical to the functionality of this chart, and is used to
   # scrape metrics.
@@ -158,6 +164,7 @@ components:
     image:
       repository: quay.io/prometheus/prometheus
       tag:  # This will fall back on .Chart.AppVersion if not set.
+
   # prometheusReloader contains details about where to find the Prometheus
   # reloader image.
   #
@@ -167,6 +174,22 @@ components:
     image:
       repository: quay.io/prometheus-operator/prometheus-config-reloader
       tag: "v0.70.0"
+
+  # Settings for the aggregator component. This is the piece which accepts
+  # metrics from the agent, webhook, etc., and sends them to the CloudZero API
+  # after some processing.
+  aggregator:
+    replicas: 3
+    podDisruptionBudget:
+      minAvailable:
+      maxUnavailable:
+
+  # Settings for the webhook server.
+  webhookServer:
+    replicas: 3
+    podDisruptionBudget:
+      minAvailable:
+      maxUnavailable:
 
 # Due to limitations of Helm, we are unfortunately not able to automatically configure the
 # kube-state-metrics subchart using the configuration above, and instead need to configure
@@ -410,7 +433,7 @@ insightsController:
     useCertManager: false
   server:
     name: webhook-server
-    replicaCount: 3
+    replicaCount:
     # -- Uncomment to use a specific imagePullSecrets; otherwise, the default top level imagePullSecrets is used.
     # imagePullSecrets: []
     image:
@@ -489,7 +512,6 @@ configmapReload:
 # ensuring that there is no data loss in the event of any loss of communication with the CloudZero API,
 # even when a misconfiguration (such as an incorrect API key) prevents it.
 aggregator:
-  replicas: 1
   logging:
     # Logging level that will be posted to stdout.
     # Valid values are: 'debug', 'info', 'warn', 'error'

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1244,9 +1244,9 @@ metadata:
     checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
   labels:
     app.kubernetes.io/component: aggregator
-    app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.50.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1256,7 +1256,7 @@ spec:
       app.kubernetes.io/component: aggregator
       app.kubernetes.io/name: cz-agent-aggregator
       app.kubernetes.io/instance: cz-agent
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       annotations:


### PR DESCRIPTION
## What?

Support for setting a pod disruption budget for all our deployments.

This also bumps the default replica count for the gator from 1 to 3, and moves the setting to `.Values.components.aggregator.replicas`. Similarly, `.Values.insightsController.server.replicaCount` moves to `.Values.components.webhookServer.replicas`, though if the former is set it will be used (preserving BC isn't an issue for the gator since we haven't had a release yet)

## How Tested

Lots of tweaking the values and looking at the `helm template` output. Also set couple values and did a deployment.