### PR TITLE
CP-29026: update duration and renew of certificate to include minutes

### DIFF
--- a/helm/templates/webhook-certificate.yaml
+++ b/helm/templates/webhook-certificate.yaml
@@ -16,8 +16,8 @@ spec:
     algorithm: RSA
     encoding: PKCS1
     size: 2048
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
   dnsNames:
     - {{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc
   issuerRef:


### PR DESCRIPTION
## Why?

ArgoCD apparently has trouble with the durations not including hours/minutes, which results in it always thinking there is a diff between what is applied and what is installed.

## What

Personally, I didn't do anything. But @ddemaret-plaid was kind enough to supply a patch to add hours/minutes to the relevant fields in the chart, in #227. I'm only opening this because of a permissions issue with GitHub Actions preventing the container image from being pushed to GHCR during the build.

## How Tested

Change is effectively a no-op from our perspective.

Closes #227