### PR TITLE
merge group work

### DIFF
--- a/.github/workflows/cleanup-daily.yml
+++ b/.github/workflows/cleanup-daily.yml
@@ -1,0 +1,27 @@
+name: CleanDaily
+on:
+  schedule:
+    - cron: "0 14 * * *"
+
+concurrency:
+  # This concurrency group ensures that only one job in the group runs at a time.
+  # If a new job is triggered, the previous one will be canceled.
+  group: cleanup-daily-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup-daily:
+    name: Daily cleanup activities
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Cleanup older GHCR dev container images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        continue-on-error: true
+        with:
+          older-than: 2 weeks
+          repository: cloudzero-agent
+          package: "untested-cloudzero/untested-cloudzero-agent"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,7 +21,7 @@ concurrency:
   # This concurrency group ensures that only one job in the group runs at a time.
   # If a new job is triggered, the previous one will be canceled.
   group: docker-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'release' || github.ref != 'refs/heads/develop' || github.ref != 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/v') }}
 
 env:
   REGISTRY_PROD_ADDR: ghcr.io
@@ -272,14 +272,6 @@ jobs:
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
 
-      - name: Cleanup older dev images
-        uses: dataaxiom/ghcr-cleanup-action@v1
-        continue-on-error: true
-        with:
-          older-than: 2 weeks
-          repository: cloudzero-agent
-          package: "untested-cloudzero/untested-cloudzero-agent"
-
   k8s-version-matrix-tests:
     # These should match the permissions in the called workflow.
     permissions:
@@ -315,12 +307,12 @@ jobs:
     needs: ["k8s-version-matrix-tests"]
     if: ${{ always() }}
     steps:
-      - uses: spkane/commit-status-updater@merge-group-support
+      - uses: spkane/commit-status-updater@ab7c154fa766cdd0619d3a64fccafe653180108e
         if: ${{ needs.k8s-version-matrix-tests.outputs.version-test-status == 'success' }}
         with:
           name: "k8s-version-matrix-tests"
           status: "success"
-      - uses: spkane/commit-status-updater@merge-group-support
+      - uses: spkane/commit-status-updater@ab7c154fa766cdd0619d3a64fccafe653180108e
         if: ${{ needs.k8s-version-matrix-tests.outputs.version-test-status != 'success' }}
         with:
           name: "k8s-version-matrix-tests"
@@ -331,14 +323,14 @@ jobs:
     permissions:
       statuses: write
     needs: ["replicated-compatibility-matrix-tests"]
-    if: ${{ always() && github.event_name != 'pull_request' }}
+    if: ${{ always() && github.event_name == 'merge_group' }}
     steps:
-      - uses: spkane/commit-status-updater@merge-group-support
+      - uses: spkane/commit-status-updater@ab7c154fa766cdd0619d3a64fccafe653180108e
         if: ${{ needs.replicated-compatibility-matrix-tests.outputs.cluster-test-status == 'success' }}
         with:
           name: "replicated-compatibility-matrix-tests"
           status: "success"
-      - uses: spkane/commit-status-updater@merge-group-support
+      - uses: spkane/commit-status-updater@ab7c154fa766cdd0619d3a64fccafe653180108e
         if: ${{ needs.replicated-compatibility-matrix-tests.outputs.cluster-test-status != 'success' }}
         with:
           name: "replicated-compatibility-matrix-tests"
@@ -415,14 +407,14 @@ jobs:
       ]
     if: ${{ always() }}
     steps:
-      - uses: spkane/commit-status-updater@merge-group-support
+      - uses: spkane/commit-status-updater@ab7c154fa766cdd0619d3a64fccafe653180108e
         if: |
           !contains(needs.*.result, 'failure') &&
           !contains(needs.*.result, 'cancelled')
         with:
           name: "docker-build"
           status: "success"
-      - uses: spkane/commit-status-updater@merge-group-support
+      - uses: spkane/commit-status-updater@ab7c154fa766cdd0619d3a64fccafe653180108e
         if: |
           contains(needs.*.result, 'failure') ||
           contains(needs.*.result, 'cancelled')

--- a/app/types/status/cluster_status.pb.go
+++ b/app/types/status/cluster_status.pb.go
@@ -4,7 +4,6 @@
 // 	protoc        v5.29.3
 // source: cluster_status.proto
 
-// Package status contains generated code for reading and writing the ClusterStatus protobuf.
 package status
 
 import (

--- a/app/types/status/cluster_status.proto
+++ b/app/types/status/cluster_status.proto
@@ -32,4 +32,3 @@ message ClusterStatus {
 
     repeated StatusCheck checks = 10;
 }
-

--- a/app/types/status/report.go
+++ b/app/types/status/report.go
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Package status contains generated code for reading and writing the ClusterStatus protobuf.
 package status
 
 import (


### PR DESCRIPTION
## Why?

> This awesome thing improves my smile brightness

This primary reverts the GitHub status action fork back to a specific git ref. However, it also pulls out the GHCR image cleaning step into it's own scheduled workflow as it take many minutes to run.

## What

> Outline the actions you took to achieve a brighter smile

Mostly did a lot of testing a debugging in https://github.com/spkane/commit-status-updater/tree/merge-group-support

## How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile

Tested via a previous merge that was failing tests, but is now passing. Merging this will provide a secondary/confirmation test.