### PR TITLE
CP-28622: add Helm to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+
+  - package-ecosystem: "helm"
+    directory: "/helm/"
+    schedule:
+      interval: "weekly"
+      day: "friday"


### PR DESCRIPTION
## Why?

To keep our Helm dependencies (currently only kube-state-metrics) up-to-date.

## What

Add /helm/ ecosystem to our Dependabot configuration.

## How Tested

Completely untested. YOLO!