### PR TITLE
CP-29130: logging improvements in collector

### DIFF
--- a/app/http/middleware/middleware.go
+++ b/app/http/middleware/middleware.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -59,13 +60,19 @@ func LoggingMiddlewareWrapper(next http.Handler) http.Handler {
 		route := r.URL.Path
 		method := r.Method
 
+		level := zerolog.DebugLevel
+		if route == "/healthz" || route == "/metrics" {
+			level = zerolog.TraceLevel
+		}
+
 		// Log the request details
-		log.Ctx(r.Context()).Debug().
+		log.Ctx(r.Context()).WithLevel(level).
 			Str("method", method).
 			Str("route", route).
 			Int("statusCode", statusCode).
 			Str("status", http.StatusText(statusCode)).
 			Dur("duration", duration).
+			Str("client", r.RemoteAddr).
 			Msg("HTTP request")
 	})
 }


### PR DESCRIPTION
## What and Why?

This fixes a few papercuts in the logging code in the collector. Namely:

1. No longer log HTTP requests to /healthz and /metrics at debug level; only log them at trace.
2. Include the address of the client in the logs. This is especially useful for daemonset mode to make sure the cAdvisor metrics are coming from each node.
3. Include the count of which metrics we're receiving each time we receive new metrics. This is only computed if the log level is set to debug or trace, so it shouldn't have any performance impact in the standard deployment.

## How Tested

`make package-debug`, deploy it to a cluster. Then do something like `kubectl -n cza logs -f pod/cz-agent-aggregator-68d48f8559-tdvgq | jq .`, sit back and enjoy your new, more useful logs :)
