### PR TITLE
Limit replicated to merge Qs & critical pushes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,7 @@
 name: DockerBuild
 on:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - develop
@@ -296,6 +298,8 @@ jobs:
       contents: read
       packages: read
     needs: ["docker-build", "docker-merge"]
+    # We primarily want to run this when we are in a merge queue.
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/test-matrix-replicated-k8s-clusters.yaml
     with:
       image-repo: ${{ needs.docker-build.outputs.image-repo }}
@@ -326,7 +330,7 @@ jobs:
     permissions:
       statuses: write
     needs: ["replicated-compatibility-matrix-tests"]
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name != 'pull_request' }}
     steps:
       - uses: ouzi-dev/commit-status-updater@v2
         if: ${{ needs.replicated-compatibility-matrix-tests.outputs.cluster-test-status == 'success' }}


### PR DESCRIPTION
## Why?

> This awesome thing improves my smile brightness

by limiting the replicated tests, so that they only run when a PR has been added to a merge queue or there is a push directly to develop or main.

## What

> Outline the actions you took to achieve a brighter smile

Taking advantage of the merge queue support for GitHub Enterprise customers.

## How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile

By creating this PR...