### PR TITLE
CP-28706: remove unnecessary rollout restart call from init cert job

### DIFF
--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -100,7 +100,6 @@ rules:
     verbs:
       - "get"
       - "list"
-      - "patch"
   - apiGroups:
       - ""
     resources:

--- a/helm/templates/init-job.yaml
+++ b/helm/templates/init-job.yaml
@@ -181,8 +181,6 @@ spec:
                 --type='json' \
                 -p="[{'op': 'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value':'$CA_BUNDLE'}]"
               {{- end }}
-              # Now that the secret and webhook configuration are updated, roll the webhook-server pods to pick up the new certificate
-              kubectl rollout restart deployment -n {{ .Release.Namespace }} {{ include "cloudzero-agent.insightsController.deploymentName" . }}
               {{- else }}
               echo "The useCertManager flag is set to true. Skipping certificate generation and patching of resources."
               {{- end }}

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1017,7 +1017,6 @@ rules:
     verbs:
       - "get"
       - "list"
-      - "patch"
   - apiGroups:
       - ""
     resources:
@@ -1907,8 +1906,6 @@ spec:
               kubectl patch validatingwebhookconfiguration  cz-agent-cloudzero-agent-webhook-server-webhook \
                 --type='json' \
                 -p="[{'op': 'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value':'$CA_BUNDLE'}]"
-              # Now that the secret and webhook configuration are updated, roll the webhook-server pods to pick up the new certificate
-              kubectl rollout restart deployment -n default cz-agent-cloudzero-agent-webhook-server
               exit 0
 ---
 # Source: cloudzero-agent/templates/webhooks.yaml


### PR DESCRIPTION
## Why?

The `kubectl rollout restart` call in the init cert job is not necessary, and was the only reason we needed the "patch" permission on deployments in that job, so that can be removed too.

## What

Removed the unnecessary permission and rollout restart call.

## How Tested

Deployed a cluster with this change, then created a pod with a custom label, then waited for it to appear in the server side in Snowflake.