### PR TITLE
CP-29129: remove obsolete section on ArgoCD

### DIFF
--- a/helm/docs/upgrades.md
+++ b/helm/docs/upgrades.md
@@ -23,25 +23,6 @@ Both the **`backfill`** and **`init-cert`** Jobs expire after a configurable per
 
 ---
 
-## **ArgoCD Integration**
-
-If installing this Helm chart using ArgoCD, set the following annotations in the `initBackfillJob` and `initCertJob` fields to ensure that ArgoCD does not constantly consider the Application out of sync:
-
-```yaml
-initBackfillJob:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
-initCertJob:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
-```
-
-See the ArgoCD [Hook Deletion](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies) documentation for further details.
-
----
-
 ## **Common Issues & Troubleshooting**
 
 ### **Issue: Forced Upgrade (`--force`) Fails Due to Running `backfill` Job**


### PR DESCRIPTION
These annotations were necessary in days of yore, when we had a `ttlSecondsAfterFinished` on the jobs. However, we removed that a while back in favor of just giving each job a unique name derived from a hash of the configuration version. With that change, the jobs are run whenever the configuration is updated without relying on the cluster to delete the old jobs.