### PR TITLE
CP-28708: fix domain for webhook service

### DIFF
--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -27,7 +27,7 @@ certificate:
   cert: {{ .tls.mountPath }}/tls.crt
 server:
   namespace: {{ $namespace }}
-  domain: {{ $namespace }}-{{ .server.name }}-svc
+  domain: {{ include "cloudzero-agent.serviceName" $ }}
   port: {{ .server.port }}
   read_timeout: {{ .server.read_timeout }}
   write_timeout: {{ .server.write_timeout }}

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -95,7 +95,7 @@ metadata:
   name: cz-agent-configuration
   namespace: default
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
 data:
   prometheus.yml: |-
     global:
@@ -277,7 +277,7 @@ metadata:
   name: cz-agent-webhook-configuration
   namespace: default
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
 data:
   server-config.yaml: |-
     cloud_account_id: 1234567890
@@ -303,7 +303,7 @@ data:
       cert: /etc/certs/tls.crt
     server:
       namespace: default
-      domain: default-webhook-server-svc
+      domain: cz-agent-cloudzero-agent-webhook-server-svc
       port: 8443
       read_timeout: 10s
       write_timeout: 10s
@@ -348,7 +348,7 @@ metadata:
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
 data:
   config.yml: |-
     cloud_account_id: "1234567890"
@@ -907,7 +907,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: cloudzero-agent
@@ -1004,7 +1004,7 @@ metadata:
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
   name: cz-agent-cloudzero-agent-webhook-server-init-cert
   namespace: default
 rules:
@@ -1073,7 +1073,7 @@ metadata:
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
   name: cz-agent-cloudzero-agent-server
 subjects:
   - kind: ServiceAccount
@@ -1097,7 +1097,7 @@ metadata:
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
   name: cz-agent-cloudzero-agent-webhook-server-init-cert
 subjects:
   - kind: ServiceAccount
@@ -1266,7 +1266,7 @@ metadata:
   name: cz-agent-aggregator
   namespace: default
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
   labels:
     app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
@@ -1285,7 +1285,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+        checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
       labels:
         app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
   name: cz-agent-cloudzero-agent-server
   namespace: default
 spec:
@@ -1634,7 +1634,7 @@ spec:
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
-        checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+        checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       
@@ -1719,7 +1719,7 @@ metadata:
   name: cz-agent-backfill-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
   namespace: default
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
   labels:
     app.kubernetes.io/component: webhook-server
     app.kubernetes.io/name: cloudzero-agent
@@ -1738,7 +1738,7 @@ spec:
         app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
       annotations:
-        checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+        checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       restartPolicy: OnFailure
@@ -1793,7 +1793,7 @@ metadata:
   name: cz-agent-init-cert-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
   namespace: default
   annotations:
-    checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+    checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
   labels:
     app.kubernetes.io/component: webhook-server
     app.kubernetes.io/name: cloudzero-agent
@@ -1811,7 +1811,7 @@ spec:
         app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
       annotations:
-        checksum/config: 0cfb77ac8a608fb64953d9a8da0a97aae3fb490c443db1b9c32e0d7761d1eefb
+        checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
     spec:
       
       affinity:


### PR DESCRIPTION
## Why?

https://github.com/Cloudzero/cloudzero-charts/issues/200

In some situations, the webhook-configuration configmap would contain an incorrect value for the domain, causing the backfill job to fail due to an inability to resolve the (incorrect) DNS entry for the webhook service.

## What

This patch just tweaks the helper to generate the name using the same function which is used to generate the service name in the service resource.

## How Tested

The issue can be reproduced by installing to a namespaces different from the chart name (i.e., `helm install -n cza cz-agent ./helm`). The backfill job will fail before this patch, and works after it.