### PR TITLE
CP-28953: clean input strings

### DIFF
--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -45,9 +45,9 @@ filters:
 Configuration for the aggregator Deployment. Configuration is defined in this tpl so that we can roll Deployment pods based on a checksum of these values
 */}}
 {{ define "cloudzero-agent.aggregator.configuration" -}}
-cloud_account_id: "{{ .Values.cloudAccountId }}"
-region: "{{ .Values.region }}"
-cluster_name: "{{ .Values.clusterName }}"
+cloud_account_id: {{ include "cloudzero-agent.cleanString" .Values.cloudAccountId }}
+cluster_name: {{ include "cloudzero-agent.cleanString" .Values.clusterName }}
+region: {{ include "cloudzero-agent.cleanString" .Values.region }}
 
 metrics:
   {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost" "filters"                 (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.name) | nindent 2 }}

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -279,9 +279,9 @@ metadata:
     checksum/config: 9a9ff43f870efab33429a0415882d2c031d205aedc523f59c52e3cc1134d5a6e
 data:
   config.yml: |-
-    cloud_account_id: "1234567890"
-    region: "us-east-1"
-    cluster_name: "my-cluster"
+    cloud_account_id: 1234567890
+    cluster_name: my-cluster
+    region: us-east-1
     
     metrics:
       


### PR DESCRIPTION
## Why?

When using ArgoCD, due to the schema validations -- AWS account ID which is a numeric value is asserted as a string since Helm will put it in scientific notation format - which prevents proper matching the actual account ID.

In practice we have seen multiple approaches, and many times users add extra quotes (double and single) to work around the differences in the schema versus ArgoCD issues.

This PR Cleans input strings before use using the method previously defined for this purpose.

# What

1. Apply the cleanString to the values before use


## How Tested
1. Use junk values as follows
```yaml
# notice the JUNK here
cloudAccountId: -|
  '"975482786146"''
clusterName: aws-cirrus-jb-cluster
region: us-east-2
existingSecretName: cloudzero-api-key
host: dev-api.cloudzero.com

commonMetaLabels:
  cloudzero.com/component: cloudzero-agent
  cloudzero.com/team: cirrus
  cloudzero.com/feature: conrtainer-analysis

# Override the image tag
components:
  agent:
    image:
      pullPolicy: Always
      repository: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent
      tag: dev-4753bcf5bd86702446fa5353bd026aa17678b54b

insightsController:
  server:
    logging:
      level: info
    replicaCount: 3
  annotations:
    enabled: false
    patterns:
      - .*
  enabled: true
  labels:
    enabled: true
    patterns:
      - .*
  tls:
```

2. Generate the template
```yaml
$ helm template cloudzero-agent . --values values.yaml --values override-values.yaml --dry-run --namespace cloudzero-agent --debug

...
---
# Source: cloudzero-agent/templates/aggregator-cm.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cloudzero-agent-aggregator
  namespace: cloudzero-agent
  labels:
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: cloudzero-agent
    app.kubernetes.io/version: v2.55.1
    cloudzero.com/component: cloudzero-agent
    cloudzero.com/feature: conrtainer-analysis
    cloudzero.com/team: cirrus
    helm.sh/chart: cloudzero-agent-1.1.0-dev
  annotations:
    checksum/config: c71912b89a0c7803a18952bb7764c2fa5479690ba51fcc52a042e5a5632d88ba
data:
  config.yml: |-
    cloud_account_id: 975482786146
    cluster_name: aws-cirrus-jb-cluster
    region: us-east-2
    ...
```
