### PR TITLE
CP-28707: reduce Kubernetes dependency to 1.21

### DIFF
--- a/.github/workflows/test-matrix-k8s-k3s.yaml
+++ b/.github/workflows/test-matrix-k8s-k3s.yaml
@@ -50,6 +50,8 @@ jobs:
         # From: https://github.com/e-minguez/k3s-versions
         kver:
           [
+            { k8s: v1.21.14, k3s: v1.21.14+k3s1 },
+            { k8s: v1.22.17, k3s: v1.22.17+k3s1 },
             { k8s: v1.23.17, k3s: v1.23.17+k3s1 },
             { k8s: v1.24.17, k3s: v1.24.17+k3s1 },
             { k8s: v1.25.16, k3s: v1.25.16+k3s4 },

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: cloudzero-agent
 description: A chart for using Prometheus in agent mode to send cluster metrics to the CloudZero platform.
 type: application
 version: 1.1.0-dev
-kubeVersion: ">= 1.23.0-0"
+kubeVersion: ">= 1.21.0-0"
 
 maintainers:
   - name: CloudZero


### PR DESCRIPTION
## Why?

To support older clusters.

## What

Reduce Kubernetes dependency from 1.23 to 1.21, add 1.21 and 1.22 to the test matrix.

## How Tested

Mostly relying on the test matrix here...
