### PR TITLE
changed mkdir to mkdirall to fix create dir error

### DIFF
--- a/app/domain/shipper/shipper.go
+++ b/app/domain/shipper/shipper.go
@@ -83,10 +83,10 @@ func (m *MetricShipper) GetMetricHandler() http.Handler {
 // Run starts the MetricShipper service and blocks until a shutdown signal is received.
 func (m *MetricShipper) Run() error {
 	// create the required directories for this application
-	if err := os.Mkdir(m.GetUploadedDir(), filePermissions); err != nil {
+	if err := os.MkdirAll(m.GetUploadedDir(), filePermissions); err != nil {
 		return errors.Join(ErrCreateDirectory, fmt.Errorf("failed to create the uploaded directory: %w", err))
 	}
-	if err := os.Mkdir(m.GetReplayRequestDir(), filePermissions); err != nil {
+	if err := os.MkdirAll(m.GetReplayRequestDir(), filePermissions); err != nil {
 		return errors.Join(ErrCreateDirectory, fmt.Errorf("failed to create the replay request directory: %w", err))
 	}
 


### PR DESCRIPTION
@roberthocking pointed out an error where in some cases where the shipper restarts (but the pod does NOT restart), then there would be an error for a directory already created in the emptyDir.

Changing `Mkdir` to `MkdirAll` fixes this. If the directory already exists then it will just return null. In addition, I did a quick check throughout to ensure we are not making this mistake anywhere else. This was the only occurrence, so it must have slipped through the cracks. potentially we should all K8s tests to restart individual containers within the pod and ensure we get no error logs.