### PR TITLE
CP-28109: separate config for cost and o11y metrics rotation interval

### DIFF
--- a/app/functions/collector/main.go
+++ b/app/functions/collector/main.go
@@ -62,7 +62,11 @@ func main() {
 		fmt.Println(string(enc))
 	}
 
-	costMetricStore, err := disk.NewDiskStore(settings.Database, disk.WithContentIdentifier(disk.CostContentIdentifier))
+	costMetricStore, err := disk.NewDiskStore(
+		settings.Database,
+		disk.WithContentIdentifier(disk.CostContentIdentifier),
+		disk.WithMaxInterval(settings.Database.CostMaxInterval),
+	)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to initialize database")
 	}
@@ -75,7 +79,11 @@ func main() {
 		}
 	}()
 
-	observabilityMetricStore, err := disk.NewDiskStore(settings.Database, disk.WithContentIdentifier(disk.ObservabilityContentIdentifier))
+	observabilityMetricStore, err := disk.NewDiskStore(
+		settings.Database,
+		disk.WithContentIdentifier(disk.ObservabilityContentIdentifier),
+		disk.WithMaxInterval(settings.Database.ObservabilityMaxInterval),
+	)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to initialize database")
 	}

--- a/app/storage/disk/disk_test.go
+++ b/app/storage/disk/disk_test.go
@@ -95,7 +95,7 @@ func TestDiskStore_FlushTimeout(t *testing.T) {
 	dirPath := t.TempDir()
 	rowLimit := 5
 
-	ps, err := disk.NewDiskStore(config.Database{StoragePath: dirPath, MaxRecords: rowLimit, MaxInterval: 50 * time.Millisecond})
+	ps, err := disk.NewDiskStore(config.Database{StoragePath: dirPath, MaxRecords: rowLimit}, disk.WithMaxInterval(50*time.Millisecond))
 	assert.NoError(t, err)
 
 	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -63,7 +63,8 @@ logging:
 database:
   storage_path: {{ .Values.aggregator.mountRoot }}/data
   max_records: {{ .Values.aggregator.database.maxRecords }}
-  max_interval: {{ .Values.aggregator.database.maxInterval }}
+  cost_max_interval: {{ .Values.aggregator.database.costMaxInterval }}
+  observability_max_interval: {{ .Values.aggregator.database.observabilityMaxInterval }}
   compression_level: {{ .Values.aggregator.database.compressionLevel }}
   purge_rules:
     metrics_older_than: {{ .Values.aggregator.database.purgeRules.metricsOlderThan }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -538,8 +538,10 @@ aggregator:
   database:
     # Max number of records per file. Use this to adjust file sizes uploaded to the server. The default value is good in most cases.
     maxRecords: 1500000
-    # Max interval to flush a metrics file. This is mostly useful for smaller clusters with little activity.
-    maxInterval: 10m
+    # Max interval to flush a cost metrics file. This is mostly useful for smaller clusters with little activity.
+    costMaxInterval: 10m
+    # Max interval to flush an observability metrics file. This is mostly useful for smaller clusters with little activity.
+    observabilityMaxInterval: 30m
     # Compression level to use when compressing metrics files on-disk.
     # Valid value range from 0-11, with higher values yielding improved compression ratios
     # at the expense of speed and memory usage.

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -654,7 +654,8 @@ data:
     database:
       storage_path: /cloudzero/data
       max_records: 1.5e+06
-      max_interval: 10m
+      cost_max_interval: 10m
+      observability_max_interval: 30m
       compression_level: 8
       purge_rules:
         metrics_older_than: 2160h

--- a/tests/smoke/client_test.go
+++ b/tests/smoke/client_test.go
@@ -80,6 +80,7 @@ func TestSmoke_ClientApplication_Runs(t *testing.T) {
 		settings.Cloudzero.SendInterval = time.Second * 10
 		settings.Cloudzero.UseHTTP = true
 		settings.Cloudzero.SendTimeout = time.Second * 30
-		settings.Database.MaxInterval = time.Second * 10
+		settings.Database.CostMaxInterval = time.Second * 10
+		settings.Database.ObservabilityMaxInterval = time.Second * 10
 	}))
 }

--- a/tests/smoke/collector_test.go
+++ b/tests/smoke/collector_test.go
@@ -68,7 +68,8 @@ func TestSmoke_Controller_FileRotate(t *testing.T) {
 		settings.Cloudzero.SendInterval = time.Second * 10
 		settings.Cloudzero.UseHTTP = true
 		settings.Cloudzero.SendTimeout = time.Second * 30
-		settings.Database.MaxInterval = time.Second * 10
+		settings.Database.CostMaxInterval = time.Second * 10
+		settings.Database.ObservabilityMaxInterval = time.Second * 10
 		settings.Database.MaxRecords = 10_000 // small record count to encourage file rotation
 	}))
 }

--- a/tests/smoke/load_test.go
+++ b/tests/smoke/load_test.go
@@ -129,6 +129,7 @@ func TestLoad_ClientApplication(t *testing.T) {
 		settings.Cloudzero.SendInterval = time.Second * 10
 		settings.Cloudzero.UseHTTP = true
 		settings.Cloudzero.SendTimeout = time.Second * 30
-		settings.Database.MaxInterval = time.Second * 10
+		settings.Database.CostMaxInterval = time.Second * 10
+		settings.Database.ObservabilityMaxInterval = time.Second * 10
 	}))
 }


### PR DESCRIPTION
## What

This allows us to set the rotation interval independently for Cost and Observability metrics.

## Why

The latter are lower-priority and can probably wait longer, but we generally want to get the cost metrics shipped to the CloudZero server much more quickly.

## How Tested

`make test` has some tests which rely on the setting. I also deployed to a cluster to verify the Helm changes. Just to make extra sure the settings were being picked up, I also added some logging to the DiskStore (locally, not in the patch) to dump the interval being used and verified that it corresponded to the relevant setting.