### PR TITLE
CP-29142: complete Helm schema validation.

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -112,6 +112,8 @@ jobs:
         run: make install-tools
       - name: Generate code
         run: make generate
+      - name: Format code
+        run: make format
       - name: Check file format
         run: git diff --exit-code --color
 

--- a/helm/schema/k8s.json
+++ b/helm/schema/k8s.json
@@ -1,88 +1,5 @@
 {
-  "$defs": {
-    "com.cloudzero.agent.dns": {
-      "additionalProperties": false,
-      "description": "Specifies DNS configurations, both the dnsPolicy and dnsConfig.\nFor documentation, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config\n",
-      "properties": {
-        "config": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodDNSConfig",
-          "description": "DNS configuration to use.\nFor documentation, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config\n"
-        },
-        "policy": {
-          "description": "DNS policy to use.\nFor documentation, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy\n",
-          "oneOf": [
-            {
-              "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec/properties/dnsPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "com.cloudzero.agent.duration": {
-      "description": "A time duration in Go's time.ParseDuration format. Valid formats include:\n\"300ms\", \"1.5h\", \"2h45m\", etc. Valid time units are: \"ns\", \"us\" (or \"µs\"),\n\"ms\", \"s\", \"m\", \"h\"\n",
-      "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))*$",
-      "type": "string"
-    },
-    "com.cloudzero.agent.image": {
-      "additionalProperties": false,
-      "description": "A container image type similar to the Kubernetes image type, but with\nadditional support for pullSecrets. This type is used to specify container\nimages across the chart.\n",
-      "properties": {
-        "digest": {
-          "additionalProperties": false,
-          "description": "The digest of the container image.\n",
-          "type": ["string", "null"]
-        },
-        "pullPolicy": {
-          "description": "Corresponds to the Kubernetes imagePullPolicy. For documentation, see\nhttps://kubernetes.io/docs/concepts/containers/images/#image-pull-policy\n",
-          "oneOf": [
-            {
-              "$ref": "#/$defs/io.k8s.api.core.v1.Container/properties/imagePullPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "pullSecrets": {
-          "description": "A list of image pull secrets to use.\n",
-          "oneOf": [
-            {
-              "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec/properties/imagePullSecrets"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "registry": {
-          "additionalProperties": false,
-          "description": "The container registry to pull the image from.\n",
-          "type": ["string", "null"]
-        },
-        "repository": {
-          "additionalProperties": false,
-          "description": "The name of the container image repository.\n",
-          "type": ["string", "null"]
-        },
-        "tag": {
-          "additionalProperties": false,
-          "description": "The tag of the container image to use.\n",
-          "type": ["string", "null"]
-        }
-      },
-      "type": "object"
-    },
-    "com.cloudzero.agent.tolerations": {
-      "description": "Used to control pod scheduling with taints\n",
-      "items": {
-        "$ref": "#/$defs/io.k8s.api.core.v1.Toleration"
-      },
-      "type": "array"
-    },
+  "definitions": {
     "io.k8s.api.admissionregistration.v1.AuditAnnotation": {
       "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
       "properties": {
@@ -134,7 +51,7 @@
         "excludeResourceRules": {
           "description": "ExcludeResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy should not care about. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.NamedRuleWithOperations"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.NamedRuleWithOperations"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -144,17 +61,17 @@
           "type": "string"
         },
         "namespaceSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the policy.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the policy on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything."
         },
         "objectSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "ObjectSelector decides whether to run the validation based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the cel validation, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything."
         },
         "resourceRules": {
           "description": "ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches. The policy cares about an operation if it matches _any_ Rule.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.NamedRuleWithOperations"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.NamedRuleWithOperations"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -175,7 +92,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "clientConfig": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.WebhookClientConfig",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.WebhookClientConfig",
           "description": "ClientConfig defines how to communicate with the hook. Required"
         },
         "failurePolicy": {
@@ -185,7 +102,7 @@
         "matchConditions": {
           "description": "MatchConditions is a list of conditions that must be met for a request to be sent to this webhook. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.\n\nThe exact matching logic is (in order):\n  1. If ANY matchCondition evaluates to FALSE, the webhook is skipped.\n  2. If ALL matchConditions evaluate to TRUE, the webhook is called.\n  3. If any matchCondition evaluates to an error (but none are FALSE):\n     - If failurePolicy=Fail, reject the request\n     - If failurePolicy=Ignore, the error is ignored and the webhook is skipped",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.MatchCondition"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.MatchCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -202,11 +119,11 @@
           "type": "string"
         },
         "namespaceSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything."
         },
         "objectSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything."
         },
         "reinvocationPolicy": {
@@ -216,7 +133,7 @@
         "rules": {
           "description": "Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.RuleWithOperations"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.RuleWithOperations"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -248,17 +165,17 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["MutatingWebhookConfiguration"],
-          "type": "string"
+          "type": "string",
+          "enum": ["MutatingWebhookConfiguration"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
         },
         "webhooks": {
           "description": "Webhooks is a list of webhooks and the affected resources and operations.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.MutatingWebhook"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.MutatingWebhook"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -286,17 +203,17 @@
         "items": {
           "description": "List of MutatingWebhookConfiguration.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["MutatingWebhookConfigurationList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["MutatingWebhookConfigurationList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -392,7 +309,7 @@
           "type": "string"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset."
         }
       },
@@ -471,7 +388,7 @@
         "expressionWarnings": {
           "description": "The type checking warnings for each expression.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ExpressionWarning"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ExpressionWarning"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -488,19 +405,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingAdmissionPolicy"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingAdmissionPolicy"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicySpec",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicySpec",
           "description": "Specification of the desired behavior of the ValidatingAdmissionPolicy."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyStatus",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyStatus",
           "description": "The status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy behaves in the expected way. Populated by the system. Read-only."
         }
       },
@@ -522,15 +439,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingAdmissionPolicyBinding"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingAdmissionPolicyBinding"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBindingSpec",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBindingSpec",
           "description": "Specification of the desired behavior of the ValidatingAdmissionPolicyBinding."
         }
       },
@@ -553,17 +470,17 @@
         "items": {
           "description": "List of PolicyBinding.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBinding"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBinding"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingAdmissionPolicyBindingList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingAdmissionPolicyBindingList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -581,11 +498,11 @@
       "description": "ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.",
       "properties": {
         "matchResources": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.MatchResources",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.MatchResources",
           "description": "MatchResources declares what resources match this binding and will be validated by it. Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this. If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching. If a resource is matched by the other fields of this object, it will be validated. Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required."
         },
         "paramRef": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ParamRef",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ParamRef",
           "description": "paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param."
         },
         "policyName": {
@@ -613,17 +530,17 @@
         "items": {
           "description": "List of ValidatingAdmissionPolicy.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicy"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ValidatingAdmissionPolicy"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingAdmissionPolicyList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingAdmissionPolicyList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -643,7 +560,7 @@
         "auditAnnotations": {
           "description": "auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request. validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.AuditAnnotation"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.AuditAnnotation"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -655,7 +572,7 @@
         "matchConditions": {
           "description": "MatchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.\n\nIf a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.\n\nThe exact matching logic is (in order):\n  1. If ANY matchCondition evaluates to FALSE, the policy is skipped.\n  2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.\n  3. If any matchCondition evaluates to an error (but none are FALSE):\n     - If failurePolicy=Fail, reject the request\n     - If failurePolicy=Ignore, the policy is skipped",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.MatchCondition"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.MatchCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -664,17 +581,17 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "matchConstraints": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.MatchResources",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.MatchResources",
           "description": "MatchConstraints specifies what resources this policy is designed to validate. The AdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding. Required."
         },
         "paramKind": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ParamKind",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ParamKind",
           "description": "ParamKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null."
         },
         "validations": {
           "description": "Validations contain CEL expressions which is used to apply the validation. Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.Validation"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.Validation"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -682,7 +599,7 @@
         "variables": {
           "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.\n\nThe expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, Variables must be sorted by the order of first appearance and acyclic.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.Variable"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.Variable"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -699,7 +616,7 @@
         "conditions": {
           "description": "The conditions represent the latest available observations of a policy's current state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -711,7 +628,7 @@
           "type": "integer"
         },
         "typeChecking": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.TypeChecking",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.TypeChecking",
           "description": "The results of type checking for each expression. Presence of this field indicates the completion of the type checking."
         }
       },
@@ -729,7 +646,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "clientConfig": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.WebhookClientConfig",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.WebhookClientConfig",
           "description": "ClientConfig defines how to communicate with the hook. Required"
         },
         "failurePolicy": {
@@ -739,7 +656,7 @@
         "matchConditions": {
           "description": "MatchConditions is a list of conditions that must be met for a request to be sent to this webhook. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.\n\nThe exact matching logic is (in order):\n  1. If ANY matchCondition evaluates to FALSE, the webhook is skipped.\n  2. If ALL matchConditions evaluate to TRUE, the webhook is called.\n  3. If any matchCondition evaluates to an error (but none are FALSE):\n     - If failurePolicy=Fail, reject the request\n     - If failurePolicy=Ignore, the error is ignored and the webhook is skipped",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.MatchCondition"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.MatchCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -756,17 +673,17 @@
           "type": "string"
         },
         "namespaceSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the webhook on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything."
         },
         "objectSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything."
         },
         "rules": {
           "description": "Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.RuleWithOperations"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.RuleWithOperations"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -798,17 +715,17 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingWebhookConfiguration"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingWebhookConfiguration"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
         },
         "webhooks": {
           "description": "Webhooks is a list of webhooks and the affected resources and operations.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ValidatingWebhook"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ValidatingWebhook"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -836,17 +753,17 @@
         "items": {
           "description": "List of ValidatingWebhookConfiguration.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingWebhookConfigurationList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingWebhookConfigurationList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -908,7 +825,7 @@
           "type": "string"
         },
         "service": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ServiceReference",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1.ServiceReference",
           "description": "`service` is a reference to the service for this webhook. Either `service` or `url` must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`."
         },
         "url": {
@@ -958,7 +875,7 @@
         "excludeResourceRules": {
           "description": "ExcludeResourceRules describes what operations on what resources/subresources the policy should not care about. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.NamedRuleWithOperations"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.NamedRuleWithOperations"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -968,17 +885,17 @@
           "type": "string"
         },
         "namespaceSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the policy.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the policy on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything."
         },
         "objectSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "ObjectSelector decides whether to run the policy based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the policy's expression (CEL), and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything."
         },
         "resourceRules": {
           "description": "ResourceRules describes what operations on what resources/subresources the admission policy matches. The policy cares about an operation if it matches _any_ Rule.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.NamedRuleWithOperations"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.NamedRuleWithOperations"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -996,15 +913,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["MutatingAdmissionPolicy"],
-          "type": "string"
+          "type": "string",
+          "enum": ["MutatingAdmissionPolicy"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicySpec",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicySpec",
           "description": "Specification of the desired behavior of the MutatingAdmissionPolicy."
         }
       },
@@ -1026,15 +943,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["MutatingAdmissionPolicyBinding"],
-          "type": "string"
+          "type": "string",
+          "enum": ["MutatingAdmissionPolicyBinding"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicyBindingSpec",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicyBindingSpec",
           "description": "Specification of the desired behavior of the MutatingAdmissionPolicyBinding."
         }
       },
@@ -1057,17 +974,17 @@
         "items": {
           "description": "List of PolicyBinding.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicyBinding"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicyBinding"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["MutatingAdmissionPolicyBindingList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["MutatingAdmissionPolicyBindingList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -1085,11 +1002,11 @@
       "description": "MutatingAdmissionPolicyBindingSpec is the specification of the MutatingAdmissionPolicyBinding.",
       "properties": {
         "matchResources": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.MatchResources",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.MatchResources",
           "description": "matchResources limits what resources match this binding and may be mutated by it. Note that if matchResources matches a resource, the resource must also match a policy's matchConstraints and matchConditions before the resource may be mutated. When matchResources is unset, it does not constrain resource matching, and only the policy's matchConstraints and matchConditions must match for the resource to be mutated. Additionally, matchResources.resourceRules are optional and do not constraint matching when unset. Note that this is differs from MutatingAdmissionPolicy matchConstraints, where resourceRules are required. The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched. '*' matches CREATE, UPDATE and CONNECT."
         },
         "paramRef": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.ParamRef",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.ParamRef",
           "description": "paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in spec.ParamKind of the bound MutatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the MutatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param."
         },
         "policyName": {
@@ -1109,17 +1026,17 @@
         "items": {
           "description": "List of ValidatingAdmissionPolicy.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicy"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.MutatingAdmissionPolicy"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["MutatingAdmissionPolicyList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["MutatingAdmissionPolicyList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -1143,7 +1060,7 @@
         "matchConditions": {
           "description": "matchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the matchConstraints. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.\n\nIf a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.\n\nThe exact matching logic is (in order):\n  1. If ANY matchCondition evaluates to FALSE, the policy is skipped.\n  2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.\n  3. If any matchCondition evaluates to an error (but none are FALSE):\n     - If failurePolicy=Fail, reject the request\n     - If failurePolicy=Ignore, the policy is skipped",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.MatchCondition"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.MatchCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -1152,19 +1069,19 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "matchConstraints": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.MatchResources",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.MatchResources",
           "description": "matchConstraints specifies what resources this policy is designed to validate. The MutatingAdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API MutatingAdmissionPolicy cannot match MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding. The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched. '*' matches CREATE, UPDATE and CONNECT. Required."
         },
         "mutations": {
           "description": "mutations contain operations to perform on matching objects. mutations may not be empty; a minimum of one mutation is required. mutations are evaluated in order, and are reinvoked according to the reinvocationPolicy. The mutations of a policy are invoked for each binding of this policy and reinvocation of mutations occurs on a per binding basis.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.Mutation"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.Mutation"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "paramKind": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.ParamKind",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.ParamKind",
           "description": "paramKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If paramKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in MutatingAdmissionPolicyBinding, the params variable will be null."
         },
         "reinvocationPolicy": {
@@ -1174,7 +1091,7 @@
         "variables": {
           "description": "variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except matchConditions because matchConditions are evaluated before the rest of the policy.\n\nThe expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, variables must be sorted by the order of first appearance and acyclic.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.Variable"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.Variable"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -1186,11 +1103,11 @@
       "description": "Mutation specifies the CEL expression which is used to apply the Mutation.",
       "properties": {
         "applyConfiguration": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.ApplyConfiguration",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.ApplyConfiguration",
           "description": "applyConfiguration defines the desired configuration values of an object. The configuration is applied to the admission object using [structured merge diff](https://github.com/kubernetes-sigs/structured-merge-diff). A CEL expression is used to create apply configuration."
         },
         "jsonPatch": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1alpha1.JSONPatch",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1alpha1.JSONPatch",
           "description": "jsonPatch defines a [JSON patch](https://jsonpatch.com/) operation to perform a mutation to the object. A CEL expression is used to create the JSON patch."
         },
         "patchType": {
@@ -1283,7 +1200,7 @@
           "type": "string"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset."
         }
       },
@@ -1356,7 +1273,7 @@
         "excludeResourceRules": {
           "description": "ExcludeResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy should not care about. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.NamedRuleWithOperations"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.NamedRuleWithOperations"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -1366,17 +1283,17 @@
           "type": "string"
         },
         "namespaceSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the policy.\n\nFor example, to run the webhook on any objects whose namespace is not associated with \"runlevel\" of \"0\" or \"1\";  you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"runlevel\",\n      \"operator\": \"NotIn\",\n      \"values\": [\n        \"0\",\n        \"1\"\n      ]\n    }\n  ]\n}\n\nIf instead you want to only run the policy on any objects whose namespace is associated with the \"environment\" of \"prod\" or \"staging\"; you will set the selector as follows: \"namespaceSelector\": {\n  \"matchExpressions\": [\n    {\n      \"key\": \"environment\",\n      \"operator\": \"In\",\n      \"values\": [\n        \"prod\",\n        \"staging\"\n      ]\n    }\n  ]\n}\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.\n\nDefault to the empty LabelSelector, which matches everything."
         },
         "objectSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "ObjectSelector decides whether to run the validation based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the cel validation, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything."
         },
         "resourceRules": {
           "description": "ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches. The policy cares about an operation if it matches _any_ Rule.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.NamedRuleWithOperations"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.NamedRuleWithOperations"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -1467,7 +1384,7 @@
           "type": "string"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset."
         }
       },
@@ -1480,7 +1397,7 @@
         "expressionWarnings": {
           "description": "The type checking warnings for each expression.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.ExpressionWarning"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ExpressionWarning"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -1497,19 +1414,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingAdmissionPolicy"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingAdmissionPolicy"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicySpec",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicySpec",
           "description": "Specification of the desired behavior of the ValidatingAdmissionPolicy."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyStatus",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyStatus",
           "description": "The status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy behaves in the expected way. Populated by the system. Read-only."
         }
       },
@@ -1531,15 +1448,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingAdmissionPolicyBinding"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingAdmissionPolicyBinding"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBindingSpec",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBindingSpec",
           "description": "Specification of the desired behavior of the ValidatingAdmissionPolicyBinding."
         }
       },
@@ -1562,17 +1479,17 @@
         "items": {
           "description": "List of PolicyBinding.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBinding"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBinding"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingAdmissionPolicyBindingList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingAdmissionPolicyBindingList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -1590,11 +1507,11 @@
       "description": "ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.",
       "properties": {
         "matchResources": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.MatchResources",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MatchResources",
           "description": "MatchResources declares what resources match this binding and will be validated by it. Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this. If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching. If a resource is matched by the other fields of this object, it will be validated. Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required."
         },
         "paramRef": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.ParamRef",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ParamRef",
           "description": "paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param."
         },
         "policyName": {
@@ -1622,17 +1539,17 @@
         "items": {
           "description": "List of ValidatingAdmissionPolicy.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicy"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicy"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ValidatingAdmissionPolicyList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ValidatingAdmissionPolicyList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -1652,7 +1569,7 @@
         "auditAnnotations": {
           "description": "auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request. validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.AuditAnnotation"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.AuditAnnotation"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -1664,7 +1581,7 @@
         "matchConditions": {
           "description": "MatchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.\n\nIf a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.\n\nThe exact matching logic is (in order):\n  1. If ANY matchCondition evaluates to FALSE, the policy is skipped.\n  2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.\n  3. If any matchCondition evaluates to an error (but none are FALSE):\n     - If failurePolicy=Fail, reject the request\n     - If failurePolicy=Ignore, the policy is skipped",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.MatchCondition"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MatchCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -1673,17 +1590,17 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "matchConstraints": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.MatchResources",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MatchResources",
           "description": "MatchConstraints specifies what resources this policy is designed to validate. The AdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding. Required."
         },
         "paramKind": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.ParamKind",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ParamKind",
           "description": "ParamKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null."
         },
         "validations": {
           "description": "Validations contain CEL expressions which is used to apply the validation. Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.Validation"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.Validation"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -1691,7 +1608,7 @@
         "variables": {
           "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.\n\nThe expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, Variables must be sorted by the order of first appearance and acyclic.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.Variable"
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.Variable"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -1708,7 +1625,7 @@
         "conditions": {
           "description": "The conditions represent the latest available observations of a policy's current state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -1720,7 +1637,7 @@
           "type": "integer"
         },
         "typeChecking": {
-          "$ref": "#/$defs/io.k8s.api.admissionregistration.v1beta1.TypeChecking",
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.TypeChecking",
           "description": "The results of type checking for each expression. Presence of this field indicates the completion of the type checking."
         }
       },
@@ -1804,19 +1721,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["StorageVersion"],
-          "type": "string"
+          "type": "string",
+          "enum": ["StorageVersion"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "The name is <group>.<resource>."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.apiserverinternal.v1alpha1.StorageVersionSpec",
+          "$ref": "#/definitions/io.k8s.api.apiserverinternal.v1alpha1.StorageVersionSpec",
           "description": "Spec is an empty spec. It is here to comply with Kubernetes API style."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.apiserverinternal.v1alpha1.StorageVersionStatus",
+          "$ref": "#/definitions/io.k8s.api.apiserverinternal.v1alpha1.StorageVersionStatus",
           "description": "API server instances report the version they can decode and the version they encode objects to when persisting objects in the backend."
         }
       },
@@ -1834,7 +1751,7 @@
       "description": "Describes the state of the storageVersion at a certain point.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition transitioned from one status to another."
         },
         "message": {
@@ -1872,17 +1789,17 @@
         "items": {
           "description": "Items holds a list of StorageVersion",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apiserverinternal.v1alpha1.StorageVersion"
+            "$ref": "#/definitions/io.k8s.api.apiserverinternal.v1alpha1.StorageVersion"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["StorageVersionList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["StorageVersionList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -1910,7 +1827,7 @@
         "conditions": {
           "description": "The latest available observations of the storageVersion's state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apiserverinternal.v1alpha1.StorageVersionCondition"
+            "$ref": "#/definitions/io.k8s.api.apiserverinternal.v1alpha1.StorageVersionCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -1919,7 +1836,7 @@
         "storageVersions": {
           "description": "The reported versions per API server instance.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apiserverinternal.v1alpha1.ServerStorageVersion"
+            "$ref": "#/definitions/io.k8s.api.apiserverinternal.v1alpha1.ServerStorageVersion"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["apiServerID"],
@@ -1936,16 +1853,16 @@
           "type": "string"
         },
         "data": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
           "description": "Data is the serialized representation of the state."
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ControllerRevision"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ControllerRevision"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "revision": {
@@ -1974,17 +1891,17 @@
         "items": {
           "description": "Items is the list of ControllerRevisions",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apps.v1.ControllerRevision"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.ControllerRevision"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ControllerRevisionList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ControllerRevisionList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -2007,19 +1924,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DaemonSet"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DaemonSet"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.DaemonSetSpec",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSetSpec",
           "description": "The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.DaemonSetStatus",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSetStatus",
           "description": "The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -2036,7 +1953,7 @@
       "description": "DaemonSetCondition describes the state of a DaemonSet at a certain point.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition transitioned from one status to another."
         },
         "message": {
@@ -2069,17 +1986,17 @@
         "items": {
           "description": "A list of daemon sets.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apps.v1.DaemonSet"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSet"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DaemonSetList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DaemonSetList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -2107,15 +2024,15 @@
           "type": "integer"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
         },
         "template": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
           "description": "An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). The only allowed template.spec.restartPolicy value is \"Always\". More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
         },
         "updateStrategy": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.DaemonSetUpdateStrategy",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSetUpdateStrategy",
           "description": "An update strategy to replace existing DaemonSet pods with new pods."
         }
       },
@@ -2133,7 +2050,7 @@
         "conditions": {
           "description": "Represents the latest available observations of a DaemonSet's current state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apps.v1.DaemonSetCondition"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.DaemonSetCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -2194,7 +2111,7 @@
       "description": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
       "properties": {
         "rollingUpdate": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.RollingUpdateDaemonSet",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.RollingUpdateDaemonSet",
           "description": "Rolling update config params. Present only if type = \"RollingUpdate\"."
         },
         "type": {
@@ -2213,19 +2130,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Deployment"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Deployment"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.DeploymentSpec",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentSpec",
           "description": "Specification of the desired behavior of the Deployment."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.DeploymentStatus",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStatus",
           "description": "Most recently observed status of the Deployment."
         }
       },
@@ -2242,11 +2159,11 @@
       "description": "DeploymentCondition describes the state of a deployment at a certain point.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition transitioned from one status to another."
         },
         "lastUpdateTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "The last time this condition was updated."
         },
         "message": {
@@ -2279,17 +2196,17 @@
         "items": {
           "description": "Items is the list of Deployments.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apps.v1.Deployment"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.Deployment"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeploymentList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeploymentList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata."
         }
       },
@@ -2331,16 +2248,16 @@
           "type": "integer"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels."
         },
         "strategy": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.DeploymentStrategy",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
           "description": "The deployment strategy to use to replace existing pods with new ones.",
           "x-kubernetes-patch-strategy": "retainKeys"
         },
         "template": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
           "description": "Template describes the pods that will be created. The only allowed template.spec.restartPolicy value is \"Always\"."
         }
       },
@@ -2363,7 +2280,7 @@
         "conditions": {
           "description": "Represents the latest available observations of a deployment's current state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apps.v1.DeploymentCondition"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -2408,7 +2325,7 @@
       "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
       "properties": {
         "rollingUpdate": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.RollingUpdateDeployment",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.RollingUpdateDeployment",
           "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
         },
         "type": {
@@ -2427,19 +2344,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ReplicaSet"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ReplicaSet"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.ReplicaSetSpec",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.ReplicaSetSpec",
           "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.ReplicaSetStatus",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.ReplicaSetStatus",
           "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -2456,7 +2373,7 @@
       "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "The last time the condition transitioned from one status to another."
         },
         "message": {
@@ -2489,17 +2406,17 @@
         "items": {
           "description": "List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apps.v1.ReplicaSet"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.ReplicaSet"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ReplicaSetList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ReplicaSetList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -2527,11 +2444,11 @@
           "type": "integer"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
         },
         "template": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
           "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#pod-template"
         }
       },
@@ -2549,7 +2466,7 @@
         "conditions": {
           "description": "Represents the latest available observations of a replica set's current state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apps.v1.ReplicaSetCondition"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.ReplicaSetCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -2590,11 +2507,11 @@
       "description": "Spec to control the desired behavior of daemon set rolling update.",
       "properties": {
         "maxSurge": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediately created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption."
         },
         "maxUnavailable": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update."
         }
       },
@@ -2604,11 +2521,11 @@
       "description": "Spec to control the desired behavior of rolling update.",
       "properties": {
         "maxSurge": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods."
         },
         "maxUnavailable": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
         }
       },
@@ -2618,7 +2535,7 @@
       "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
       "properties": {
         "maxUnavailable": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. This can not be 0. Defaults to 1. This field is alpha-level and is only honored by servers that enable the MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it will be counted towards MaxUnavailable."
         },
         "partition": {
@@ -2638,19 +2555,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["StatefulSet"],
-          "type": "string"
+          "type": "string",
+          "enum": ["StatefulSet"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.StatefulSetSpec",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetSpec",
           "description": "Spec defines the desired identities of pods in this set."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.StatefulSetStatus",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetStatus",
           "description": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time."
         }
       },
@@ -2667,7 +2584,7 @@
       "description": "StatefulSetCondition describes the state of a statefulset at a certain point.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition transitioned from one status to another."
         },
         "message": {
@@ -2700,17 +2617,17 @@
         "items": {
           "description": "Items is the list of stateful sets.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apps.v1.StatefulSet"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSet"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["StatefulSetList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["StatefulSetList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -2758,11 +2675,11 @@
           "type": "integer"
         },
         "ordinals": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.StatefulSetOrdinals",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetOrdinals",
           "description": "ordinals controls the numbering of replica indices in a StatefulSet. The default ordinals behavior assigns a \"0\" index to the first replica and increments the index by one for each additional replica requested."
         },
         "persistentVolumeClaimRetentionPolicy": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetPersistentVolumeClaimRetentionPolicy",
           "description": "persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down."
         },
         "podManagementPolicy": {
@@ -2780,7 +2697,7 @@
           "type": "integer"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
         },
         "serviceName": {
@@ -2788,17 +2705,17 @@
           "type": "string"
         },
         "template": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
           "description": "template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet. Each pod will be named with the format <statefulsetname>-<podindex>. For example, a pod in a StatefulSet named \"web\" with index number \"3\" would be named \"web-3\". The only allowed template.spec.restartPolicy value is \"Always\"."
         },
         "updateStrategy": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.StatefulSetUpdateStrategy",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetUpdateStrategy",
           "description": "updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template."
         },
         "volumeClaimTemplates": {
           "description": "volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaim"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -2823,7 +2740,7 @@
         "conditions": {
           "description": "Represents the latest available observations of a statefulset's current state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.apps.v1.StatefulSetCondition"
+            "$ref": "#/definitions/io.k8s.api.apps.v1.StatefulSetCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -2872,7 +2789,7 @@
       "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
       "properties": {
         "rollingUpdate": {
-          "$ref": "#/$defs/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy",
+          "$ref": "#/definitions/io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy",
           "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType."
         },
         "type": {
@@ -2913,15 +2830,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["SelfSubjectReview"],
-          "type": "string"
+          "type": "string",
+          "enum": ["SelfSubjectReview"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.authentication.v1.SelfSubjectReviewStatus",
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.SelfSubjectReviewStatus",
           "description": "Status is filled in by the server with the user attributes."
         }
       },
@@ -2938,7 +2855,7 @@
       "description": "SelfSubjectReviewStatus is filled by the kube-apiserver and sent back to a user.",
       "properties": {
         "userInfo": {
-          "$ref": "#/$defs/io.k8s.api.authentication.v1.UserInfo",
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.UserInfo",
           "description": "User attributes of the user making this request."
         }
       },
@@ -2953,19 +2870,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["TokenRequest"],
-          "type": "string"
+          "type": "string",
+          "enum": ["TokenRequest"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.authentication.v1.TokenRequestSpec",
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.TokenRequestSpec",
           "description": "Spec holds information about the request being evaluated"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.authentication.v1.TokenRequestStatus",
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.TokenRequestStatus",
           "description": "Status is filled in by the server and indicates whether the token can be authenticated."
         }
       },
@@ -2991,7 +2908,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "boundObjectRef": {
-          "$ref": "#/$defs/io.k8s.api.authentication.v1.BoundObjectReference",
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.BoundObjectReference",
           "description": "BoundObjectRef is a reference to an object that the token will be bound to. The token will only be valid for as long as the bound object exists. NOTE: The API server's TokenReview endpoint will validate the BoundObjectRef, but other audiences may not. Keep ExpirationSeconds small if you want prompt revocation."
         },
         "expirationSeconds": {
@@ -3007,7 +2924,7 @@
       "description": "TokenRequestStatus is the result of a token request.",
       "properties": {
         "expirationTimestamp": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "ExpirationTimestamp is the time of expiration of the returned token."
         },
         "token": {
@@ -3027,19 +2944,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["TokenReview"],
-          "type": "string"
+          "type": "string",
+          "enum": ["TokenReview"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.authentication.v1.TokenReviewSpec",
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.TokenReviewSpec",
           "description": "Spec holds information about the request being evaluated"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.authentication.v1.TokenReviewStatus",
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.TokenReviewStatus",
           "description": "Status is filled in by the server and indicates whether the request can be authenticated."
         }
       },
@@ -3091,7 +3008,7 @@
           "type": "string"
         },
         "user": {
-          "$ref": "#/$defs/io.k8s.api.authentication.v1.UserInfo",
+          "$ref": "#/definitions/io.k8s.api.authentication.v1.UserInfo",
           "description": "User is the UserInfo associated with the provided token."
         }
       },
@@ -3139,7 +3056,7 @@
         "requirements": {
           "description": "requirements is the parsed interpretation of a field selector. All requirements must be met for a resource instance to match the selector. Webhook implementations should handle requirements, but how to handle them is up to the webhook. Since requirements can only limit the request, it is safe to authorize as unlimited request if the requirements are not understood.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.FieldSelectorRequirement"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldSelectorRequirement"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -3157,7 +3074,7 @@
         "requirements": {
           "description": "requirements is the parsed interpretation of a label selector. All requirements must be met for a resource instance to match the selector. Webhook implementations should handle requirements, but how to handle them is up to the webhook. Since requirements can only limit the request, it is safe to authorize as unlimited request if the requirements are not understood.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -3174,19 +3091,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["LocalSubjectAccessReview"],
-          "type": "string"
+          "type": "string",
+          "enum": ["LocalSubjectAccessReview"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.SubjectAccessReviewSpec",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec",
           "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
           "description": "Status is filled in by the server and indicates whether the request is allowed or not"
         }
       },
@@ -3241,7 +3158,7 @@
       "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
       "properties": {
         "fieldSelector": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.FieldSelectorAttributes",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.FieldSelectorAttributes",
           "description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default)."
         },
         "group": {
@@ -3249,7 +3166,7 @@
           "type": "string"
         },
         "labelSelector": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.LabelSelectorAttributes",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.LabelSelectorAttributes",
           "description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default)."
         },
         "name": {
@@ -3327,19 +3244,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["SelfSubjectAccessReview"],
-          "type": "string"
+          "type": "string",
+          "enum": ["SelfSubjectAccessReview"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec",
           "description": "Spec holds information about the request being evaluated.  user and groups must be empty"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
           "description": "Status is filled in by the server and indicates whether the request is allowed or not"
         }
       },
@@ -3357,11 +3274,11 @@
       "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
       "properties": {
         "nonResourceAttributes": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.NonResourceAttributes",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes",
           "description": "NonResourceAttributes describes information for a non-resource access request"
         },
         "resourceAttributes": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.ResourceAttributes",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes",
           "description": "ResourceAuthorizationAttributes describes information for a resource access request"
         }
       },
@@ -3376,19 +3293,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["SelfSubjectRulesReview"],
-          "type": "string"
+          "type": "string",
+          "enum": ["SelfSubjectRulesReview"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec",
           "description": "Spec holds information about the request being evaluated."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.SubjectRulesReviewStatus",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectRulesReviewStatus",
           "description": "Status is filled in by the server and indicates the set of actions a user can perform."
         }
       },
@@ -3421,19 +3338,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["SubjectAccessReview"],
-          "type": "string"
+          "type": "string",
+          "enum": ["SubjectAccessReview"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.SubjectAccessReviewSpec",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewSpec",
           "description": "Spec holds information about the request being evaluated"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.SubjectAccessReviewStatus",
           "description": "Status is filled in by the server and indicates whether the request is allowed or not"
         }
       },
@@ -3469,11 +3386,11 @@
           "x-kubernetes-list-type": "atomic"
         },
         "nonResourceAttributes": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.NonResourceAttributes",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceAttributes",
           "description": "NonResourceAttributes describes information for a non-resource access request"
         },
         "resourceAttributes": {
-          "$ref": "#/$defs/io.k8s.api.authorization.v1.ResourceAttributes",
+          "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceAttributes",
           "description": "ResourceAuthorizationAttributes describes information for a resource access request"
         },
         "uid": {
@@ -3524,7 +3441,7 @@
         "nonResourceRules": {
           "description": "NonResourceRules is the list of actions the subject is allowed to perform on non-resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.authorization.v1.NonResourceRule"
+            "$ref": "#/definitions/io.k8s.api.authorization.v1.NonResourceRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -3532,7 +3449,7 @@
         "resourceRules": {
           "description": "ResourceRules is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.authorization.v1.ResourceRule"
+            "$ref": "#/definitions/io.k8s.api.authorization.v1.ResourceRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -3570,19 +3487,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["HorizontalPodAutoscaler"],
-          "type": "string"
+          "type": "string",
+          "enum": ["HorizontalPodAutoscaler"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec",
           "description": "spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus",
           "description": "status is the current information about the autoscaler."
         }
       },
@@ -3605,17 +3522,17 @@
         "items": {
           "description": "items is the list of horizontal pod autoscaler objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler"
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["HorizontalPodAutoscalerList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["HorizontalPodAutoscalerList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata."
         }
       },
@@ -3643,7 +3560,7 @@
           "type": "integer"
         },
         "scaleTargetRef": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v1.CrossVersionObjectReference",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.CrossVersionObjectReference",
           "description": "reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource."
         },
         "targetCPUUtilizationPercentage": {
@@ -3674,7 +3591,7 @@
           "type": "integer"
         },
         "lastScaleTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed."
         },
         "observedGeneration": {
@@ -3695,19 +3612,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Scale"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Scale"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v1.ScaleSpec",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.ScaleSpec",
           "description": "spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v1.ScaleStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v1.ScaleStatus",
           "description": "status is the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only."
         }
       },
@@ -3759,7 +3676,7 @@
           "type": "string"
         },
         "target": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricTarget",
           "description": "target specifies the target value for the given metric"
         }
       },
@@ -3774,7 +3691,7 @@
           "type": "string"
         },
         "current": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricValueStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricValueStatus",
           "description": "current contains the current value for the given metric"
         },
         "name": {
@@ -3808,11 +3725,11 @@
       "description": "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
       "properties": {
         "metric": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricIdentifier",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricIdentifier",
           "description": "metric identifies the target metric by name and selector"
         },
         "target": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricTarget",
           "description": "target specifies the target value for the given metric"
         }
       },
@@ -3823,11 +3740,11 @@
       "description": "ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.",
       "properties": {
         "current": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricValueStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricValueStatus",
           "description": "current contains the current value for the given metric"
         },
         "metric": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricIdentifier",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricIdentifier",
           "description": "metric identifies the target metric by name and selector"
         }
       },
@@ -3861,7 +3778,7 @@
         "policies": {
           "description": "policies is a list of potential scaling polices which can be used during scaling. If not set, use the default values: - For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window. - For scale down: allow all pods to be removed in a 15s window.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HPAScalingPolicy"
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2.HPAScalingPolicy"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -3876,7 +3793,7 @@
           "type": "integer"
         },
         "tolerance": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "tolerance is the tolerance on the ratio between the current and desired metric value under which no updates are made to the desired number of replicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not set, the default cluster-wide tolerance is applied (by default 10%).\n\nFor example, if autoscaling is configured with a memory consumption target of 100Mi, and scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be triggered when the actual consumption falls below 95Mi or exceeds 101Mi.\n\nThis is an alpha field and requires enabling the HPAConfigurableTolerance feature gate."
         }
       },
@@ -3891,19 +3808,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["HorizontalPodAutoscaler"],
-          "type": "string"
+          "type": "string",
+          "enum": ["HorizontalPodAutoscaler"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec",
           "description": "spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus",
           "description": "status is the current information about the autoscaler."
         }
       },
@@ -3920,11 +3837,11 @@
       "description": "HorizontalPodAutoscalerBehavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively).",
       "properties": {
         "scaleDown": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HPAScalingRules",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.HPAScalingRules",
           "description": "scaleDown is scaling policy for scaling Down. If not set, the default value is to allow to scale down to minReplicas pods, with a 300 second stabilization window (i.e., the highest recommendation for the last 300sec is used)."
         },
         "scaleUp": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HPAScalingRules",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.HPAScalingRules",
           "description": "scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of:\n  * increase no more than 4 pods per 60 seconds\n  * double the number of pods per 60 seconds\nNo stabilization is used."
         }
       },
@@ -3934,7 +3851,7 @@
       "description": "HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastTransitionTime is the last time the condition transitioned from one status to another"
         },
         "message": {
@@ -3967,17 +3884,17 @@
         "items": {
           "description": "items is the list of horizontal pod autoscaler objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler"
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["HorizontalPodAutoscalerList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["HorizontalPodAutoscalerList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "metadata is the standard list metadata."
         }
       },
@@ -3995,7 +3912,7 @@
       "description": "HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.",
       "properties": {
         "behavior": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior",
           "description": "behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used."
         },
         "maxReplicas": {
@@ -4006,7 +3923,7 @@
         "metrics": {
           "description": "metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricSpec"
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricSpec"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -4017,7 +3934,7 @@
           "type": "integer"
         },
         "scaleTargetRef": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.CrossVersionObjectReference",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.CrossVersionObjectReference",
           "description": "scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count."
         }
       },
@@ -4030,7 +3947,7 @@
         "conditions": {
           "description": "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition"
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -4041,7 +3958,7 @@
         "currentMetrics": {
           "description": "currentMetrics is the last read state of the metrics used by this autoscaler.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricStatus"
+            "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricStatus"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -4057,7 +3974,7 @@
           "type": "integer"
         },
         "lastScaleTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed."
         },
         "observedGeneration": {
@@ -4077,7 +3994,7 @@
           "type": "string"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics."
         }
       },
@@ -4088,23 +4005,23 @@
       "description": "MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).",
       "properties": {
         "containerResource": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource",
           "description": "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source."
         },
         "external": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ExternalMetricSource",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.ExternalMetricSource",
           "description": "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster)."
         },
         "object": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ObjectMetricSource",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.ObjectMetricSource",
           "description": "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object)."
         },
         "pods": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.PodsMetricSource",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.PodsMetricSource",
           "description": "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value."
         },
         "resource": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ResourceMetricSource",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.ResourceMetricSource",
           "description": "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source."
         },
         "type": {
@@ -4119,23 +4036,23 @@
       "description": "MetricStatus describes the last-read state of a single metric.",
       "properties": {
         "containerResource": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.ContainerResourceMetricStatus",
           "description": "container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source."
         },
         "external": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ExternalMetricStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.ExternalMetricStatus",
           "description": "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster)."
         },
         "object": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ObjectMetricStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.ObjectMetricStatus",
           "description": "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object)."
         },
         "pods": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.PodsMetricStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.PodsMetricStatus",
           "description": "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value."
         },
         "resource": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ResourceMetricStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.ResourceMetricStatus",
           "description": "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source."
         },
         "type": {
@@ -4155,7 +4072,7 @@
           "type": "integer"
         },
         "averageValue": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)"
         },
         "type": {
@@ -4163,7 +4080,7 @@
           "type": "string"
         },
         "value": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "value is the target value of the metric (as a quantity)."
         }
       },
@@ -4179,11 +4096,11 @@
           "type": "integer"
         },
         "averageValue": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "averageValue is the current value of the average of the metric across all relevant pods (as a quantity)"
         },
         "value": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "value is the current value of the metric (as a quantity)."
         }
       },
@@ -4193,15 +4110,15 @@
       "description": "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
       "properties": {
         "describedObject": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.CrossVersionObjectReference",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.CrossVersionObjectReference",
           "description": "describedObject specifies the descriptions of a object,such as kind,name apiVersion"
         },
         "metric": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricIdentifier",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricIdentifier",
           "description": "metric identifies the target metric by name and selector"
         },
         "target": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricTarget",
           "description": "target specifies the target value for the given metric"
         }
       },
@@ -4212,15 +4129,15 @@
       "description": "ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
       "properties": {
         "current": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricValueStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricValueStatus",
           "description": "current contains the current value for the given metric"
         },
         "describedObject": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.CrossVersionObjectReference",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.CrossVersionObjectReference",
           "description": "DescribedObject specifies the descriptions of a object,such as kind,name apiVersion"
         },
         "metric": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricIdentifier",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricIdentifier",
           "description": "metric identifies the target metric by name and selector"
         }
       },
@@ -4231,11 +4148,11 @@
       "description": "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.",
       "properties": {
         "metric": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricIdentifier",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricIdentifier",
           "description": "metric identifies the target metric by name and selector"
         },
         "target": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricTarget",
           "description": "target specifies the target value for the given metric"
         }
       },
@@ -4246,11 +4163,11 @@
       "description": "PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).",
       "properties": {
         "current": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricValueStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricValueStatus",
           "description": "current contains the current value for the given metric"
         },
         "metric": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricIdentifier",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricIdentifier",
           "description": "metric identifies the target metric by name and selector"
         }
       },
@@ -4265,7 +4182,7 @@
           "type": "string"
         },
         "target": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricTarget",
           "description": "target specifies the target value for the given metric"
         }
       },
@@ -4276,7 +4193,7 @@
       "description": "ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
       "properties": {
         "current": {
-          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricValueStatus",
+          "$ref": "#/definitions/io.k8s.api.autoscaling.v2.MetricValueStatus",
           "description": "current contains the current value for the given metric"
         },
         "name": {
@@ -4296,19 +4213,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CronJob"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CronJob"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.CronJobSpec",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.CronJobSpec",
           "description": "Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.CronJobStatus",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.CronJobStatus",
           "description": "Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -4331,17 +4248,17 @@
         "items": {
           "description": "items is the list of CronJobs.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.batch.v1.CronJob"
+            "$ref": "#/definitions/io.k8s.api.batch.v1.CronJob"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CronJobList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CronJobList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -4368,7 +4285,7 @@
           "type": "integer"
         },
         "jobTemplate": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.JobTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.JobTemplateSpec",
           "description": "Specifies the job that will be created when executing a CronJob."
         },
         "schedule": {
@@ -4403,17 +4320,17 @@
         "active": {
           "description": "A list of pointers to currently running jobs.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "lastScheduleTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Information when was the last time the job was successfully scheduled."
         },
         "lastSuccessfulTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Information when was the last time the job successfully completed."
         }
       },
@@ -4428,19 +4345,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Job"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Job"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.JobSpec",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.JobSpec",
           "description": "Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.JobStatus",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.JobStatus",
           "description": "Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -4457,11 +4374,11 @@
       "description": "JobCondition describes current state of a job.",
       "properties": {
         "lastProbeTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition was checked."
         },
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition transit from one status to another."
         },
         "message": {
@@ -4494,17 +4411,17 @@
         "items": {
           "description": "items is the list of Jobs.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.batch.v1.Job"
+            "$ref": "#/definitions/io.k8s.api.batch.v1.Job"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["JobList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["JobList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -4564,7 +4481,7 @@
           "type": "integer"
         },
         "podFailurePolicy": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.PodFailurePolicy",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.PodFailurePolicy",
           "description": "Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure."
         },
         "podReplacementPolicy": {
@@ -4572,11 +4489,11 @@
           "type": "string"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
         },
         "successPolicy": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.SuccessPolicy",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.SuccessPolicy",
           "description": "successPolicy specifies the policy when the Job can be declared as succeeded. If empty, the default behavior applies - the Job is declared as succeeded only when the number of succeeded pods equals to the completions. When the field is specified, it must be immutable and works only for the Indexed Jobs. Once the Job meets the SuccessPolicy, the lingering pods are terminated."
         },
         "suspend": {
@@ -4584,7 +4501,7 @@
           "type": "boolean"
         },
         "template": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
           "description": "Describes the pod that will be created when executing a job. The only allowed template.spec.restartPolicy values are \"Never\" or \"OnFailure\". More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/"
         },
         "ttlSecondsAfterFinished": {
@@ -4609,13 +4526,13 @@
           "type": "string"
         },
         "completionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC. The completion time is set when the job finishes successfully, and only then. The value cannot be updated or removed. The value indicates the same or later point in time as the startTime field."
         },
         "conditions": {
           "description": "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true.\n\nA job is considered finished when it is in a terminal condition, either \"Complete\" or \"Failed\". A Job cannot have both the \"Complete\" and \"Failed\" conditions. Additionally, it cannot be in the \"Complete\" and \"FailureTarget\" conditions. The \"Complete\", \"Failed\" and \"FailureTarget\" conditions cannot be disabled.\n\nMore info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.batch.v1.JobCondition"
+            "$ref": "#/definitions/io.k8s.api.batch.v1.JobCondition"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic",
@@ -4637,7 +4554,7 @@
           "type": "integer"
         },
         "startTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Represents time when the job controller started processing a job. When a Job is created in the suspended state, this field is not set until the first time it is resumed. This field is reset every time a Job is resumed from suspension. It is represented in RFC3339 form and is in UTC.\n\nOnce set, the field can only be removed when the job is suspended. The field cannot be modified while the job is unsuspended or finished."
         },
         "succeeded": {
@@ -4651,7 +4568,7 @@
           "type": "integer"
         },
         "uncountedTerminatedPods": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.UncountedTerminatedPods",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.UncountedTerminatedPods",
           "description": "uncountedTerminatedPods holds the UIDs of Pods that have terminated but the job controller hasn't yet accounted for in the status counters.\n\nThe job controller creates pods with a finalizer. When a pod terminates (succeeded or failed), the controller does three steps to account for it in the job status:\n\n1. Add the pod UID to the arrays in this field. 2. Remove the pod finalizer. 3. Remove the pod UID from the arrays while increasing the corresponding\n    counter.\n\nOld jobs might not be tracked using this field, in which case the field remains null. The structure is empty for finished jobs."
         }
       },
@@ -4661,11 +4578,11 @@
       "description": "JobTemplateSpec describes the data a Job should have when created from a template",
       "properties": {
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.JobSpec",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.JobSpec",
           "description": "Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -4677,7 +4594,7 @@
         "rules": {
           "description": "A list of pod failure policy rules. The rules are evaluated in order. Once a rule matches a Pod failure, the remaining of the rules are ignored. When no rule matches the Pod failure, the default handling applies - the counter of pod failures is incremented and it is checked against the backoffLimit. At most 20 elements are allowed.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.batch.v1.PodFailurePolicyRule"
+            "$ref": "#/definitions/io.k8s.api.batch.v1.PodFailurePolicyRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -4733,13 +4650,13 @@
           "type": "string"
         },
         "onExitCodes": {
-          "$ref": "#/$defs/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement",
+          "$ref": "#/definitions/io.k8s.api.batch.v1.PodFailurePolicyOnExitCodesRequirement",
           "description": "Represents the requirement on the container exit codes."
         },
         "onPodConditions": {
           "description": "Represents the requirement on the pod conditions. The requirement is represented as a list of pod condition patterns. The requirement is satisfied if at least one pattern matches an actual pod condition. At most 20 elements are allowed.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.batch.v1.PodFailurePolicyOnPodConditionsPattern"
+            "$ref": "#/definitions/io.k8s.api.batch.v1.PodFailurePolicyOnPodConditionsPattern"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -4754,7 +4671,7 @@
         "rules": {
           "description": "rules represents the list of alternative rules for the declaring the Jobs as successful before `.status.succeeded >= .spec.completions`. Once any of the rules are met, the \"SuccessCriteriaMet\" condition is added, and the lingering pods are removed. The terminal state for such a Job has the \"Complete\" condition. Additionally, these rules are evaluated in order; Once the Job meets one of the rules, other rules are ignored. At most 20 elements are allowed.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.batch.v1.SuccessPolicyRule"
+            "$ref": "#/definitions/io.k8s.api.batch.v1.SuccessPolicyRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -4809,18 +4726,18 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CertificateSigningRequest"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CertificateSigningRequest"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.certificates.v1.CertificateSigningRequestSpec",
+          "$ref": "#/definitions/io.k8s.api.certificates.v1.CertificateSigningRequestSpec",
           "description": "spec contains the certificate request, and is immutable after creation. Only the request, signerName, expirationSeconds, and usages fields can be set on creation. Other fields are derived by Kubernetes and cannot be modified by users."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.certificates.v1.CertificateSigningRequestStatus",
+          "$ref": "#/definitions/io.k8s.api.certificates.v1.CertificateSigningRequestStatus",
           "description": "status contains information about whether the request is approved or denied, and the certificate issued by the signer, or the failure condition indicating signer failure."
         }
       },
@@ -4838,11 +4755,11 @@
       "description": "CertificateSigningRequestCondition describes a condition of a CertificateSigningRequest object",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastTransitionTime is the time the condition last transitioned from one status to another. If unset, when a new condition type is added or an existing condition's status is changed, the server defaults this to the current time."
         },
         "lastUpdateTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastUpdateTime is the time of the last update to this condition"
         },
         "message": {
@@ -4875,17 +4792,17 @@
         "items": {
           "description": "items is a collection of CertificateSigningRequest objects",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.certificates.v1.CertificateSigningRequest"
+            "$ref": "#/definitions/io.k8s.api.certificates.v1.CertificateSigningRequest"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CertificateSigningRequestList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CertificateSigningRequestList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       },
       "required": ["items"],
@@ -4966,7 +4883,7 @@
         "conditions": {
           "description": "conditions applied to the request. Known conditions are \"Approved\", \"Denied\", and \"Failed\".",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.certificates.v1.CertificateSigningRequestCondition"
+            "$ref": "#/definitions/io.k8s.api.certificates.v1.CertificateSigningRequestCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -4984,15 +4901,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ClusterTrustBundle"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ClusterTrustBundle"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "metadata contains the object metadata."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.certificates.v1alpha1.ClusterTrustBundleSpec",
+          "$ref": "#/definitions/io.k8s.api.certificates.v1alpha1.ClusterTrustBundleSpec",
           "description": "spec contains the signer (if any) and trust anchors."
         }
       },
@@ -5016,17 +4933,17 @@
         "items": {
           "description": "items is a collection of ClusterTrustBundle objects",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.certificates.v1alpha1.ClusterTrustBundle"
+            "$ref": "#/definitions/io.k8s.api.certificates.v1alpha1.ClusterTrustBundle"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ClusterTrustBundleList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ClusterTrustBundleList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "metadata contains the list metadata."
         }
       },
@@ -5064,15 +4981,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ClusterTrustBundle"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ClusterTrustBundle"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "metadata contains the object metadata."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.certificates.v1beta1.ClusterTrustBundleSpec",
+          "$ref": "#/definitions/io.k8s.api.certificates.v1beta1.ClusterTrustBundleSpec",
           "description": "spec contains the signer (if any) and trust anchors."
         }
       },
@@ -5096,17 +5013,17 @@
         "items": {
           "description": "items is a collection of ClusterTrustBundle objects",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.certificates.v1beta1.ClusterTrustBundle"
+            "$ref": "#/definitions/io.k8s.api.certificates.v1beta1.ClusterTrustBundle"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ClusterTrustBundleList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ClusterTrustBundleList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "metadata contains the list metadata."
         }
       },
@@ -5144,15 +5061,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Lease"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Lease"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.coordination.v1.LeaseSpec",
+          "$ref": "#/definitions/io.k8s.api.coordination.v1.LeaseSpec",
           "description": "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -5175,17 +5092,17 @@
         "items": {
           "description": "items is a list of schema objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.coordination.v1.Lease"
+            "$ref": "#/definitions/io.k8s.api.coordination.v1.Lease"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["LeaseList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["LeaseList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -5203,7 +5120,7 @@
       "description": "LeaseSpec is a specification of a Lease.",
       "properties": {
         "acquireTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "acquireTime is a time when the current lease was acquired."
         },
         "holderIdentity": {
@@ -5225,7 +5142,7 @@
           "type": "string"
         },
         "renewTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "renewTime is a time when the current holder of a lease has last updated the lease."
         },
         "strategy": {
@@ -5244,15 +5161,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["LeaseCandidate"],
-          "type": "string"
+          "type": "string",
+          "enum": ["LeaseCandidate"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.coordination.v1alpha2.LeaseCandidateSpec",
+          "$ref": "#/definitions/io.k8s.api.coordination.v1alpha2.LeaseCandidateSpec",
           "description": "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -5275,17 +5192,17 @@
         "items": {
           "description": "items is a list of schema objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.coordination.v1alpha2.LeaseCandidate"
+            "$ref": "#/definitions/io.k8s.api.coordination.v1alpha2.LeaseCandidate"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["LeaseCandidateList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["LeaseCandidateList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -5315,11 +5232,11 @@
           "type": "string"
         },
         "pingTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "PingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime."
         },
         "renewTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "RenewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates."
         },
         "strategy": {
@@ -5339,15 +5256,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["LeaseCandidate"],
-          "type": "string"
+          "type": "string",
+          "enum": ["LeaseCandidate"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.coordination.v1beta1.LeaseCandidateSpec",
+          "$ref": "#/definitions/io.k8s.api.coordination.v1beta1.LeaseCandidateSpec",
           "description": "spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -5370,17 +5287,17 @@
         "items": {
           "description": "items is a list of schema objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.coordination.v1beta1.LeaseCandidate"
+            "$ref": "#/definitions/io.k8s.api.coordination.v1beta1.LeaseCandidate"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["LeaseCandidateList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["LeaseCandidateList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -5410,11 +5327,11 @@
           "type": "string"
         },
         "pingTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "PingTime is the last time that the server has requested the LeaseCandidate to renew. It is only done during leader election to check if any LeaseCandidates have become ineligible. When PingTime is updated, the LeaseCandidate will respond by updating RenewTime."
         },
         "renewTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "RenewTime is the time that the LeaseCandidate was last updated. Any time a Lease needs to do leader election, the PingTime field is updated to signal to the LeaseCandidate that they should update the RenewTime. Old LeaseCandidate objects are also garbage collected if it has been hours since the last renew. The PingTime field is updated regularly to prevent garbage collection for still active LeaseCandidates."
         },
         "strategy": {
@@ -5453,15 +5370,15 @@
       "description": "Affinity is a group of affinity scheduling rules.",
       "properties": {
         "nodeAffinity": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeAffinity",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeAffinity",
           "description": "Describes node affinity scheduling rules for the pod."
         },
         "podAffinity": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodAffinity",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinity",
           "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s))."
         },
         "podAntiAffinity": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodAntiAffinity",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAntiAffinity",
           "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s))."
         }
       },
@@ -5587,15 +5504,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Binding"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Binding"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "target": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
           "description": "The target object that you want to bind to the standard object."
         }
       },
@@ -5613,11 +5530,11 @@
       "description": "Represents storage that is managed by an external CSI volume driver",
       "properties": {
         "controllerExpandSecretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "controllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
         },
         "controllerPublishSecretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "controllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
         },
         "driver": {
@@ -5629,15 +5546,15 @@
           "type": "string"
         },
         "nodeExpandSecretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "nodeExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeExpandVolume call. This field is optional, may be omitted if no secret is required. If the secret object contains more than one secret, all secrets are passed."
         },
         "nodePublishSecretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
         },
         "nodeStageSecretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "nodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed."
         },
         "readOnly": {
@@ -5652,7 +5569,7 @@
           "type": "object"
         },
         "volumeHandle": {
-          "description": "volumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
+          "description": "volumeHandle is the unique volume name returned by the CSI volume plugin\u2019s CreateVolume to refer to the volume on all subsequent calls. Required.",
           "type": "string"
         }
       },
@@ -5671,7 +5588,7 @@
           "type": "string"
         },
         "nodePublishSecretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
           "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
         },
         "readOnly": {
@@ -5735,7 +5652,7 @@
           "type": "string"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
         },
         "user": {
@@ -5770,7 +5687,7 @@
           "type": "string"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
           "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
         },
         "user": {
@@ -5793,7 +5710,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "secretRef is Optional: points to a secret object containing parameters used to connect to OpenStack."
         },
         "volumeID": {
@@ -5816,7 +5733,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
           "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack."
         },
         "volumeID": {
@@ -5842,7 +5759,7 @@
       "description": "ClusterTrustBundleProjection describes how to select a set of ClusterTrustBundle objects and project their contents into the pod filesystem.",
       "properties": {
         "labelSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "Select all ClusterTrustBundles that match this label selector.  Only has effect if signerName is set.  Mutually-exclusive with name.  If unset, interpreted as \"match nothing\".  If set but empty, interpreted as \"match everything\"."
         },
         "name": {
@@ -5898,7 +5815,7 @@
         "conditions": {
           "description": "List of component conditions observed",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ComponentCondition"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ComponentCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -5908,11 +5825,11 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ComponentStatus"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ComponentStatus"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -5935,17 +5852,17 @@
         "items": {
           "description": "List of ComponentStatus objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ComponentStatus"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ComponentStatus"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ComponentStatusList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ComponentStatusList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -5987,11 +5904,11 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ConfigMap"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ConfigMap"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -6048,17 +5965,17 @@
         "items": {
           "description": "Items is the list of ConfigMaps.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ConfigMap"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMap"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ConfigMapList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ConfigMapList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -6105,7 +6022,7 @@
         "items": {
           "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.KeyToPath"
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6132,7 +6049,7 @@
         "items": {
           "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.KeyToPath"
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6170,7 +6087,7 @@
         "env": {
           "description": "List of environment variables to set in the container. Cannot be updated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.EnvVar"
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -6181,7 +6098,7 @@
         "envFrom": {
           "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.EnvFromSource"
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6195,11 +6112,11 @@
           "type": "string"
         },
         "lifecycle": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Lifecycle",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
           "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated."
         },
         "livenessProbe": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Probe",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
           "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
         },
         "name": {
@@ -6209,7 +6126,7 @@
         "ports": {
           "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerPort"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
@@ -6218,19 +6135,19 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "readinessProbe": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Probe",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
           "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
         },
         "resizePolicy": {
           "description": "Resources resize policy for the container.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerResizePolicy"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "resources": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
           "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
         },
         "restartPolicy": {
@@ -6238,11 +6155,11 @@
           "type": "string"
         },
         "securityContext": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecurityContext",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
           "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
         },
         "startupProbe": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Probe",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
           "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
         },
         "stdin": {
@@ -6268,7 +6185,7 @@
         "volumeDevices": {
           "description": "volumeDevices is the list of block devices to be used by the container.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.VolumeDevice"
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["devicePath"],
@@ -6279,7 +6196,7 @@
         "volumeMounts": {
           "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.VolumeMount"
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["mountPath"],
@@ -6362,15 +6279,15 @@
       "description": "ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.",
       "properties": {
         "running": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStateRunning",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateRunning",
           "description": "Details about a running container"
         },
         "terminated": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStateTerminated",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateTerminated",
           "description": "Details about a terminated container"
         },
         "waiting": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStateWaiting",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStateWaiting",
           "description": "Details about a waiting container"
         }
       },
@@ -6380,7 +6297,7 @@
       "description": "ContainerStateRunning is a running state of a container.",
       "properties": {
         "startedAt": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Time at which the container was last (re-)started"
         }
       },
@@ -6399,7 +6316,7 @@
           "type": "integer"
         },
         "finishedAt": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Time at which the container last terminated"
         },
         "message": {
@@ -6416,7 +6333,7 @@
           "type": "integer"
         },
         "startedAt": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Time at which previous execution of the container started"
         }
       },
@@ -6442,7 +6359,7 @@
       "properties": {
         "allocatedResources": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "AllocatedResources represents the compute resources allocated for this container by the node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission and after successfully admitting desired pod resize.",
           "type": "object"
@@ -6450,7 +6367,7 @@
         "allocatedResourcesStatus": {
           "description": "AllocatedResourcesStatus represents the status of various resources allocated for this Pod.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ResourceStatus"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceStatus"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -6471,7 +6388,7 @@
           "type": "string"
         },
         "lastState": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerState",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState",
           "description": "LastTerminationState holds the last termination state of the container to help debug container crashes and restarts. This field is not populated if the container is still running and RestartCount is 0."
         },
         "name": {
@@ -6483,7 +6400,7 @@
           "type": "boolean"
         },
         "resources": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
           "description": "Resources represents the compute resource requests and limits that have been successfully enacted on the running container after it has been started or has been successfully resized."
         },
         "restartCount": {
@@ -6496,7 +6413,7 @@
           "type": "boolean"
         },
         "state": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerState",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerState",
           "description": "State holds details about the container's current condition."
         },
         "stopSignal": {
@@ -6504,13 +6421,13 @@
           "type": "string"
         },
         "user": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerUser",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerUser",
           "description": "User represents user identity information initially attached to the first process of the container"
         },
         "volumeMounts": {
           "description": "Status of volume mounts.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.VolumeMountStatus"
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMountStatus"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["mountPath"],
@@ -6526,7 +6443,7 @@
       "description": "ContainerUser represents user identity information",
       "properties": {
         "linux": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LinuxContainerUser",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LinuxContainerUser",
           "description": "Linux holds user identity information initially attached to the first process of the containers in Linux. Note that the actual running identity can be changed if the process has enough privilege to do so."
         }
       },
@@ -6550,7 +6467,7 @@
         "items": {
           "description": "Items is a list of DownwardAPIVolume file",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+            "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6562,7 +6479,7 @@
       "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
       "properties": {
         "fieldRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectFieldSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
           "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported."
         },
         "mode": {
@@ -6575,7 +6492,7 @@
           "type": "string"
         },
         "resourceFieldRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceFieldSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
           "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
         }
       },
@@ -6593,7 +6510,7 @@
         "items": {
           "description": "Items is a list of downward API volume file",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+            "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6609,7 +6526,7 @@
           "type": "string"
         },
         "sizeLimit": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir"
         }
       },
@@ -6631,7 +6548,7 @@
           "type": "string"
         },
         "targetRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
           "description": "Reference to object providing the endpoint."
         }
       },
@@ -6670,7 +6587,7 @@
         "addresses": {
           "description": "IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.EndpointAddress"
+            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointAddress"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6678,7 +6595,7 @@
         "notReadyAddresses": {
           "description": "IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.EndpointAddress"
+            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointAddress"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6686,7 +6603,7 @@
         "ports": {
           "description": "Port numbers available on the related IP addresses.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.EndpointPort"
+            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointPort"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6703,17 +6620,17 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Endpoints"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Endpoints"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "subsets": {
           "description": "The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.EndpointSubset"
+            "$ref": "#/definitions/io.k8s.api.core.v1.EndpointSubset"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6738,17 +6655,17 @@
         "items": {
           "description": "List of endpoints.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Endpoints"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Endpoints"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["EndpointsList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["EndpointsList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -6766,7 +6683,7 @@
       "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
       "properties": {
         "configMapRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ConfigMapEnvSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
           "description": "The ConfigMap to select from"
         },
         "prefix": {
@@ -6774,7 +6691,7 @@
           "type": "string"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretEnvSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretEnvSource",
           "description": "The Secret to select from"
         }
       },
@@ -6792,7 +6709,7 @@
           "type": "string"
         },
         "valueFrom": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.EnvVarSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.EnvVarSource",
           "description": "Source for the environment variable's value. Cannot be used if value is not empty."
         }
       },
@@ -6803,19 +6720,19 @@
       "description": "EnvVarSource represents a source for the value of an EnvVar.",
       "properties": {
         "configMapKeyRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ConfigMapKeySelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapKeySelector",
           "description": "Selects a key of a ConfigMap."
         },
         "fieldRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectFieldSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
           "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs."
         },
         "resourceFieldRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceFieldSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
           "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported."
         },
         "secretKeyRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretKeySelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretKeySelector",
           "description": "Selects a key of a secret in the pod's namespace"
         }
       },
@@ -6843,7 +6760,7 @@
         "env": {
           "description": "List of environment variables to set in the container. Cannot be updated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.EnvVar"
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -6854,7 +6771,7 @@
         "envFrom": {
           "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.EnvFromSource"
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -6868,11 +6785,11 @@
           "type": "string"
         },
         "lifecycle": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Lifecycle",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
           "description": "Lifecycle is not allowed for ephemeral containers."
         },
         "livenessProbe": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Probe",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
           "description": "Probes are not allowed for ephemeral containers."
         },
         "name": {
@@ -6882,7 +6799,7 @@
         "ports": {
           "description": "Ports are not allowed for ephemeral containers.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerPort"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["containerPort", "protocol"],
@@ -6891,19 +6808,19 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "readinessProbe": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Probe",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
           "description": "Probes are not allowed for ephemeral containers."
         },
         "resizePolicy": {
           "description": "Resources resize policy for the container.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerResizePolicy"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerResizePolicy"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "resources": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
           "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod."
         },
         "restartPolicy": {
@@ -6911,11 +6828,11 @@
           "type": "string"
         },
         "securityContext": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecurityContext",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
           "description": "Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext."
         },
         "startupProbe": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Probe",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
           "description": "Probes are not allowed for ephemeral containers."
         },
         "stdin": {
@@ -6945,7 +6862,7 @@
         "volumeDevices": {
           "description": "volumeDevices is the list of block devices to be used by the container.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.VolumeDevice"
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["devicePath"],
@@ -6956,7 +6873,7 @@
         "volumeMounts": {
           "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.VolumeMount"
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["mountPath"],
@@ -6976,7 +6893,7 @@
       "description": "Represents an ephemeral volume that is handled by a normal storage driver.",
       "properties": {
         "volumeClaimTemplate": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimTemplate",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimTemplate",
           "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.\n\nRequired, must not be nil."
         }
       },
@@ -6999,24 +6916,24 @@
           "type": "integer"
         },
         "eventTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "Time when this Event was first observed."
         },
         "firstTimestamp": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)"
         },
         "involvedObject": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
           "description": "The object that this event is about."
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Event"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Event"]
         },
         "lastTimestamp": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "The time at which the most recent occurrence of this event was recorded."
         },
         "message": {
@@ -7024,7 +6941,7 @@
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "reason": {
@@ -7032,7 +6949,7 @@
           "type": "string"
         },
         "related": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
           "description": "Optional secondary object for more complex actions."
         },
         "reportingComponent": {
@@ -7044,11 +6961,11 @@
           "type": "string"
         },
         "series": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.EventSeries",
+          "$ref": "#/definitions/io.k8s.api.core.v1.EventSeries",
           "description": "Data about the Event series this event represents or nil if it's a singleton Event."
         },
         "source": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.EventSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.EventSource",
           "description": "The component reporting this event. Should be a short machine understandable string."
         },
         "type": {
@@ -7076,17 +6993,17 @@
         "items": {
           "description": "List of events",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Event"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Event"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["EventList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["EventList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -7109,7 +7026,7 @@
           "type": "integer"
         },
         "lastObservedTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "Time of the last occurrence observed"
         }
       },
@@ -7201,7 +7118,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "secretRef is Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
         }
       },
@@ -7231,7 +7148,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
           "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
         }
       },
@@ -7363,7 +7280,7 @@
         "httpHeaders": {
           "description": "Custom headers to set in the request. HTTP allows repeated headers.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.HTTPHeader"
+            "$ref": "#/definitions/io.k8s.api.core.v1.HTTPHeader"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -7373,7 +7290,7 @@
           "type": "string"
         },
         "port": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
         },
         "scheme": {
@@ -7489,7 +7406,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
         },
         "targetPortal": {
@@ -7545,7 +7462,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
           "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication"
         },
         "targetPortal": {
@@ -7594,11 +7511,11 @@
       "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
       "properties": {
         "postStart": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LifecycleHandler",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LifecycleHandler",
           "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
         },
         "preStop": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LifecycleHandler",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LifecycleHandler",
           "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
         },
         "stopSignal": {
@@ -7612,19 +7529,19 @@
       "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
       "properties": {
         "exec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ExecAction",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
           "description": "Exec specifies a command to execute in the container."
         },
         "httpGet": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.HTTPGetAction",
+          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
           "description": "HTTPGet specifies an HTTP GET request to perform."
         },
         "sleep": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SleepAction",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SleepAction",
           "description": "Sleep represents a duration that the container should sleep."
         },
         "tcpSocket": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.TCPSocketAction",
+          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
           "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility. There is no validation of this field and lifecycle hooks will fail at runtime when it is specified."
         }
       },
@@ -7639,15 +7556,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["LimitRange"],
-          "type": "string"
+          "type": "string",
+          "enum": ["LimitRange"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LimitRangeSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeSpec",
           "description": "Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -7665,35 +7582,35 @@
       "properties": {
         "default": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Default resource requirement limit value by resource name if resource limit is omitted.",
           "type": "object"
         },
         "defaultRequest": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.",
           "type": "object"
         },
         "max": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Max usage constraints on this kind by resource name.",
           "type": "object"
         },
         "maxLimitRequestRatio": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.",
           "type": "object"
         },
         "min": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Min usage constraints on this kind by resource name.",
           "type": "object"
@@ -7716,17 +7633,17 @@
         "items": {
           "description": "Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.LimitRange"
+            "$ref": "#/definitions/io.k8s.api.core.v1.LimitRange"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["LimitRangeList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["LimitRangeList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -7746,7 +7663,7 @@
         "limits": {
           "description": "Limits is the list of LimitRangeItem objects that are enforced.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.LimitRangeItem"
+            "$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeItem"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -7799,7 +7716,7 @@
         "ports": {
           "description": "Ports is a list of records of service ports If used, every port defined in the service should have an entry in it",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PortStatus"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PortStatus"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -7813,7 +7730,7 @@
         "ingress": {
           "description": "Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.LoadBalancerIngress"
+            "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerIngress"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -7890,19 +7807,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Namespace"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Namespace"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NamespaceSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NamespaceSpec",
           "description": "Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NamespaceStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NamespaceStatus",
           "description": "Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -7919,7 +7836,7 @@
       "description": "NamespaceCondition contains details about state of namespace.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition transitioned from one status to another."
         },
         "message": {
@@ -7952,17 +7869,17 @@
         "items": {
           "description": "Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Namespace"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Namespace"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["NamespaceList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["NamespaceList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -7996,7 +7913,7 @@
         "conditions": {
           "description": "Represents the latest available observations of a namespace's current state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.NamespaceCondition"
+            "$ref": "#/definitions/io.k8s.api.core.v1.NamespaceCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -8020,19 +7937,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Node"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Node"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSpec",
           "description": "Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeStatus",
           "description": "Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -8066,13 +7983,13 @@
         "preferredDuringSchedulingIgnoredDuringExecution": {
           "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PreferredSchedulingTerm"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PreferredSchedulingTerm"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "requiredDuringSchedulingIgnoredDuringExecution": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node."
         }
       },
@@ -8082,11 +7999,11 @@
       "description": "NodeCondition contains condition information for a node.",
       "properties": {
         "lastHeartbeatTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time we got an update on a given condition."
         },
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition transit from one status to another."
         },
         "message": {
@@ -8113,7 +8030,7 @@
       "description": "NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil. This API is deprecated since 1.22",
       "properties": {
         "configMap": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ConfigMapNodeConfigSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapNodeConfigSource",
           "description": "ConfigMap is a reference to a Node's ConfigMap"
         }
       },
@@ -8123,11 +8040,11 @@
       "description": "NodeConfigStatus describes the status of the config assigned by Node.Spec.ConfigSource.",
       "properties": {
         "active": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource",
           "description": "Active reports the checkpointed config the node is actively using. Active will represent either the current version of the Assigned config, or the current LastKnownGood config, depending on whether attempting to use the Assigned config results in an error."
         },
         "assigned": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource",
           "description": "Assigned reports the checkpointed config the node will try to use. When Node.Spec.ConfigSource is updated, the node checkpoints the associated config payload to local disk, along with a record indicating intended config. The node refers to this record to choose its config checkpoint, and reports this record in Assigned. Assigned only updates in the status after the record has been checkpointed to disk. When the Kubelet is restarted, it tries to make the Assigned config the Active config by loading and validating the checkpointed payload identified by Assigned."
         },
         "error": {
@@ -8135,7 +8052,7 @@
           "type": "string"
         },
         "lastKnownGood": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource",
           "description": "LastKnownGood reports the checkpointed config the node will fall back to when it encounters an error attempting to use the Assigned config. The Assigned config becomes the LastKnownGood config when the node determines that the Assigned config is stable and correct. This is currently implemented as a 10-minute soak period starting when the local record of Assigned config is updated. If the Assigned config is Active at the end of this period, it becomes the LastKnownGood. Note that if Spec.ConfigSource is reset to nil (use local defaults), the LastKnownGood is also immediately reset to nil, because the local default config is always assumed good. You should not make assumptions about the node's method of determining config stability and correctness, as this may change or become configurable in the future."
         }
       },
@@ -8145,7 +8062,7 @@
       "description": "NodeDaemonEndpoints lists ports opened by daemons running on the Node.",
       "properties": {
         "kubeletEndpoint": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.DaemonEndpoint",
+          "$ref": "#/definitions/io.k8s.api.core.v1.DaemonEndpoint",
           "description": "Endpoint on which Kubelet is listening."
         }
       },
@@ -8171,17 +8088,17 @@
         "items": {
           "description": "List of nodes",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Node"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Node"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["NodeList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["NodeList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -8199,7 +8116,7 @@
       "description": "NodeRuntimeHandler is a set of runtime handler information.",
       "properties": {
         "features": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeRuntimeHandlerFeatures",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeRuntimeHandlerFeatures",
           "description": "Supported features."
         },
         "name": {
@@ -8229,7 +8146,7 @@
         "nodeSelectorTerms": {
           "description": "Required. A list of node selector terms. The terms are ORed.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelectorTerm"
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -8268,7 +8185,7 @@
         "matchExpressions": {
           "description": "A list of node selector requirements by node's labels.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelectorRequirement"
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -8276,7 +8193,7 @@
         "matchFields": {
           "description": "A list of node selector requirements by node's fields.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelectorRequirement"
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -8289,7 +8206,7 @@
       "description": "NodeSpec describes the attributes that a node is created with.",
       "properties": {
         "configSource": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigSource",
           "description": "Deprecated: Previously used to specify the source of the node's configuration for the DynamicKubeletConfig feature. This feature is removed."
         },
         "externalID": {
@@ -8316,7 +8233,7 @@
         "taints": {
           "description": "If specified, the node's taints.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Taint"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Taint"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -8334,7 +8251,7 @@
         "addresses": {
           "description": "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/reference/node/node-status/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See https://pr.k8s.io/79391 for an example. Consumers should assume that addresses can change during the lifetime of a Node. However, there are some exceptions where this may not be possible, such as Pods that inherit a Node's address in its own status or consumers of the downward API (status.hostIP).",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.NodeAddress"
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeAddress"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -8344,14 +8261,14 @@
         },
         "allocatable": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.",
           "type": "object"
         },
         "capacity": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Capacity represents the total resources of a node. More info: https://kubernetes.io/docs/reference/node/node-status/#capacity",
           "type": "object"
@@ -8359,7 +8276,7 @@
         "conditions": {
           "description": "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/reference/node/node-status/#condition",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.NodeCondition"
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -8368,27 +8285,27 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "config": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeConfigStatus",
           "description": "Status of the config assigned to the node via the dynamic Kubelet config feature."
         },
         "daemonEndpoints": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeDaemonEndpoints",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeDaemonEndpoints",
           "description": "Endpoints of daemons running on the Node."
         },
         "features": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeFeatures",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeFeatures",
           "description": "Features describes the set of features implemented by the CRI implementation."
         },
         "images": {
           "description": "List of container images on this node",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerImage"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerImage"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "nodeInfo": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSystemInfo",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSystemInfo",
           "description": "Set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/reference/node/node-status/#info"
         },
         "phase": {
@@ -8398,7 +8315,7 @@
         "runtimeHandlers": {
           "description": "The available runtime handlers.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.NodeRuntimeHandler"
+            "$ref": "#/definitions/io.k8s.api.core.v1.NodeRuntimeHandler"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -8406,7 +8323,7 @@
         "volumesAttached": {
           "description": "List of volumes that are attached to the node.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.AttachedVolume"
+            "$ref": "#/definitions/io.k8s.api.core.v1.AttachedVolume"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -8473,7 +8390,7 @@
           "type": "string"
         },
         "swap": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSwapStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSwapStatus",
           "description": "Swap Info reported by the node."
         },
         "systemUUID": {
@@ -8555,19 +8472,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PersistentVolume"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PersistentVolume"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeSpec",
           "description": "spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeStatus",
           "description": "status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes"
         }
       },
@@ -8589,19 +8506,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PersistentVolumeClaim"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PersistentVolumeClaim"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimSpec",
           "description": "spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimStatus",
           "description": "status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
         }
       },
@@ -8618,11 +8535,11 @@
       "description": "PersistentVolumeClaimCondition contains details about state of pvc",
       "properties": {
         "lastProbeTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastProbeTime is the time we probed the condition."
         },
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastTransitionTime is the time the condition transitioned from one status to another."
         },
         "message": {
@@ -8655,17 +8572,17 @@
         "items": {
           "description": "items is a list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaim"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaim"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PersistentVolumeClaimList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PersistentVolumeClaimList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -8691,19 +8608,19 @@
           "x-kubernetes-list-type": "atomic"
         },
         "dataSource": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.TypedLocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.TypedLocalObjectReference",
           "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource."
         },
         "dataSourceRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.TypedObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.TypedObjectReference",
           "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled."
         },
         "resources": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.VolumeResourceRequirements",
+          "$ref": "#/definitions/io.k8s.api.core.v1.VolumeResourceRequirements",
           "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "selector is a label query over volumes to consider for binding."
         },
         "storageClassName": {
@@ -8746,14 +8663,14 @@
         },
         "allocatedResources": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
           "type": "object"
         },
         "capacity": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "capacity represents the actual resources of the underlying volume.",
           "type": "object"
@@ -8761,7 +8678,7 @@
         "conditions": {
           "description": "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'Resizing'.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimCondition"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -8774,7 +8691,7 @@
           "type": "string"
         },
         "modifyVolumeStatus": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ModifyVolumeStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ModifyVolumeStatus",
           "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation. When this is unset, there is no ModifyVolume operation being attempted. This is a beta field and requires enabling VolumeAttributesClass feature (off by default)."
         },
         "phase": {
@@ -8788,11 +8705,11 @@
       "description": "PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.",
       "properties": {
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimSpec",
           "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here."
         }
       },
@@ -8824,17 +8741,17 @@
         "items": {
           "description": "items is a list of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolume"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolume"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PersistentVolumeList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PersistentVolumeList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -8860,71 +8777,71 @@
           "x-kubernetes-list-type": "atomic"
         },
         "awsElasticBlockStore": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource",
           "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
         },
         "azureDisk": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.AzureDiskVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource",
           "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod. Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type are redirected to the disk.csi.azure.com CSI driver."
         },
         "azureFile": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.AzureFilePersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFilePersistentVolumeSource",
           "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod. Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type are redirected to the file.csi.azure.com CSI driver."
         },
         "capacity": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "capacity is the description of the persistent volume's resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity",
           "type": "object"
         },
         "cephfs": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.CephFSPersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSPersistentVolumeSource",
           "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime. Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported."
         },
         "cinder": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.CinderPersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.CinderPersistentVolumeSource",
           "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. Deprecated: Cinder is deprecated. All operations for the in-tree cinder type are redirected to the cinder.csi.openstack.org CSI driver. More info: https://examples.k8s.io/mysql-cinder-pd/README.md"
         },
         "claimRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
           "description": "claimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding",
           "x-kubernetes-map-type": "granular"
         },
         "csi": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.CSIPersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.CSIPersistentVolumeSource",
           "description": "csi represents storage that is handled by an external CSI driver."
         },
         "fc": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.FCVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource",
           "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod."
         },
         "flexVolume": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.FlexPersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlexPersistentVolumeSource",
           "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead."
         },
         "flocker": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.FlockerVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource",
           "description": "flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running. Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported."
         },
         "gcePersistentDisk": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource",
           "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
         },
         "glusterfs": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.GlusterfsPersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsPersistentVolumeSource",
           "description": "glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported. More info: https://examples.k8s.io/volumes/glusterfs/README.md"
         },
         "hostPath": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.HostPathVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource",
           "description": "hostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
         },
         "iscsi": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ISCSIPersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIPersistentVolumeSource",
           "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin."
         },
         "local": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LocalVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalVolumeSource",
           "description": "local represents directly-attached storage with node affinity"
         },
         "mountOptions": {
@@ -8936,11 +8853,11 @@
           "x-kubernetes-list-type": "atomic"
         },
         "nfs": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NFSVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource",
           "description": "nfs represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
         },
         "nodeAffinity": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.VolumeNodeAffinity",
+          "$ref": "#/definitions/io.k8s.api.core.v1.VolumeNodeAffinity",
           "description": "nodeAffinity defines constraints that limit what nodes this volume can be accessed from. This field influences the scheduling of pods that use this volume."
         },
         "persistentVolumeReclaimPolicy": {
@@ -8948,23 +8865,23 @@
           "type": "string"
         },
         "photonPersistentDisk": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource",
           "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine. Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported."
         },
         "portworxVolume": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PortworxVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource",
           "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine. Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate is on."
         },
         "quobyte": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.QuobyteVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource",
           "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime. Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported."
         },
         "rbd": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.RBDPersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.RBDPersistentVolumeSource",
           "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported. More info: https://examples.k8s.io/volumes/rbd/README.md"
         },
         "scaleIO": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ScaleIOPersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOPersistentVolumeSource",
           "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes. Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported."
         },
         "storageClassName": {
@@ -8972,7 +8889,7 @@
           "type": "string"
         },
         "storageos": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.StorageOSPersistentVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSPersistentVolumeSource",
           "description": "storageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod. Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported. More info: https://examples.k8s.io/volumes/storageos/README.md"
         },
         "volumeAttributesClassName": {
@@ -8984,7 +8901,7 @@
           "type": "string"
         },
         "vsphereVolume": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource",
           "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine. Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type are redirected to the csi.vsphere.vmware.com CSI driver."
         }
       },
@@ -8994,7 +8911,7 @@
       "description": "PersistentVolumeStatus is the current status of a persistent volume.",
       "properties": {
         "lastPhaseTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions."
         },
         "message": {
@@ -9036,19 +8953,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Pod"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Pod"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec",
           "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodStatus",
           "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -9067,7 +8984,7 @@
         "preferredDuringSchedulingIgnoredDuringExecution": {
           "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+            "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9075,7 +8992,7 @@
         "requiredDuringSchedulingIgnoredDuringExecution": {
           "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodAffinityTerm"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9087,7 +9004,7 @@
       "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
       "properties": {
         "labelSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods."
         },
         "matchLabelKeys": {
@@ -9107,7 +9024,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "namespaceSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces."
         },
         "namespaces": {
@@ -9132,7 +9049,7 @@
         "preferredDuringSchedulingIgnoredDuringExecution": {
           "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and subtracting \"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+            "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9140,7 +9057,7 @@
         "requiredDuringSchedulingIgnoredDuringExecution": {
           "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodAffinityTerm"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9152,11 +9069,11 @@
       "description": "PodCondition contains details for the current condition of this pod.",
       "properties": {
         "lastProbeTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time we probed the condition."
         },
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition transitioned from one status to another."
         },
         "message": {
@@ -9198,7 +9115,7 @@
         "options": {
           "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodDNSConfigOption"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfigOption"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9249,17 +9166,17 @@
         "items": {
           "description": "List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Pod"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Pod"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PodList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PodList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -9344,7 +9261,7 @@
       "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
       "properties": {
         "appArmorProfile": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.AppArmorProfile",
+          "$ref": "#/definitions/io.k8s.api.core.v1.AppArmorProfile",
           "description": "appArmorProfile is the AppArmor options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows."
         },
         "fsGroup": {
@@ -9375,11 +9292,11 @@
           "type": "string"
         },
         "seLinuxOptions": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SELinuxOptions",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
           "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows."
         },
         "seccompProfile": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SeccompProfile",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SeccompProfile",
           "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows."
         },
         "supplementalGroups": {
@@ -9398,13 +9315,13 @@
         "sysctls": {
           "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Sysctl"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Sysctl"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "windowsOptions": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
           "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux."
         }
       },
@@ -9419,7 +9336,7 @@
           "type": "integer"
         },
         "affinity": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Affinity",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Affinity",
           "description": "If specified, the pod's scheduling constraints"
         },
         "automountServiceAccountToken": {
@@ -9429,7 +9346,7 @@
         "containers": {
           "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Container"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Container"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -9438,7 +9355,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "dnsConfig": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodDNSConfig",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodDNSConfig",
           "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy."
         },
         "dnsPolicy": {
@@ -9452,7 +9369,7 @@
         "ephemeralContainers": {
           "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.EphemeralContainer"
+            "$ref": "#/definitions/io.k8s.api.core.v1.EphemeralContainer"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -9463,7 +9380,7 @@
         "hostAliases": {
           "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.HostAlias"
+            "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["ip"],
@@ -9494,7 +9411,7 @@
         "imagePullSecrets": {
           "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference"
+            "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -9505,7 +9422,7 @@
         "initContainers": {
           "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Container"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Container"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -9526,12 +9443,12 @@
           "x-kubernetes-map-type": "atomic"
         },
         "os": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodOS",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodOS",
           "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.securityContext.supplementalGroupsPolicy - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup"
         },
         "overhead": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md",
           "type": "object"
@@ -9552,7 +9469,7 @@
         "readinessGates": {
           "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodReadinessGate"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodReadinessGate"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9560,7 +9477,7 @@
         "resourceClaims": {
           "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodResourceClaim"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodResourceClaim"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -9569,7 +9486,7 @@
           "x-kubernetes-patch-strategy": "merge,retainKeys"
         },
         "resources": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
           "description": "Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for \"cpu\" and \"memory\" resource names only. ResourceClaims are not supported.\n\nThis field enables fine-grained control over resource allocation for the entire pod, allowing resource sharing among containers in a pod.\n\nThis is an alpha field and requires enabling the PodLevelResources feature gate."
         },
         "restartPolicy": {
@@ -9587,7 +9504,7 @@
         "schedulingGates": {
           "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodSchedulingGate"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodSchedulingGate"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -9596,7 +9513,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "securityContext": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodSecurityContext",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
           "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
         },
         "serviceAccount": {
@@ -9627,7 +9544,7 @@
         "tolerations": {
           "description": "If specified, the pod's tolerations.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Toleration"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9635,7 +9552,7 @@
         "topologySpreadConstraints": {
           "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.TopologySpreadConstraint"
+            "$ref": "#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["topologyKey", "whenUnsatisfiable"],
@@ -9646,7 +9563,7 @@
         "volumes": {
           "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Volume"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -9664,7 +9581,7 @@
         "conditions": {
           "description": "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodCondition"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -9675,7 +9592,7 @@
         "containerStatuses": {
           "description": "Statuses of containers in this pod. Each container in the pod should have at most one status in this list, and all statuses should be for containers in the pod. However this is not enforced. If a status for a non-existent container is present in the list, or the list has duplicate names, the behavior of various Kubernetes components is not defined and those statuses might be ignored. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStatus"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9683,7 +9600,7 @@
         "ephemeralContainerStatuses": {
           "description": "Statuses for any ephemeral containers that have run in this pod. Each ephemeral container in the pod should have at most one status in this list, and all statuses should be for containers in the pod. However this is not enforced. If a status for a non-existent container is present in the list, or the list has duplicate names, the behavior of various Kubernetes components is not defined and those statuses might be ignored. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStatus"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9695,7 +9612,7 @@
         "hostIPs": {
           "description": "hostIPs holds the IP addresses allocated to the host. If this field is specified, the first entry must match the hostIP field. This list is empty if the pod has not started yet. A pod can be assigned to a node that has a problem in kubelet which in turns means that HostIPs will not be updated even if there is a node is assigned to this pod.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.HostIP"
+            "$ref": "#/definitions/io.k8s.api.core.v1.HostIP"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic",
@@ -9705,7 +9622,7 @@
         "initContainerStatuses": {
           "description": "Statuses of init containers in this pod. The most recent successful non-restartable init container will have ready = true, the most recently started container will have startTime set. Each init container in the pod should have at most one status in this list, and all statuses should be for containers in the pod. However this is not enforced. If a status for a non-existent container is present in the list, or the list has duplicate names, the behavior of various Kubernetes components is not defined and those statuses might be ignored. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-and-container-status",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStatus"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerStatus"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -9734,7 +9651,7 @@
         "podIPs": {
           "description": "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodIP"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodIP"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["ip"],
@@ -9757,7 +9674,7 @@
         "resourceClaimStatuses": {
           "description": "Status of resource claims.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodResourceClaimStatus"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodResourceClaimStatus"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -9766,7 +9683,7 @@
           "x-kubernetes-patch-strategy": "merge,retainKeys"
         },
         "startTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod."
         }
       },
@@ -9781,15 +9698,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PodTemplate"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PodTemplate"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "template": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
           "description": "Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -9812,17 +9729,17 @@
         "items": {
           "description": "List of pod templates",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.PodTemplate"
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplate"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PodTemplateList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PodTemplateList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -9840,11 +9757,11 @@
       "description": "PodTemplateSpec describes the data a pod should have when created from a template",
       "properties": {
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSpec",
           "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -9893,7 +9810,7 @@
       "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
       "properties": {
         "preference": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelectorTerm",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm",
           "description": "A node selector term, associated with the corresponding weight."
         },
         "weight": {
@@ -9909,7 +9826,7 @@
       "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
       "properties": {
         "exec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ExecAction",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
           "description": "Exec specifies a command to execute in the container."
         },
         "failureThreshold": {
@@ -9918,11 +9835,11 @@
           "type": "integer"
         },
         "grpc": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.GRPCAction",
+          "$ref": "#/definitions/io.k8s.api.core.v1.GRPCAction",
           "description": "GRPC specifies a GRPC HealthCheckRequest."
         },
         "httpGet": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.HTTPGetAction",
+          "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
           "description": "HTTPGet specifies an HTTP GET request to perform."
         },
         "initialDelaySeconds": {
@@ -9941,7 +9858,7 @@
           "type": "integer"
         },
         "tcpSocket": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.TCPSocketAction",
+          "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
           "description": "TCPSocket specifies a connection to a TCP port."
         },
         "terminationGracePeriodSeconds": {
@@ -9968,7 +9885,7 @@
         "sources": {
           "description": "sources is the list of volume projections. Each entry in this list handles one source.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.VolumeProjection"
+            "$ref": "#/definitions/io.k8s.api.core.v1.VolumeProjection"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -10039,7 +9956,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
         },
         "user": {
@@ -10082,7 +9999,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
           "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
         },
         "user": {
@@ -10102,19 +10019,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ReplicationController"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ReplicationController"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ReplicationControllerSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerSpec",
           "description": "Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ReplicationControllerStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerStatus",
           "description": "Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -10131,7 +10048,7 @@
       "description": "ReplicationControllerCondition describes the state of a replication controller at a certain point.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "The last time the condition transitioned from one status to another."
         },
         "message": {
@@ -10164,17 +10081,17 @@
         "items": {
           "description": "List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ReplicationController"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationController"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ReplicationControllerList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ReplicationControllerList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -10210,7 +10127,7 @@
           "x-kubernetes-map-type": "atomic"
         },
         "template": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec",
           "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. The only allowed template.spec.restartPolicy value is \"Always\". More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
         }
       },
@@ -10227,7 +10144,7 @@
         "conditions": {
           "description": "Represents the latest available observations of a replication controller's current state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ReplicationControllerCondition"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ReplicationControllerCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -10282,7 +10199,7 @@
           "type": "string"
         },
         "divisor": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "Specifies the output format of the exposed resources, defaults to \"1\""
         },
         "resource": {
@@ -10318,19 +10235,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceQuota"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceQuota"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceQuotaSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuotaSpec",
           "description": "Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceQuotaStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuotaStatus",
           "description": "Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -10353,17 +10270,17 @@
         "items": {
           "description": "Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ResourceQuota"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceQuota"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceQuotaList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceQuotaList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -10382,13 +10299,13 @@
       "properties": {
         "hard": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
           "type": "object"
         },
         "scopeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ScopeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ScopeSelector",
           "description": "scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched."
         },
         "scopes": {
@@ -10407,14 +10324,14 @@
       "properties": {
         "hard": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
           "type": "object"
         },
         "used": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Used is the current observed total usage of the resource in the namespace.",
           "type": "object"
@@ -10428,7 +10345,7 @@
         "claims": {
           "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ResourceClaim"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceClaim"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -10436,14 +10353,14 @@
         },
         "limits": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
           "type": "object"
         },
         "requests": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
           "type": "object"
@@ -10461,7 +10378,7 @@
         "resources": {
           "description": "List of unique resources health. Each element in the list contains an unique resource ID and its health. At a minimum, for the lifetime of a Pod, resource ID must uniquely identify the resource allocated to the Pod on the Node. If other Pod on the same Node reports the status with the same resource ID, it must be the same resource they share. See ResourceID type definition for a specific format it has in various use cases.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ResourceHealth"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceHealth"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["resourceID"],
@@ -10513,7 +10430,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretReference",
           "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
         },
         "sslEnabled": {
@@ -10560,7 +10477,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
           "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
         },
         "sslEnabled": {
@@ -10593,7 +10510,7 @@
         "matchExpressions": {
           "description": "A list of scope selector requirements by scope of the resources.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ScopedResourceSelectorRequirement"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ScopedResourceSelectorRequirement"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -10669,11 +10586,11 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Secret"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Secret"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "stringData": {
@@ -10741,17 +10658,17 @@
         "items": {
           "description": "Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Secret"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["SecretList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["SecretList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -10771,7 +10688,7 @@
         "items": {
           "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.KeyToPath"
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -10813,7 +10730,7 @@
         "items": {
           "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.KeyToPath"
+            "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -10837,11 +10754,11 @@
           "type": "boolean"
         },
         "appArmorProfile": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.AppArmorProfile",
+          "$ref": "#/definitions/io.k8s.api.core.v1.AppArmorProfile",
           "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile overrides the pod's appArmorProfile. Note that this field cannot be set when spec.os.name is windows."
         },
         "capabilities": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Capabilities",
+          "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities",
           "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows."
         },
         "privileged": {
@@ -10871,15 +10788,15 @@
           "type": "integer"
         },
         "seLinuxOptions": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SELinuxOptions",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
           "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows."
         },
         "seccompProfile": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SeccompProfile",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SeccompProfile",
           "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows."
         },
         "windowsOptions": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
           "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux."
         }
       },
@@ -10894,19 +10811,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Service"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Service"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ServiceSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceSpec",
           "description": "Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ServiceStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceStatus",
           "description": "Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -10933,24 +10850,24 @@
         "imagePullSecrets": {
           "description": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference"
+            "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ServiceAccount"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ServiceAccount"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "secrets": {
           "description": "Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a \"kubernetes.io/enforce-mountable-secrets\" annotation set to \"true\". The \"kubernetes.io/enforce-mountable-secrets\" annotation is deprecated since v1.32. Prefer separate namespaces to isolate access to mounted secrets. This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -10978,17 +10895,17 @@
         "items": {
           "description": "List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ServiceAccount"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ServiceAccount"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ServiceAccountList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ServiceAccountList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -11032,17 +10949,17 @@
         "items": {
           "description": "List of services",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Service"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Service"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ServiceList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ServiceList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         }
       },
@@ -11082,7 +10999,7 @@
           "type": "string"
         },
         "targetPort": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service"
         }
       },
@@ -11164,7 +11081,7 @@
         "ports": {
           "description": "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.ServicePort"
+            "$ref": "#/definitions/io.k8s.api.core.v1.ServicePort"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["port", "protocol"],
@@ -11189,7 +11106,7 @@
           "type": "string"
         },
         "sessionAffinityConfig": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SessionAffinityConfig",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SessionAffinityConfig",
           "description": "sessionAffinityConfig contains the configurations of session affinity."
         },
         "trafficDistribution": {
@@ -11209,7 +11126,7 @@
         "conditions": {
           "description": "Current service state",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -11218,7 +11135,7 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "loadBalancer": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LoadBalancerStatus",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerStatus",
           "description": "LoadBalancer contains the current status of the load-balancer, if one is present."
         }
       },
@@ -11228,7 +11145,7 @@
       "description": "SessionAffinityConfig represents the configurations of session affinity.",
       "properties": {
         "clientIP": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ClientIPConfig",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ClientIPConfig",
           "description": "clientIP contains the configurations of Client IP based session affinity."
         }
       },
@@ -11258,7 +11175,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
           "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
         },
         "volumeName": {
@@ -11284,7 +11201,7 @@
           "type": "boolean"
         },
         "secretRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.LocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
           "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
         },
         "volumeName": {
@@ -11321,7 +11238,7 @@
           "type": "string"
         },
         "port": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
         }
       },
@@ -11340,7 +11257,7 @@
           "type": "string"
         },
         "timeAdded": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "TimeAdded represents the time at which the taint was added."
         },
         "value": {
@@ -11403,7 +11320,7 @@
         "matchLabelExpressions": {
           "description": "A list of topology selector requirements by labels.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.TopologySelectorLabelRequirement"
+            "$ref": "#/definitions/io.k8s.api.core.v1.TopologySelectorLabelRequirement"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -11416,7 +11333,7 @@
       "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
       "properties": {
         "labelSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain."
         },
         "matchLabelKeys": {
@@ -11504,79 +11421,79 @@
       "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
       "properties": {
         "awsElasticBlockStore": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource",
           "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
         },
         "azureDisk": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.AzureDiskVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource",
           "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod. Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type are redirected to the disk.csi.azure.com CSI driver."
         },
         "azureFile": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.AzureFileVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.AzureFileVolumeSource",
           "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod. Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type are redirected to the file.csi.azure.com CSI driver."
         },
         "cephfs": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.CephFSVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.CephFSVolumeSource",
           "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime. Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported."
         },
         "cinder": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.CinderVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource",
           "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. Deprecated: Cinder is deprecated. All operations for the in-tree cinder type are redirected to the cinder.csi.openstack.org CSI driver. More info: https://examples.k8s.io/mysql-cinder-pd/README.md"
         },
         "configMap": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ConfigMapVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource",
           "description": "configMap represents a configMap that should populate this volume"
         },
         "csi": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.CSIVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.CSIVolumeSource",
           "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers."
         },
         "downwardAPI": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.DownwardAPIVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeSource",
           "description": "downwardAPI represents downward API about the pod that should populate this volume"
         },
         "emptyDir": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.EmptyDirVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource",
           "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir"
         },
         "ephemeral": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.EphemeralVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.EphemeralVolumeSource",
           "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.\n\nUse this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.\n\nA pod can use both types of ephemeral volumes and persistent volumes at the same time."
         },
         "fc": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.FCVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource",
           "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod."
         },
         "flexVolume": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.FlexVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource",
           "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead."
         },
         "flocker": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.FlockerVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource",
           "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running. Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported."
         },
         "gcePersistentDisk": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource",
           "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
         },
         "gitRepo": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.GitRepoVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.GitRepoVolumeSource",
           "description": "gitRepo represents a git repository at a particular revision. Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container."
         },
         "glusterfs": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.GlusterfsVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource",
           "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported. More info: https://examples.k8s.io/volumes/glusterfs/README.md"
         },
         "hostPath": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.HostPathVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource",
           "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
         },
         "image": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ImageVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ImageVolumeSource",
           "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine. The volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation. A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message. The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field. The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images. The volume will be mounted read-only (ro) and non-executable files (noexec). Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33. The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type."
         },
         "iscsi": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ISCSIVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource",
           "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md"
         },
         "name": {
@@ -11584,47 +11501,47 @@
           "type": "string"
         },
         "nfs": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NFSVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource",
           "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
         },
         "persistentVolumeClaim": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource",
           "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
         },
         "photonPersistentDisk": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource",
           "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine. Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported."
         },
         "portworxVolume": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PortworxVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource",
           "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine. Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate is on."
         },
         "projected": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ProjectedVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ProjectedVolumeSource",
           "description": "projected items for all in one resources secrets, configmaps, and downward API"
         },
         "quobyte": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.QuobyteVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource",
           "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime. Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported."
         },
         "rbd": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.RBDVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource",
           "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported. More info: https://examples.k8s.io/volumes/rbd/README.md"
         },
         "scaleIO": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ScaleIOVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource",
           "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes. Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported."
         },
         "secret": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretVolumeSource",
           "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret"
         },
         "storageos": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.StorageOSVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSVolumeSource",
           "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes. Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported."
         },
         "vsphereVolume": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource",
           "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine. Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type are redirected to the csi.vsphere.vmware.com CSI driver."
         }
       },
@@ -11708,7 +11625,7 @@
       "description": "VolumeNodeAffinity defines constraints that limit what nodes this volume can be accessed from.",
       "properties": {
         "required": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "required specifies hard node constraints that must be met."
         }
       },
@@ -11718,23 +11635,23 @@
       "description": "Projection that may be projected along with other supported volume types. Exactly one of these fields must be set.",
       "properties": {
         "clusterTrustBundle": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ClusterTrustBundleProjection",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ClusterTrustBundleProjection",
           "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the combination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written into the pod filesystem.  Esoteric PEM features such as inter-block comments and block headers are stripped.  Certificates are deduplicated. The ordering of certificates within the file is arbitrary, and Kubelet may change the order over time."
         },
         "configMap": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ConfigMapProjection",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapProjection",
           "description": "configMap information about the configMap data to project"
         },
         "downwardAPI": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.DownwardAPIProjection",
+          "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIProjection",
           "description": "downwardAPI information about the downwardAPI data to project"
         },
         "secret": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.SecretProjection",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecretProjection",
           "description": "secret information about the secret data to project"
         },
         "serviceAccountToken": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ServiceAccountTokenProjection",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ServiceAccountTokenProjection",
           "description": "serviceAccountToken is information about the serviceAccountToken data to project"
         }
       },
@@ -11745,14 +11662,14 @@
       "properties": {
         "limits": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
           "type": "object"
         },
         "requests": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
           "type": "object"
@@ -11787,7 +11704,7 @@
       "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
       "properties": {
         "podAffinityTerm": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodAffinityTerm",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm",
           "description": "Required. A pod affinity term, associated with the corresponding weight."
         },
         "weight": {
@@ -11833,7 +11750,7 @@
           "x-kubernetes-list-type": "set"
         },
         "conditions": {
-          "$ref": "#/$defs/io.k8s.api.discovery.v1.EndpointConditions",
+          "$ref": "#/definitions/io.k8s.api.discovery.v1.EndpointConditions",
           "description": "conditions contains information about the current status of the endpoint."
         },
         "deprecatedTopology": {
@@ -11844,7 +11761,7 @@
           "type": "object"
         },
         "hints": {
-          "$ref": "#/$defs/io.k8s.api.discovery.v1.EndpointHints",
+          "$ref": "#/definitions/io.k8s.api.discovery.v1.EndpointHints",
           "description": "hints contains information associated with how an endpoint should be consumed."
         },
         "hostname": {
@@ -11856,7 +11773,7 @@
           "type": "string"
         },
         "targetRef": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
           "description": "targetRef is a reference to a Kubernetes object that represents this endpoint."
         },
         "zone": {
@@ -11891,7 +11808,7 @@
         "forNodes": {
           "description": "forNodes indicates the node(s) this endpoint should be consumed by when using topology aware routing. May contain a maximum of 8 entries. This is an Alpha feature and is only used when the PreferSameTrafficDistribution feature gate is enabled.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.discovery.v1.ForNode"
+            "$ref": "#/definitions/io.k8s.api.discovery.v1.ForNode"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -11899,7 +11816,7 @@
         "forZones": {
           "description": "forZones indicates the zone(s) this endpoint should be consumed by when using topology aware routing. May contain a maximum of 8 entries.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.discovery.v1.ForZone"
+            "$ref": "#/definitions/io.k8s.api.discovery.v1.ForZone"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -11945,24 +11862,24 @@
         "endpoints": {
           "description": "endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.discovery.v1.Endpoint"
+            "$ref": "#/definitions/io.k8s.api.discovery.v1.Endpoint"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["EndpointSlice"],
-          "type": "string"
+          "type": "string",
+          "enum": ["EndpointSlice"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata."
         },
         "ports": {
           "description": "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. Each slice may include a maximum of 100 ports. Services always have at least 1 port, so EndpointSlices generated by the EndpointSlice controller will likewise always have at least 1 port. EndpointSlices used for other purposes may have an empty ports list.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.discovery.v1.EndpointPort"
+            "$ref": "#/definitions/io.k8s.api.discovery.v1.EndpointPort"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -11988,17 +11905,17 @@
         "items": {
           "description": "items is the list of endpoint slices",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.discovery.v1.EndpointSlice"
+            "$ref": "#/definitions/io.k8s.api.discovery.v1.EndpointSlice"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["EndpointSliceList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["EndpointSliceList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata."
         }
       },
@@ -12051,28 +11968,28 @@
           "type": "integer"
         },
         "deprecatedFirstTimestamp": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "deprecatedFirstTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type."
         },
         "deprecatedLastTimestamp": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "deprecatedLastTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type."
         },
         "deprecatedSource": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.EventSource",
+          "$ref": "#/definitions/io.k8s.api.core.v1.EventSource",
           "description": "deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type."
         },
         "eventTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "eventTime is the time when this Event was first observed. It is required."
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Event"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Event"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "note": {
@@ -12084,11 +12001,11 @@
           "type": "string"
         },
         "regarding": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
           "description": "regarding contains the object this Event is about. In most cases it's an Object reporting controller implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object."
         },
         "related": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.ObjectReference",
           "description": "related is the optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object."
         },
         "reportingController": {
@@ -12100,7 +12017,7 @@
           "type": "string"
         },
         "series": {
-          "$ref": "#/$defs/io.k8s.api.events.v1.EventSeries",
+          "$ref": "#/definitions/io.k8s.api.events.v1.EventSeries",
           "description": "series is data about the Event series this event represents or nil if it's a singleton Event."
         },
         "type": {
@@ -12128,17 +12045,17 @@
         "items": {
           "description": "items is a list of schema objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.events.v1.Event"
+            "$ref": "#/definitions/io.k8s.api.events.v1.Event"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["EventList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["EventList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -12161,7 +12078,7 @@
           "type": "integer"
         },
         "lastObservedTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime",
           "description": "lastObservedTime is the time when last Event from the series was seen before last heartbeat."
         }
       },
@@ -12204,19 +12121,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["FlowSchema"],
-          "type": "string"
+          "type": "string",
+          "enum": ["FlowSchema"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.FlowSchemaSpec",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.FlowSchemaSpec",
           "description": "`spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.FlowSchemaStatus",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.FlowSchemaStatus",
           "description": "`status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -12233,7 +12150,7 @@
       "description": "FlowSchemaCondition describes conditions for a FlowSchema.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "`lastTransitionTime` is the last time the condition transitioned from one status to another."
         },
         "message": {
@@ -12265,17 +12182,17 @@
         "items": {
           "description": "`items` is a list of FlowSchemas.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.FlowSchema"
+            "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.FlowSchema"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["FlowSchemaList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["FlowSchemaList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "`metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -12293,7 +12210,7 @@
       "description": "FlowSchemaSpec describes how the FlowSchema's specification looks like.",
       "properties": {
         "distinguisherMethod": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.FlowDistinguisherMethod",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.FlowDistinguisherMethod",
           "description": "`distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string."
         },
         "matchingPrecedence": {
@@ -12302,13 +12219,13 @@
           "type": "integer"
         },
         "priorityLevelConfiguration": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationReference",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationReference",
           "description": "`priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required."
         },
         "rules": {
           "description": "`rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.PolicyRulesWithSubjects"
+            "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.PolicyRulesWithSubjects"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -12323,7 +12240,7 @@
         "conditions": {
           "description": "`conditions` is a list of the current states of FlowSchema.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.FlowSchemaCondition"
+            "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.FlowSchemaCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -12349,7 +12266,7 @@
       "description": "LimitResponse defines how to handle requests that can not be executed right now.",
       "properties": {
         "queuing": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.QueuingConfiguration",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.QueuingConfiguration",
           "description": "`queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `\"Queue\"`."
         },
         "type": {
@@ -12382,7 +12299,7 @@
           "type": "integer"
         },
         "limitResponse": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.LimitResponse",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.LimitResponse",
           "description": "`limitResponse` indicates what to do with requests that can not be executed right now"
         },
         "nominalConcurrencyShares": {
@@ -12422,7 +12339,7 @@
         "nonResourceRules": {
           "description": "`nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.NonResourcePolicyRule"
+            "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.NonResourcePolicyRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -12430,7 +12347,7 @@
         "resourceRules": {
           "description": "`resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.ResourcePolicyRule"
+            "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.ResourcePolicyRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -12438,7 +12355,7 @@
         "subjects": {
           "description": "subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.Subject"
+            "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.Subject"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -12456,19 +12373,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PriorityLevelConfiguration"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PriorityLevelConfiguration"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationSpec",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationSpec",
           "description": "`spec` is the specification of the desired behavior of a \"request-priority\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationStatus",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationStatus",
           "description": "`status` is the current status of a \"request-priority\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -12485,7 +12402,7 @@
       "description": "PriorityLevelConfigurationCondition defines the condition of priority level.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "`lastTransitionTime` is the last time the condition transitioned from one status to another."
         },
         "message": {
@@ -12517,17 +12434,17 @@
         "items": {
           "description": "`items` is a list of request-priorities.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.PriorityLevelConfiguration"
+            "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.PriorityLevelConfiguration"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PriorityLevelConfigurationList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PriorityLevelConfigurationList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -12556,11 +12473,11 @@
       "description": "PriorityLevelConfigurationSpec specifies the configuration of a priority level.",
       "properties": {
         "exempt": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.ExemptPriorityLevelConfiguration",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.ExemptPriorityLevelConfiguration",
           "description": "`exempt` specifies how requests are handled for an exempt priority level. This field MUST be empty if `type` is `\"Limited\"`. This field MAY be non-empty if `type` is `\"Exempt\"`. If empty and `type` is `\"Exempt\"` then the default values for `ExemptPriorityLevelConfiguration` apply."
         },
         "limited": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.LimitedPriorityLevelConfiguration",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.LimitedPriorityLevelConfiguration",
           "description": "`limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `\"Limited\"`."
         },
         "type": {
@@ -12586,7 +12503,7 @@
         "conditions": {
           "description": "`conditions` is the current state of \"request-priority\".",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationCondition"
+            "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.PriorityLevelConfigurationCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -12680,7 +12597,7 @@
       "description": "Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.",
       "properties": {
         "group": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.GroupSubject",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.GroupSubject",
           "description": "`group` matches based on user group name."
         },
         "kind": {
@@ -12688,11 +12605,11 @@
           "type": "string"
         },
         "serviceAccount": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.ServiceAccountSubject",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.ServiceAccountSubject",
           "description": "`serviceAccount` matches ServiceAccounts."
         },
         "user": {
-          "$ref": "#/$defs/io.k8s.api.flowcontrol.v1.UserSubject",
+          "$ref": "#/definitions/io.k8s.api.flowcontrol.v1.UserSubject",
           "description": "`user` matches based on username."
         }
       },
@@ -12724,7 +12641,7 @@
       "description": "HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.",
       "properties": {
         "backend": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IngressBackend",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IngressBackend",
           "description": "backend defines the referenced service endpoint to which the traffic will be forwarded to."
         },
         "path": {
@@ -12745,7 +12662,7 @@
         "paths": {
           "description": "paths is a collection of paths that map requests to backends.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.HTTPIngressPath"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.HTTPIngressPath"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -12763,15 +12680,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["IPAddress"],
-          "type": "string"
+          "type": "string",
+          "enum": ["IPAddress"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IPAddressSpec",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IPAddressSpec",
           "description": "spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -12794,17 +12711,17 @@
         "items": {
           "description": "items is the list of IPAddresses.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.IPAddress"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.IPAddress"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["IPAddressList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["IPAddressList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -12822,7 +12739,7 @@
       "description": "IPAddressSpec describe the attributes in an IP Address.",
       "properties": {
         "parentRef": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.ParentReference",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.ParentReference",
           "description": "ParentRef references the resource that an IPAddress is attached to. An IPAddress must reference a parent object."
         }
       },
@@ -12857,19 +12774,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Ingress"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Ingress"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IngressSpec",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IngressSpec",
           "description": "spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IngressStatus",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IngressStatus",
           "description": "status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -12886,11 +12803,11 @@
       "description": "IngressBackend describes all endpoints for a given service and port.",
       "properties": {
         "resource": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.TypedLocalObjectReference",
+          "$ref": "#/definitions/io.k8s.api.core.v1.TypedLocalObjectReference",
           "description": "resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with \"Service\"."
         },
         "service": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IngressServiceBackend",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IngressServiceBackend",
           "description": "service references a service as a backend. This is a mutually exclusive setting with \"Resource\"."
         }
       },
@@ -12905,15 +12822,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["IngressClass"],
-          "type": "string"
+          "type": "string",
+          "enum": ["IngressClass"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IngressClassSpec",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IngressClassSpec",
           "description": "spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -12936,17 +12853,17 @@
         "items": {
           "description": "items is the list of IngressClasses.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.IngressClass"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.IngressClass"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["IngressClassList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["IngressClassList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata."
         }
       },
@@ -12995,7 +12912,7 @@
           "type": "string"
         },
         "parameters": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IngressClassParametersReference",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IngressClassParametersReference",
           "description": "parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters."
         }
       },
@@ -13011,17 +12928,17 @@
         "items": {
           "description": "items is the list of Ingress.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.Ingress"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.Ingress"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["IngressList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["IngressList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -13049,7 +12966,7 @@
         "ports": {
           "description": "ports provides information about the ports exposed by this LoadBalancer.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.IngressPortStatus"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.IngressPortStatus"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13063,7 +12980,7 @@
         "ingress": {
           "description": "ingress is a list containing ingress points for the load-balancer.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.IngressLoadBalancerIngress"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.IngressLoadBalancerIngress"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13099,7 +13016,7 @@
           "type": "string"
         },
         "http": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.HTTPIngressRuleValue"
+          "$ref": "#/definitions/io.k8s.api.networking.v1.HTTPIngressRuleValue"
         }
       },
       "type": "object"
@@ -13112,7 +13029,7 @@
           "type": "string"
         },
         "port": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.ServiceBackendPort",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.ServiceBackendPort",
           "description": "port of the referenced service. A port name or port number is required for a IngressServiceBackend."
         }
       },
@@ -13123,7 +13040,7 @@
       "description": "IngressSpec describes the Ingress the user wishes to exist.",
       "properties": {
         "defaultBackend": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IngressBackend",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IngressBackend",
           "description": "defaultBackend is the backend that should handle requests that don't match any rule. If Rules are not specified, DefaultBackend must be specified. If DefaultBackend is not set, the handling of requests that do not match any of the rules will be up to the Ingress controller."
         },
         "ingressClassName": {
@@ -13133,7 +13050,7 @@
         "rules": {
           "description": "rules is a list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.IngressRule"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.IngressRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13141,7 +13058,7 @@
         "tls": {
           "description": "tls represents the TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.IngressTLS"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.IngressTLS"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13153,7 +13070,7 @@
       "description": "IngressStatus describe the current state of the Ingress.",
       "properties": {
         "loadBalancer": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IngressLoadBalancerStatus",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IngressLoadBalancerStatus",
           "description": "loadBalancer contains the current status of the load-balancer."
         }
       },
@@ -13186,15 +13103,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["NetworkPolicy"],
-          "type": "string"
+          "type": "string",
+          "enum": ["NetworkPolicy"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicySpec",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicySpec",
           "description": "spec represents the specification of the desired behavior for this NetworkPolicy."
         }
       },
@@ -13213,7 +13130,7 @@
         "ports": {
           "description": "ports is a list of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyPort"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13221,7 +13138,7 @@
         "to": {
           "description": "to is a list of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyPeer"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13235,7 +13152,7 @@
         "from": {
           "description": "from is a list of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyPeer"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13243,7 +13160,7 @@
         "ports": {
           "description": "ports is a list of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyPort"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13261,17 +13178,17 @@
         "items": {
           "description": "items is a list of schema objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicy"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicy"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["NetworkPolicyList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["NetworkPolicyList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -13289,15 +13206,15 @@
       "description": "NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed",
       "properties": {
         "ipBlock": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.IPBlock",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.IPBlock",
           "description": "ipBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be."
         },
         "namespaceSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "namespaceSelector selects namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf podSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the namespaces selected by namespaceSelector. Otherwise it selects all pods in the namespaces selected by namespaceSelector."
         },
         "podSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "podSelector is a label selector which selects pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace."
         }
       },
@@ -13312,7 +13229,7 @@
           "type": "integer"
         },
         "port": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched."
         },
         "protocol": {
@@ -13328,7 +13245,7 @@
         "egress": {
           "description": "egress is a list of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyEgressRule"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13336,13 +13253,13 @@
         "ingress": {
           "description": "ingress is a list of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.NetworkPolicyIngressRule"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyIngressRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "podSelector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "podSelector selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace."
         },
         "policyTypes": {
@@ -13405,19 +13322,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ServiceCIDR"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ServiceCIDR"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.ServiceCIDRSpec",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.ServiceCIDRSpec",
           "description": "spec is the desired state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1.ServiceCIDRStatus",
+          "$ref": "#/definitions/io.k8s.api.networking.v1.ServiceCIDRStatus",
           "description": "status represents the current state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -13440,17 +13357,17 @@
         "items": {
           "description": "items is the list of ServiceCIDRs.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1.ServiceCIDR"
+            "$ref": "#/definitions/io.k8s.api.networking.v1.ServiceCIDR"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ServiceCIDRList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ServiceCIDRList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -13484,7 +13401,7 @@
         "conditions": {
           "description": "conditions holds an array of metav1.Condition that describe the state of the ServiceCIDR. Current service state",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -13504,15 +13421,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["IPAddress"],
-          "type": "string"
+          "type": "string",
+          "enum": ["IPAddress"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1beta1.IPAddressSpec",
+          "$ref": "#/definitions/io.k8s.api.networking.v1beta1.IPAddressSpec",
           "description": "spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -13535,17 +13452,17 @@
         "items": {
           "description": "items is the list of IPAddresses.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1beta1.IPAddress"
+            "$ref": "#/definitions/io.k8s.api.networking.v1beta1.IPAddress"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["IPAddressList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["IPAddressList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -13563,7 +13480,7 @@
       "description": "IPAddressSpec describe the attributes in an IP Address.",
       "properties": {
         "parentRef": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1beta1.ParentReference",
+          "$ref": "#/definitions/io.k8s.api.networking.v1beta1.ParentReference",
           "description": "ParentRef references the resource that an IPAddress is attached to. An IPAddress must reference a parent object."
         }
       },
@@ -13602,19 +13519,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ServiceCIDR"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ServiceCIDR"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1beta1.ServiceCIDRSpec",
+          "$ref": "#/definitions/io.k8s.api.networking.v1beta1.ServiceCIDRSpec",
           "description": "spec is the desired state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.networking.v1beta1.ServiceCIDRStatus",
+          "$ref": "#/definitions/io.k8s.api.networking.v1beta1.ServiceCIDRStatus",
           "description": "status represents the current state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
@@ -13637,17 +13554,17 @@
         "items": {
           "description": "items is the list of ServiceCIDRs.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.networking.v1beta1.ServiceCIDR"
+            "$ref": "#/definitions/io.k8s.api.networking.v1beta1.ServiceCIDR"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ServiceCIDRList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ServiceCIDRList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -13681,7 +13598,7 @@
         "conditions": {
           "description": "conditions holds an array of metav1.Condition that describe the state of the ServiceCIDR. Current service state",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -13697,7 +13614,7 @@
       "properties": {
         "podFixed": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "podFixed represents the fixed resource overhead associated with running a pod.",
           "type": "object"
@@ -13718,19 +13635,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["RuntimeClass"],
-          "type": "string"
+          "type": "string",
+          "enum": ["RuntimeClass"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "overhead": {
-          "$ref": "#/$defs/io.k8s.api.node.v1.Overhead",
+          "$ref": "#/definitions/io.k8s.api.node.v1.Overhead",
           "description": "overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see\n https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/"
         },
         "scheduling": {
-          "$ref": "#/$defs/io.k8s.api.node.v1.Scheduling",
+          "$ref": "#/definitions/io.k8s.api.node.v1.Scheduling",
           "description": "scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes."
         }
       },
@@ -13754,17 +13671,17 @@
         "items": {
           "description": "items is a list of schema objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.node.v1.RuntimeClass"
+            "$ref": "#/definitions/io.k8s.api.node.v1.RuntimeClass"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["RuntimeClassList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["RuntimeClassList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -13792,7 +13709,7 @@
         "tolerations": {
           "description": "tolerations are appended (excluding duplicates) to pods running with this RuntimeClass during admission, effectively unioning the set of nodes tolerated by the pod and the RuntimeClass.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Toleration"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13808,16 +13725,16 @@
           "type": "string"
         },
         "deleteOptions": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions",
           "description": "DeleteOptions may be provided"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Eviction"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Eviction"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "ObjectMeta describes the pod that is being evicted."
         }
       },
@@ -13839,19 +13756,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PodDisruptionBudget"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PodDisruptionBudget"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudgetSpec",
+          "$ref": "#/definitions/io.k8s.api.policy.v1.PodDisruptionBudgetSpec",
           "description": "Specification of the desired behavior of the PodDisruptionBudget."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudgetStatus",
+          "$ref": "#/definitions/io.k8s.api.policy.v1.PodDisruptionBudgetStatus",
           "description": "Most recently observed status of the PodDisruptionBudget."
         }
       },
@@ -13874,17 +13791,17 @@
         "items": {
           "description": "Items is a list of PodDisruptionBudgets",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudget"
+            "$ref": "#/definitions/io.k8s.api.policy.v1.PodDisruptionBudget"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PodDisruptionBudgetList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PodDisruptionBudgetList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -13902,15 +13819,15 @@
       "description": "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.",
       "properties": {
         "maxUnavailable": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by \"selector\" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with \"minAvailable\"."
         },
         "minAvailable": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
           "description": "An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\"."
         },
         "selector": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "Label query over pods whose evictions are managed by the disruption budget. A null selector will match no pods, while an empty ({}) selector will select all pods within the namespace.",
           "x-kubernetes-patch-strategy": "replace"
         },
@@ -13927,7 +13844,7 @@
         "conditions": {
           "description": "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -13947,7 +13864,7 @@
         },
         "disruptedPods": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
           },
           "description": "DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.",
           "type": "object"
@@ -13982,7 +13899,7 @@
         "clusterRoleSelectors": {
           "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -13994,7 +13911,7 @@
       "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
       "properties": {
         "aggregationRule": {
-          "$ref": "#/$defs/io.k8s.api.rbac.v1.AggregationRule",
+          "$ref": "#/definitions/io.k8s.api.rbac.v1.AggregationRule",
           "description": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller."
         },
         "apiVersion": {
@@ -14003,17 +13920,17 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ClusterRole"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ClusterRole"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata."
         },
         "rules": {
           "description": "Rules holds all the PolicyRules for this ClusterRole",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.rbac.v1.PolicyRule"
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.PolicyRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14037,21 +13954,21 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ClusterRoleBinding"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ClusterRoleBinding"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata."
         },
         "roleRef": {
-          "$ref": "#/$defs/io.k8s.api.rbac.v1.RoleRef",
+          "$ref": "#/definitions/io.k8s.api.rbac.v1.RoleRef",
           "description": "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
         },
         "subjects": {
           "description": "Subjects holds references to the objects the role applies to.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.rbac.v1.Subject"
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.Subject"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14077,17 +13994,17 @@
         "items": {
           "description": "Items is a list of ClusterRoleBindings",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.rbac.v1.ClusterRoleBinding"
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.ClusterRoleBinding"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ClusterRoleBindingList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ClusterRoleBindingList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata."
         }
       },
@@ -14111,17 +14028,17 @@
         "items": {
           "description": "Items is a list of ClusterRoles",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.rbac.v1.ClusterRole"
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.ClusterRole"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ClusterRoleList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ClusterRoleList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata."
         }
       },
@@ -14191,17 +14108,17 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Role"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Role"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata."
         },
         "rules": {
           "description": "Rules holds all the PolicyRules for this Role",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.rbac.v1.PolicyRule"
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.PolicyRule"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14225,21 +14142,21 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["RoleBinding"],
-          "type": "string"
+          "type": "string",
+          "enum": ["RoleBinding"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata."
         },
         "roleRef": {
-          "$ref": "#/$defs/io.k8s.api.rbac.v1.RoleRef",
+          "$ref": "#/definitions/io.k8s.api.rbac.v1.RoleRef",
           "description": "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable."
         },
         "subjects": {
           "description": "Subjects holds references to the objects the role applies to.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.rbac.v1.Subject"
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.Subject"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14265,17 +14182,17 @@
         "items": {
           "description": "Items is a list of RoleBindings",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.rbac.v1.RoleBinding"
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.RoleBinding"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["RoleBindingList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["RoleBindingList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata."
         }
       },
@@ -14299,17 +14216,17 @@
         "items": {
           "description": "Items is a list of Roles",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.rbac.v1.Role"
+            "$ref": "#/definitions/io.k8s.api.rbac.v1.Role"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["RoleList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["RoleList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata."
         }
       },
@@ -14373,14 +14290,14 @@
         "conditions": {
           "description": "Conditions contains the latest observation of the device's state. If the device has been configured according to the class and claim config references, the `Ready` condition should be True.\n\nMust not contain more than 8 entries.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
           "x-kubernetes-list-type": "map"
         },
         "data": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
           "description": "Data contains arbitrary driver-specific data.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
         },
         "device": {
@@ -14392,7 +14309,7 @@
           "type": "string"
         },
         "networkData": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.NetworkDeviceData",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.NetworkDeviceData",
           "description": "NetworkData contains network-related information specific to the device."
         },
         "pool": {
@@ -14407,11 +14324,11 @@
       "description": "AllocationResult contains attributes of an allocated resource.",
       "properties": {
         "devices": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceAllocationResult",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceAllocationResult",
           "description": "Devices is the result of allocating devices."
         },
         "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "NodeSelector defines where the allocated resources are available. If unset, they are available everywhere."
         }
       },
@@ -14426,14 +14343,14 @@
         },
         "attributes": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceAttribute"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceAttribute"
           },
           "description": "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
           "type": "object"
         },
         "capacity": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
           "description": "Capacity defines the set of capacities for this device. The name of each capacity must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
           "type": "object"
@@ -14441,7 +14358,7 @@
         "consumesCounters": {
           "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceCounterConsumption"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceCounterConsumption"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14451,13 +14368,13 @@
           "type": "string"
         },
         "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "NodeSelector defines the nodes where the device is available.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set."
         },
         "taints": {
           "description": "If specified, these are the driver-defined taints.\n\nThe maximum number of taints is 4.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceTaint"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceTaint"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14480,7 +14397,7 @@
       "description": "Counter describes a quantity associated with a device.",
       "properties": {
         "value": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "Value defines how much of a certain device counter is available."
         }
       },
@@ -14492,7 +14409,7 @@
       "properties": {
         "counters": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.Counter"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.Counter"
           },
           "description": "Counters defines the counters that will be consumed by the device. The name of each counter must be unique in that set and must be a DNS label.\n\nTo ensure this uniqueness, capacities defined by the vendor must be listed without the driver name as domain prefix in their name. All others must be listed with their domain prefix.\n\nThe maximum number of counters is 32.",
           "type": "object"
@@ -14509,7 +14426,7 @@
       "description": "Device represents one individual hardware instance that can be selected based on its attributes. Besides the name, exactly one field must be set.",
       "properties": {
         "basic": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.BasicDevice",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.BasicDevice",
           "description": "Basic defines one device instance."
         },
         "name": {
@@ -14524,7 +14441,7 @@
       "description": "DeviceAllocationConfiguration gets embedded in an AllocationResult.",
       "properties": {
         "opaque": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.OpaqueDeviceConfiguration",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.OpaqueDeviceConfiguration",
           "description": "Opaque provides driver-specific configuration parameters."
         },
         "requests": {
@@ -14549,7 +14466,7 @@
         "config": {
           "description": "This field is a combination of all the claim and class configuration parameters. Drivers can distinguish between those based on a flag.\n\nThis includes configuration parameters for drivers which have no allocated devices in the result because it is up to the drivers which configuration parameters they support. They can silently ignore unknown configuration parameters.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceAllocationConfiguration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceAllocationConfiguration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14557,7 +14474,7 @@
         "results": {
           "description": "Results lists all allocated devices.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceRequestAllocationResult"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceRequestAllocationResult"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14594,7 +14511,7 @@
         "config": {
           "description": "This field holds configuration for multiple potential drivers which could satisfy requests in this claim. It is ignored while allocating the claim.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceClaimConfiguration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceClaimConfiguration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14602,7 +14519,7 @@
         "constraints": {
           "description": "These constraints must be satisfied by the set of devices that get allocated for the claim.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceConstraint"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceConstraint"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14610,7 +14527,7 @@
         "requests": {
           "description": "Requests represent individual requests for distinct devices which must all be satisfied. If empty, nothing needs to be allocated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceRequest"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceRequest"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14622,7 +14539,7 @@
       "description": "DeviceClaimConfiguration is used for configuration parameters in DeviceClaim.",
       "properties": {
         "opaque": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.OpaqueDeviceConfiguration",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.OpaqueDeviceConfiguration",
           "description": "Opaque provides driver-specific configuration parameters."
         },
         "requests": {
@@ -14645,15 +14562,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeviceClass"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeviceClass"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceClassSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceClassSpec",
           "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
@@ -14671,7 +14588,7 @@
       "description": "DeviceClassConfiguration is used in DeviceClass.",
       "properties": {
         "opaque": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.OpaqueDeviceConfiguration",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.OpaqueDeviceConfiguration",
           "description": "Opaque provides driver-specific configuration parameters."
         }
       },
@@ -14687,17 +14604,17 @@
         "items": {
           "description": "Items is the list of resource classes.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceClass"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceClass"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeviceClassList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeviceClassList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -14717,7 +14634,7 @@
         "config": {
           "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceClassConfiguration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceClassConfiguration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14725,7 +14642,7 @@
         "selectors": {
           "description": "Each selector must be satisfied by a device which is claimed via this class.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14760,7 +14677,7 @@
         },
         "counters": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.Counter"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.Counter"
           },
           "description": "Counters defines the Counter that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
           "type": "object"
@@ -14792,7 +14709,7 @@
         "firstAvailable": {
           "description": "FirstAvailable contains subrequests, of which exactly one will be satisfied by the scheduler to satisfy this request. It tries to satisfy them in the order in which they are listed here. So if there are two entries in the list, the scheduler will only check the second one if it determines that the first one cannot be used.\n\nThis field may only be set in the entries of DeviceClaim.Requests.\n\nDRA does not yet implement scoring, so the scheduler will select the first set of devices that satisfies all the requests in the claim. And if the requirements can be satisfied on more than one node, other scheduling features will determine which node is chosen. This means that the set of devices allocated to a claim might not be the optimal set available to the cluster. Scoring will be implemented later.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceSubRequest"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceSubRequest"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14804,7 +14721,7 @@
         "selectors": {
           "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this request. All selectors must be satisfied for a device to be considered.\n\nThis field can only be set when deviceClassName is set and no subrequests are specified in the firstAvailable list.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14812,7 +14729,7 @@
         "tolerations": {
           "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis field can only be set when deviceClassName is set and no subrequests are specified in the firstAvailable list.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceToleration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceToleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14847,7 +14764,7 @@
         "tolerations": {
           "description": "A copy of all tolerations specified in the request at the time when the device got allocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceToleration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceToleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14860,7 +14777,7 @@
       "description": "DeviceSelector must have exactly one field set.",
       "properties": {
         "cel": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.CELDeviceSelector",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.CELDeviceSelector",
           "description": "CEL contains a CEL expression for selecting a device."
         }
       },
@@ -14889,7 +14806,7 @@
         "selectors": {
           "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this request. All selectors must be satisfied for a device to be considered.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14897,7 +14814,7 @@
         "tolerations": {
           "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceToleration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceToleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -14918,7 +14835,7 @@
           "type": "string"
         },
         "timeAdded": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
         },
         "value": {
@@ -14938,15 +14855,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeviceTaintRule"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeviceTaintRule"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceTaintRuleSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceTaintRuleSpec",
           "description": "Spec specifies the selector and one taint.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
@@ -14970,17 +14887,17 @@
         "items": {
           "description": "Items is the list of DeviceTaintRules.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceTaintRule"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceTaintRule"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeviceTaintRuleList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeviceTaintRuleList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -14998,11 +14915,11 @@
       "description": "DeviceTaintRuleSpec specifies the selector and one taint.",
       "properties": {
         "deviceSelector": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceTaintSelector",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceTaintSelector",
           "description": "DeviceSelector defines which device(s) the taint is applied to. All selector criteria must be satified for a device to match. The empty selector matches all devices. Without a selector, no devices are matches."
         },
         "taint": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceTaint",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceTaint",
           "description": "The taint that gets applied to matching devices."
         }
       },
@@ -15031,7 +14948,7 @@
         "selectors": {
           "description": "Selectors contains the same selection criteria as a ResourceClaim. Currently, CEL expressions are supported. All of these selectors must be satisfied.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15096,7 +15013,7 @@
           "type": "string"
         },
         "parameters": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
           "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
         }
       },
@@ -15112,19 +15029,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaim"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaim"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourceClaimSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourceClaimSpec",
           "description": "Spec describes what is being requested and how to configure it. The spec is immutable."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourceClaimStatus",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourceClaimStatus",
           "description": "Status describes whether the claim is ready to use and what has been allocated."
         }
       },
@@ -15171,17 +15088,17 @@
         "items": {
           "description": "Items is the list of resource claims.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourceClaim"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourceClaim"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaimList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaimList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -15199,7 +15116,7 @@
       "description": "ResourceClaimSpec defines what is being requested in a ResourceClaim and how to configure it.",
       "properties": {
         "devices": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.DeviceClaim",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceClaim",
           "description": "Devices defines how to request devices."
         }
       },
@@ -15209,13 +15126,13 @@
       "description": "ResourceClaimStatus tracks whether the resource has been allocated and what the result of that was.",
       "properties": {
         "allocation": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.AllocationResult",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.AllocationResult",
           "description": "Allocation is set once the claim has been allocated successfully."
         },
         "devices": {
           "description": "Devices contains the status of each device allocated for this claim, as reported by the driver. This can include driver-specific information. Entries are owned by their respective drivers.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.AllocatedDeviceStatus"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.AllocatedDeviceStatus"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["driver", "device", "pool"],
@@ -15224,7 +15141,7 @@
         "reservedFor": {
           "description": "ReservedFor indicates which entities are currently allowed to use the claim. A Pod which references a ResourceClaim which is not reserved for that Pod will not be started. A claim that is in use or might be in use because it has been reserved must not get deallocated.\n\nIn a cluster with multiple scheduler instances, two pods might get scheduled concurrently by different schedulers. When they reference the same ResourceClaim which already has reached its maximum number of consumers, only one pod can be scheduled.\n\nBoth schedulers try to add their pod to the claim.status.reservedFor field, but only the update that reaches the API server first gets stored. The other one fails with an error and the scheduler which issued it knows that it must put the pod back into the queue, waiting for the ResourceClaim to become usable again.\n\nThere can be at most 256 such reservations. This may get increased in the future, but not reduced.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourceClaimConsumerReference"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourceClaimConsumerReference"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["uid"],
@@ -15244,15 +15161,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaimTemplate"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaimTemplate"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourceClaimTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourceClaimTemplateSpec",
           "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
         }
       },
@@ -15276,17 +15193,17 @@
         "items": {
           "description": "Items is the list of resource claim templates.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourceClaimTemplate"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourceClaimTemplate"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaimTemplateList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaimTemplateList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -15304,11 +15221,11 @@
       "description": "ResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.",
       "properties": {
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "ObjectMeta may contain labels and annotations that will be copied into the ResourceClaim when creating it. No other fields are allowed and will be rejected during validation."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourceClaimSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourceClaimSpec",
           "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
         }
       },
@@ -15345,15 +15262,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceSlice"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceSlice"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourceSliceSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourceSliceSpec",
           "description": "Contains the information published by the driver.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
@@ -15377,17 +15294,17 @@
         "items": {
           "description": "Items is the list of resource ResourceSlices.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourceSlice"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourceSlice"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceSliceList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceSliceList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -15411,7 +15328,7 @@
         "devices": {
           "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.Device"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.Device"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15425,7 +15342,7 @@
           "type": "string"
         },
         "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set."
         },
         "perDeviceNodeSelection": {
@@ -15433,13 +15350,13 @@
           "type": "boolean"
         },
         "pool": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.ResourcePool",
+          "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.ResourcePool",
           "description": "Pool describes the pool that this ResourceSlice belongs to."
         },
         "sharedCounters": {
           "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of SharedCounters is 32.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1alpha3.CounterSet"
+            "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.CounterSet"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15454,14 +15371,14 @@
         "conditions": {
           "description": "Conditions contains the latest observation of the device's state. If the device has been configured according to the class and claim config references, the `Ready` condition should be True.\n\nMust not contain more than 8 entries.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
           "x-kubernetes-list-type": "map"
         },
         "data": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
           "description": "Data contains arbitrary driver-specific data.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
         },
         "device": {
@@ -15473,7 +15390,7 @@
           "type": "string"
         },
         "networkData": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.NetworkDeviceData",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.NetworkDeviceData",
           "description": "NetworkData contains network-related information specific to the device."
         },
         "pool": {
@@ -15488,11 +15405,11 @@
       "description": "AllocationResult contains attributes of an allocated resource.",
       "properties": {
         "devices": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceAllocationResult",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceAllocationResult",
           "description": "Devices is the result of allocating devices."
         },
         "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "NodeSelector defines where the allocated resources are available. If unset, they are available everywhere."
         }
       },
@@ -15507,14 +15424,14 @@
         },
         "attributes": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceAttribute"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceAttribute"
           },
           "description": "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
           "type": "object"
         },
         "capacity": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceCapacity"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceCapacity"
           },
           "description": "Capacity defines the set of capacities for this device. The name of each capacity must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
           "type": "object"
@@ -15522,7 +15439,7 @@
         "consumesCounters": {
           "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceCounterConsumption"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceCounterConsumption"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15532,13 +15449,13 @@
           "type": "string"
         },
         "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "NodeSelector defines the nodes where the device is available.\n\nMust use exactly one term.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set."
         },
         "taints": {
           "description": "If specified, these are the driver-defined taints.\n\nThe maximum number of taints is 4.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceTaint"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceTaint"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15561,7 +15478,7 @@
       "description": "Counter describes a quantity associated with a device.",
       "properties": {
         "value": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "Value defines how much of a certain device counter is available."
         }
       },
@@ -15573,7 +15490,7 @@
       "properties": {
         "counters": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.Counter"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.Counter"
           },
           "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters is 32.",
           "type": "object"
@@ -15590,7 +15507,7 @@
       "description": "Device represents one individual hardware instance that can be selected based on its attributes. Besides the name, exactly one field must be set.",
       "properties": {
         "basic": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.BasicDevice",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.BasicDevice",
           "description": "Basic defines one device instance."
         },
         "name": {
@@ -15605,7 +15522,7 @@
       "description": "DeviceAllocationConfiguration gets embedded in an AllocationResult.",
       "properties": {
         "opaque": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.OpaqueDeviceConfiguration",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.OpaqueDeviceConfiguration",
           "description": "Opaque provides driver-specific configuration parameters."
         },
         "requests": {
@@ -15630,7 +15547,7 @@
         "config": {
           "description": "This field is a combination of all the claim and class configuration parameters. Drivers can distinguish between those based on a flag.\n\nThis includes configuration parameters for drivers which have no allocated devices in the result because it is up to the drivers which configuration parameters they support. They can silently ignore unknown configuration parameters.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceAllocationConfiguration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceAllocationConfiguration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15638,7 +15555,7 @@
         "results": {
           "description": "Results lists all allocated devices.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceRequestAllocationResult"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceRequestAllocationResult"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15673,7 +15590,7 @@
       "description": "DeviceCapacity describes a quantity associated with a device.",
       "properties": {
         "value": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "Value defines how much of a certain device capacity is available."
         }
       },
@@ -15686,7 +15603,7 @@
         "config": {
           "description": "This field holds configuration for multiple potential drivers which could satisfy requests in this claim. It is ignored while allocating the claim.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceClaimConfiguration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceClaimConfiguration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15694,7 +15611,7 @@
         "constraints": {
           "description": "These constraints must be satisfied by the set of devices that get allocated for the claim.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceConstraint"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceConstraint"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15702,7 +15619,7 @@
         "requests": {
           "description": "Requests represent individual requests for distinct devices which must all be satisfied. If empty, nothing needs to be allocated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceRequest"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceRequest"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15714,7 +15631,7 @@
       "description": "DeviceClaimConfiguration is used for configuration parameters in DeviceClaim.",
       "properties": {
         "opaque": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.OpaqueDeviceConfiguration",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.OpaqueDeviceConfiguration",
           "description": "Opaque provides driver-specific configuration parameters."
         },
         "requests": {
@@ -15737,15 +15654,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeviceClass"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeviceClass"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceClassSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceClassSpec",
           "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
@@ -15763,7 +15680,7 @@
       "description": "DeviceClassConfiguration is used in DeviceClass.",
       "properties": {
         "opaque": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.OpaqueDeviceConfiguration",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.OpaqueDeviceConfiguration",
           "description": "Opaque provides driver-specific configuration parameters."
         }
       },
@@ -15779,17 +15696,17 @@
         "items": {
           "description": "Items is the list of resource classes.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceClass"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceClass"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeviceClassList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeviceClassList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -15809,7 +15726,7 @@
         "config": {
           "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceClassConfiguration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceClassConfiguration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15817,7 +15734,7 @@
         "selectors": {
           "description": "Each selector must be satisfied by a device which is claimed via this class.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15852,7 +15769,7 @@
         },
         "counters": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.Counter"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.Counter"
           },
           "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
           "type": "object"
@@ -15884,7 +15801,7 @@
         "firstAvailable": {
           "description": "FirstAvailable contains subrequests, of which exactly one will be satisfied by the scheduler to satisfy this request. It tries to satisfy them in the order in which they are listed here. So if there are two entries in the list, the scheduler will only check the second one if it determines that the first one cannot be used.\n\nThis field may only be set in the entries of DeviceClaim.Requests.\n\nDRA does not yet implement scoring, so the scheduler will select the first set of devices that satisfies all the requests in the claim. And if the requirements can be satisfied on more than one node, other scheduling features will determine which node is chosen. This means that the set of devices allocated to a claim might not be the optimal set available to the cluster. Scoring will be implemented later.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceSubRequest"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceSubRequest"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15896,7 +15813,7 @@
         "selectors": {
           "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this request. All selectors must be satisfied for a device to be considered.\n\nThis field can only be set when deviceClassName is set and no subrequests are specified in the firstAvailable list.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15904,7 +15821,7 @@
         "tolerations": {
           "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis field can only be set when deviceClassName is set and no subrequests are specified in the firstAvailable list.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceToleration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceToleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15939,7 +15856,7 @@
         "tolerations": {
           "description": "A copy of all tolerations specified in the request at the time when the device got allocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceToleration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceToleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15952,7 +15869,7 @@
       "description": "DeviceSelector must have exactly one field set.",
       "properties": {
         "cel": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.CELDeviceSelector",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.CELDeviceSelector",
           "description": "CEL contains a CEL expression for selecting a device."
         }
       },
@@ -15981,7 +15898,7 @@
         "selectors": {
           "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this subrequest. All selectors must be satisfied for a device to be considered.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -15989,7 +15906,7 @@
         "tolerations": {
           "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceToleration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceToleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16010,7 +15927,7 @@
           "type": "string"
         },
         "timeAdded": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
         },
         "value": {
@@ -16078,7 +15995,7 @@
           "type": "string"
         },
         "parameters": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
           "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
         }
       },
@@ -16094,19 +16011,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaim"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaim"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourceClaimSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourceClaimSpec",
           "description": "Spec describes what is being requested and how to configure it. The spec is immutable."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourceClaimStatus",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourceClaimStatus",
           "description": "Status describes whether the claim is ready to use and what has been allocated."
         }
       },
@@ -16153,17 +16070,17 @@
         "items": {
           "description": "Items is the list of resource claims.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourceClaim"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourceClaim"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaimList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaimList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -16181,7 +16098,7 @@
       "description": "ResourceClaimSpec defines what is being requested in a ResourceClaim and how to configure it.",
       "properties": {
         "devices": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.DeviceClaim",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceClaim",
           "description": "Devices defines how to request devices."
         }
       },
@@ -16191,13 +16108,13 @@
       "description": "ResourceClaimStatus tracks whether the resource has been allocated and what the result of that was.",
       "properties": {
         "allocation": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.AllocationResult",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.AllocationResult",
           "description": "Allocation is set once the claim has been allocated successfully."
         },
         "devices": {
           "description": "Devices contains the status of each device allocated for this claim, as reported by the driver. This can include driver-specific information. Entries are owned by their respective drivers.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.AllocatedDeviceStatus"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.AllocatedDeviceStatus"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["driver", "device", "pool"],
@@ -16206,7 +16123,7 @@
         "reservedFor": {
           "description": "ReservedFor indicates which entities are currently allowed to use the claim. A Pod which references a ResourceClaim which is not reserved for that Pod will not be started. A claim that is in use or might be in use because it has been reserved must not get deallocated.\n\nIn a cluster with multiple scheduler instances, two pods might get scheduled concurrently by different schedulers. When they reference the same ResourceClaim which already has reached its maximum number of consumers, only one pod can be scheduled.\n\nBoth schedulers try to add their pod to the claim.status.reservedFor field, but only the update that reaches the API server first gets stored. The other one fails with an error and the scheduler which issued it knows that it must put the pod back into the queue, waiting for the ResourceClaim to become usable again.\n\nThere can be at most 256 such reservations. This may get increased in the future, but not reduced.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourceClaimConsumerReference"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourceClaimConsumerReference"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["uid"],
@@ -16226,15 +16143,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaimTemplate"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaimTemplate"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourceClaimTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourceClaimTemplateSpec",
           "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
         }
       },
@@ -16258,17 +16175,17 @@
         "items": {
           "description": "Items is the list of resource claim templates.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourceClaimTemplate"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourceClaimTemplate"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaimTemplateList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaimTemplateList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -16286,11 +16203,11 @@
       "description": "ResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.",
       "properties": {
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "ObjectMeta may contain labels and annotations that will be copied into the ResourceClaim when creating it. No other fields are allowed and will be rejected during validation."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourceClaimSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourceClaimSpec",
           "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
         }
       },
@@ -16327,15 +16244,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceSlice"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceSlice"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourceSliceSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourceSliceSpec",
           "description": "Contains the information published by the driver.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
@@ -16359,17 +16276,17 @@
         "items": {
           "description": "Items is the list of resource ResourceSlices.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourceSlice"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourceSlice"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceSliceList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceSliceList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -16393,7 +16310,7 @@
         "devices": {
           "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.Device"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.Device"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16407,7 +16324,7 @@
           "type": "string"
         },
         "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set."
         },
         "perDeviceNodeSelection": {
@@ -16415,13 +16332,13 @@
           "type": "boolean"
         },
         "pool": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta1.ResourcePool",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.ResourcePool",
           "description": "Pool describes the pool that this ResourceSlice belongs to."
         },
         "sharedCounters": {
           "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of SharedCounters is 32.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta1.CounterSet"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta1.CounterSet"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16436,14 +16353,14 @@
         "conditions": {
           "description": "Conditions contains the latest observation of the device's state. If the device has been configured according to the class and claim config references, the `Ready` condition should be True.\n\nMust not contain more than 8 entries.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
           "x-kubernetes-list-type": "map"
         },
         "data": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
           "description": "Data contains arbitrary driver-specific data.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
         },
         "device": {
@@ -16455,7 +16372,7 @@
           "type": "string"
         },
         "networkData": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.NetworkDeviceData",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.NetworkDeviceData",
           "description": "NetworkData contains network-related information specific to the device."
         },
         "pool": {
@@ -16470,11 +16387,11 @@
       "description": "AllocationResult contains attributes of an allocated resource.",
       "properties": {
         "devices": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceAllocationResult",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceAllocationResult",
           "description": "Devices is the result of allocating devices."
         },
         "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "NodeSelector defines where the allocated resources are available. If unset, they are available everywhere."
         }
       },
@@ -16495,7 +16412,7 @@
       "description": "Counter describes a quantity associated with a device.",
       "properties": {
         "value": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "Value defines how much of a certain device counter is available."
         }
       },
@@ -16507,7 +16424,7 @@
       "properties": {
         "counters": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.Counter"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.Counter"
           },
           "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
           "type": "object"
@@ -16529,14 +16446,14 @@
         },
         "attributes": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceAttribute"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceAttribute"
           },
           "description": "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
           "type": "object"
         },
         "capacity": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceCapacity"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceCapacity"
           },
           "description": "Capacity defines the set of capacities for this device. The name of each capacity must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
           "type": "object"
@@ -16544,7 +16461,7 @@
         "consumesCounters": {
           "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceCounterConsumption"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceCounterConsumption"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16558,13 +16475,13 @@
           "type": "string"
         },
         "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "NodeSelector defines the nodes where the device is available.\n\nMust use exactly one term.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set."
         },
         "taints": {
           "description": "If specified, these are the driver-defined taints.\n\nThe maximum number of taints is 4.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceTaint"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceTaint"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16577,7 +16494,7 @@
       "description": "DeviceAllocationConfiguration gets embedded in an AllocationResult.",
       "properties": {
         "opaque": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.OpaqueDeviceConfiguration",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.OpaqueDeviceConfiguration",
           "description": "Opaque provides driver-specific configuration parameters."
         },
         "requests": {
@@ -16602,7 +16519,7 @@
         "config": {
           "description": "This field is a combination of all the claim and class configuration parameters. Drivers can distinguish between those based on a flag.\n\nThis includes configuration parameters for drivers which have no allocated devices in the result because it is up to the drivers which configuration parameters they support. They can silently ignore unknown configuration parameters.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceAllocationConfiguration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceAllocationConfiguration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16610,7 +16527,7 @@
         "results": {
           "description": "Results lists all allocated devices.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceRequestAllocationResult"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceRequestAllocationResult"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16645,7 +16562,7 @@
       "description": "DeviceCapacity describes a quantity associated with a device.",
       "properties": {
         "value": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "Value defines how much of a certain device capacity is available."
         }
       },
@@ -16658,7 +16575,7 @@
         "config": {
           "description": "This field holds configuration for multiple potential drivers which could satisfy requests in this claim. It is ignored while allocating the claim.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceClaimConfiguration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceClaimConfiguration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16666,7 +16583,7 @@
         "constraints": {
           "description": "These constraints must be satisfied by the set of devices that get allocated for the claim.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceConstraint"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceConstraint"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16674,7 +16591,7 @@
         "requests": {
           "description": "Requests represent individual requests for distinct devices which must all be satisfied. If empty, nothing needs to be allocated.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceRequest"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceRequest"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16686,7 +16603,7 @@
       "description": "DeviceClaimConfiguration is used for configuration parameters in DeviceClaim.",
       "properties": {
         "opaque": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.OpaqueDeviceConfiguration",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.OpaqueDeviceConfiguration",
           "description": "Opaque provides driver-specific configuration parameters."
         },
         "requests": {
@@ -16709,15 +16626,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeviceClass"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeviceClass"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceClassSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceClassSpec",
           "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
@@ -16735,7 +16652,7 @@
       "description": "DeviceClassConfiguration is used in DeviceClass.",
       "properties": {
         "opaque": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.OpaqueDeviceConfiguration",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.OpaqueDeviceConfiguration",
           "description": "Opaque provides driver-specific configuration parameters."
         }
       },
@@ -16751,17 +16668,17 @@
         "items": {
           "description": "Items is the list of resource classes.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceClass"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceClass"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeviceClassList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeviceClassList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -16781,7 +16698,7 @@
         "config": {
           "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceClassConfiguration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceClassConfiguration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16789,7 +16706,7 @@
         "selectors": {
           "description": "Each selector must be satisfied by a device which is claimed via this class.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16824,7 +16741,7 @@
         },
         "counters": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.Counter"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.Counter"
           },
           "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
           "type": "object"
@@ -16837,13 +16754,13 @@
       "description": "DeviceRequest is a request for devices required for a claim. This is typically a request for a single resource like a device, but can also ask for several identical devices. With FirstAvailable it is also possible to provide a prioritized list of requests.",
       "properties": {
         "exactly": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ExactDeviceRequest",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ExactDeviceRequest",
           "description": "Exactly specifies the details for a single request that must be met exactly for the request to be satisfied.\n\nOne of Exactly or FirstAvailable must be set."
         },
         "firstAvailable": {
           "description": "FirstAvailable contains subrequests, of which exactly one will be selected by the scheduler. It tries to satisfy them in the order in which they are listed here. So if there are two entries in the list, the scheduler will only check the second one if it determines that the first one can not be used.\n\nDRA does not yet implement scoring, so the scheduler will select the first set of devices that satisfies all the requests in the claim. And if the requirements can be satisfied on more than one node, other scheduling features will determine which node is chosen. This means that the set of devices allocated to a claim might not be the optimal set available to the cluster. Scoring will be implemented later.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceSubRequest"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceSubRequest"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16882,7 +16799,7 @@
         "tolerations": {
           "description": "A copy of all tolerations specified in the request at the time when the device got allocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceToleration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceToleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16895,7 +16812,7 @@
       "description": "DeviceSelector must have exactly one field set.",
       "properties": {
         "cel": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.CELDeviceSelector",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.CELDeviceSelector",
           "description": "CEL contains a CEL expression for selecting a device."
         }
       },
@@ -16924,7 +16841,7 @@
         "selectors": {
           "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this subrequest. All selectors must be satisfied for a device to be considered.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16932,7 +16849,7 @@
         "tolerations": {
           "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceToleration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceToleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -16953,7 +16870,7 @@
           "type": "string"
         },
         "timeAdded": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
         },
         "value": {
@@ -17014,7 +16931,7 @@
         "selectors": {
           "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this request. All selectors must be satisfied for a device to be considered.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceSelector"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceSelector"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -17022,7 +16939,7 @@
         "tolerations": {
           "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceToleration"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceToleration"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -17061,7 +16978,7 @@
           "type": "string"
         },
         "parameters": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
           "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
         }
       },
@@ -17077,19 +16994,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaim"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaim"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourceClaimSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourceClaimSpec",
           "description": "Spec describes what is being requested and how to configure it. The spec is immutable."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourceClaimStatus",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourceClaimStatus",
           "description": "Status describes whether the claim is ready to use and what has been allocated."
         }
       },
@@ -17136,17 +17053,17 @@
         "items": {
           "description": "Items is the list of resource claims.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourceClaim"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourceClaim"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaimList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaimList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -17164,7 +17081,7 @@
       "description": "ResourceClaimSpec defines what is being requested in a ResourceClaim and how to configure it.",
       "properties": {
         "devices": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.DeviceClaim",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceClaim",
           "description": "Devices defines how to request devices."
         }
       },
@@ -17174,13 +17091,13 @@
       "description": "ResourceClaimStatus tracks whether the resource has been allocated and what the result of that was.",
       "properties": {
         "allocation": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.AllocationResult",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.AllocationResult",
           "description": "Allocation is set once the claim has been allocated successfully."
         },
         "devices": {
           "description": "Devices contains the status of each device allocated for this claim, as reported by the driver. This can include driver-specific information. Entries are owned by their respective drivers.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.AllocatedDeviceStatus"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.AllocatedDeviceStatus"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["driver", "device", "pool"],
@@ -17189,7 +17106,7 @@
         "reservedFor": {
           "description": "ReservedFor indicates which entities are currently allowed to use the claim. A Pod which references a ResourceClaim which is not reserved for that Pod will not be started. A claim that is in use or might be in use because it has been reserved must not get deallocated.\n\nIn a cluster with multiple scheduler instances, two pods might get scheduled concurrently by different schedulers. When they reference the same ResourceClaim which already has reached its maximum number of consumers, only one pod can be scheduled.\n\nBoth schedulers try to add their pod to the claim.status.reservedFor field, but only the update that reaches the API server first gets stored. The other one fails with an error and the scheduler which issued it knows that it must put the pod back into the queue, waiting for the ResourceClaim to become usable again.\n\nThere can be at most 256 such reservations. This may get increased in the future, but not reduced.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourceClaimConsumerReference"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourceClaimConsumerReference"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["uid"],
@@ -17209,15 +17126,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaimTemplate"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaimTemplate"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourceClaimTemplateSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourceClaimTemplateSpec",
           "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
         }
       },
@@ -17241,17 +17158,17 @@
         "items": {
           "description": "Items is the list of resource claim templates.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourceClaimTemplate"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourceClaimTemplate"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceClaimTemplateList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceClaimTemplateList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -17269,11 +17186,11 @@
       "description": "ResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.",
       "properties": {
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "ObjectMeta may contain labels and annotations that will be copied into the ResourceClaim when creating it. No other fields are allowed and will be rejected during validation."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourceClaimSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourceClaimSpec",
           "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
         }
       },
@@ -17310,15 +17227,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceSlice"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceSlice"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourceSliceSpec",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourceSliceSpec",
           "description": "Contains the information published by the driver.\n\nChanging the spec automatically increments the metadata.generation number."
         }
       },
@@ -17342,17 +17259,17 @@
         "items": {
           "description": "Items is the list of resource ResourceSlices.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourceSlice"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourceSlice"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["ResourceSliceList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["ResourceSliceList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata"
         }
       },
@@ -17376,7 +17293,7 @@
         "devices": {
           "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.Device"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.Device"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -17390,7 +17307,7 @@
           "type": "string"
         },
         "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector",
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
           "description": "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set."
         },
         "perDeviceNodeSelection": {
@@ -17398,13 +17315,13 @@
           "type": "boolean"
         },
         "pool": {
-          "$ref": "#/$defs/io.k8s.api.resource.v1beta2.ResourcePool",
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.ResourcePool",
           "description": "Pool describes the pool that this ResourceSlice belongs to."
         },
         "sharedCounters": {
           "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.resource.v1beta2.CounterSet"
+            "$ref": "#/definitions/io.k8s.api.resource.v1beta2.CounterSet"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -17430,11 +17347,11 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PriorityClass"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PriorityClass"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "preemptionPolicy": {
@@ -17467,17 +17384,17 @@
         "items": {
           "description": "items is the list of PriorityClasses",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.scheduling.v1.PriorityClass"
+            "$ref": "#/definitions/io.k8s.api.scheduling.v1.PriorityClass"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["PriorityClassList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["PriorityClassList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -17500,15 +17417,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CSIDriver"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CSIDriver"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.storage.v1.CSIDriverSpec",
+          "$ref": "#/definitions/io.k8s.api.storage.v1.CSIDriverSpec",
           "description": "spec represents the specification of the CSI Driver."
         }
       },
@@ -17532,17 +17449,17 @@
         "items": {
           "description": "items is the list of CSIDriver",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storage.v1.CSIDriver"
+            "$ref": "#/definitions/io.k8s.api.storage.v1.CSIDriver"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CSIDriverList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CSIDriverList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -17591,7 +17508,7 @@
         "tokenRequests": {
           "description": "tokenRequests indicates the CSI driver needs pods' service account tokens it is mounting volume for to do necessary authentication. Kubelet will pass the tokens in VolumeContext in the CSI NodePublishVolume calls. The CSI driver should parse and validate the following VolumeContext: \"csi.storage.k8s.io/serviceAccount.tokens\": {\n  \"<audience>\": {\n    \"token\": <token>,\n    \"expirationTimestamp\": <expiration timestamp in RFC3339>,\n  },\n  ...\n}\n\nNote: Audience in each TokenRequest should be different and at most one token is empty string. To receive a new token after expiry, RequiresRepublish can be used to trigger NodePublishVolume periodically.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storage.v1.TokenRequest"
+            "$ref": "#/definitions/io.k8s.api.storage.v1.TokenRequest"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -17616,15 +17533,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CSINode"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CSINode"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. metadata.name must be the Kubernetes node name."
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.storage.v1.CSINodeSpec",
+          "$ref": "#/definitions/io.k8s.api.storage.v1.CSINodeSpec",
           "description": "spec is the specification of CSINode"
         }
       },
@@ -17642,7 +17559,7 @@
       "description": "CSINodeDriver holds information about the specification of one CSI driver installed on a node",
       "properties": {
         "allocatable": {
-          "$ref": "#/$defs/io.k8s.api.storage.v1.VolumeNodeResources",
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeNodeResources",
           "description": "allocatable represents the volume resources of a node that are available for scheduling. This field is beta."
         },
         "name": {
@@ -17675,17 +17592,17 @@
         "items": {
           "description": "items is the list of CSINode",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storage.v1.CSINode"
+            "$ref": "#/definitions/io.k8s.api.storage.v1.CSINode"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CSINodeList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CSINodeList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -17705,7 +17622,7 @@
         "drivers": {
           "description": "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storage.v1.CSINodeDriver"
+            "$ref": "#/definitions/io.k8s.api.storage.v1.CSINodeDriver"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["name"],
@@ -17725,24 +17642,24 @@
           "type": "string"
         },
         "capacity": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "capacity is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.\n\nThe semantic is currently (CSI spec 1.2) defined as: The available capacity, in bytes, of the storage that can be used to provision volumes. If not set, that information is currently unavailable."
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CSIStorageCapacity"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CSIStorageCapacity"]
         },
         "maximumVolumeSize": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
           "description": "maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.\n\nThis is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim."
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. The name has no particular meaning. It must be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.\n\nObjects are namespaced.\n\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "nodeTopology": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
           "description": "nodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable."
         },
         "storageClassName": {
@@ -17770,17 +17687,17 @@
         "items": {
           "description": "items is the list of CSIStorageCapacity objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storage.v1.CSIStorageCapacity"
+            "$ref": "#/definitions/io.k8s.api.storage.v1.CSIStorageCapacity"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CSIStorageCapacityList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CSIStorageCapacityList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -17804,7 +17721,7 @@
         "allowedTopologies": {
           "description": "allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.TopologySelectorTerm"
+            "$ref": "#/definitions/io.k8s.api.core.v1.TopologySelectorTerm"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -17815,11 +17732,11 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["StorageClass"],
-          "type": "string"
+          "type": "string",
+          "enum": ["StorageClass"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "mountOptions": {
@@ -17870,17 +17787,17 @@
         "items": {
           "description": "items is the list of StorageClasses",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storage.v1.StorageClass"
+            "$ref": "#/definitions/io.k8s.api.storage.v1.StorageClass"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["StorageClassList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["StorageClassList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -17919,19 +17836,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["VolumeAttachment"],
-          "type": "string"
+          "type": "string",
+          "enum": ["VolumeAttachment"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.storage.v1.VolumeAttachmentSpec",
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeAttachmentSpec",
           "description": "spec represents specification of the desired attach/detach volume behavior. Populated by the Kubernetes system."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.storage.v1.VolumeAttachmentStatus",
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeAttachmentStatus",
           "description": "status represents status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher."
         }
       },
@@ -17955,17 +17872,17 @@
         "items": {
           "description": "items is the list of VolumeAttachments",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storage.v1.VolumeAttachment"
+            "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeAttachment"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["VolumeAttachmentList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["VolumeAttachmentList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -17983,7 +17900,7 @@
       "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in the future we may allow also inline volumes in pods. Exactly one member can be set.",
       "properties": {
         "inlineVolumeSpec": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeSpec",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeSpec",
           "description": "inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is beta-level and is only honored by servers that enabled the CSIMigration feature."
         },
         "persistentVolumeName": {
@@ -18005,7 +17922,7 @@
           "type": "string"
         },
         "source": {
-          "$ref": "#/$defs/io.k8s.api.storage.v1.VolumeAttachmentSource",
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeAttachmentSource",
           "description": "source represents the volume that should be attached."
         }
       },
@@ -18016,7 +17933,7 @@
       "description": "VolumeAttachmentStatus is the status of a VolumeAttachment request.",
       "properties": {
         "attachError": {
-          "$ref": "#/$defs/io.k8s.api.storage.v1.VolumeError",
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeError",
           "description": "attachError represents the last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher."
         },
         "attached": {
@@ -18031,7 +17948,7 @@
           "type": "object"
         },
         "detachError": {
-          "$ref": "#/$defs/io.k8s.api.storage.v1.VolumeError",
+          "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeError",
           "description": "detachError represents the last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher."
         }
       },
@@ -18051,7 +17968,7 @@
           "type": "string"
         },
         "time": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "time represents the time the error was encountered."
         }
       },
@@ -18081,11 +17998,11 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["VolumeAttributesClass"],
-          "type": "string"
+          "type": "string",
+          "enum": ["VolumeAttributesClass"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "parameters": {
@@ -18116,17 +18033,17 @@
         "items": {
           "description": "items is the list of VolumeAttributesClass objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storage.v1alpha1.VolumeAttributesClass"
+            "$ref": "#/definitions/io.k8s.api.storage.v1alpha1.VolumeAttributesClass"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["VolumeAttributesClassList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["VolumeAttributesClassList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -18153,11 +18070,11 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["VolumeAttributesClass"],
-          "type": "string"
+          "type": "string",
+          "enum": ["VolumeAttributesClass"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "parameters": {
@@ -18188,17 +18105,17 @@
         "items": {
           "description": "items is the list of VolumeAttributesClass objects.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storage.v1beta1.VolumeAttributesClass"
+            "$ref": "#/definitions/io.k8s.api.storage.v1beta1.VolumeAttributesClass"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["VolumeAttributesClassList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["VolumeAttributesClassList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -18234,7 +18151,7 @@
       "description": "Describes the state of a migration at a certain point.",
       "properties": {
         "lastUpdateTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "The last time this condition was updated."
         },
         "message": {
@@ -18266,19 +18183,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["StorageVersionMigration"],
-          "type": "string"
+          "type": "string",
+          "enum": ["StorageVersionMigration"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.api.storagemigration.v1alpha1.StorageVersionMigrationSpec",
+          "$ref": "#/definitions/io.k8s.api.storagemigration.v1alpha1.StorageVersionMigrationSpec",
           "description": "Specification of the migration."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.api.storagemigration.v1alpha1.StorageVersionMigrationStatus",
+          "$ref": "#/definitions/io.k8s.api.storagemigration.v1alpha1.StorageVersionMigrationStatus",
           "description": "Status of the migration."
         }
       },
@@ -18301,7 +18218,7 @@
         "items": {
           "description": "Items is the list of StorageVersionMigration",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storagemigration.v1alpha1.StorageVersionMigration"
+            "$ref": "#/definitions/io.k8s.api.storagemigration.v1alpha1.StorageVersionMigration"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -18311,11 +18228,11 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["StorageVersionMigrationList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["StorageVersionMigrationList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -18337,7 +18254,7 @@
           "type": "string"
         },
         "resource": {
-          "$ref": "#/$defs/io.k8s.api.storagemigration.v1alpha1.GroupVersionResource",
+          "$ref": "#/definitions/io.k8s.api.storagemigration.v1alpha1.GroupVersionResource",
           "description": "The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable."
         }
       },
@@ -18350,7 +18267,7 @@
         "conditions": {
           "description": "The latest available observations of the migration's current state.",
           "items": {
-            "$ref": "#/$defs/io.k8s.api.storagemigration.v1alpha1.MigrationCondition"
+            "$ref": "#/definitions/io.k8s.api.storagemigration.v1alpha1.MigrationCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -18405,7 +18322,7 @@
           "type": "string"
         },
         "webhook": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookConversion",
           "description": "webhook describes how to call the conversion webhook. Required when `strategy` is set to `\"Webhook\"`."
         }
       },
@@ -18421,19 +18338,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CustomResourceDefinition"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CustomResourceDefinition"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec",
           "description": "spec describes how the user wants the resources to appear"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionStatus",
           "description": "status indicates the actual state of the CustomResourceDefinition"
         }
       },
@@ -18451,7 +18368,7 @@
       "description": "CustomResourceDefinitionCondition contains details for the current condition of this pod.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastTransitionTime last time the condition transitioned from one status to another."
         },
         "message": {
@@ -18484,17 +18401,17 @@
         "items": {
           "description": "items list individual CustomResourceDefinition objects",
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["CustomResourceDefinitionList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["CustomResourceDefinitionList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -18551,7 +18468,7 @@
       "description": "CustomResourceDefinitionSpec describes how a user wants their resource to appear",
       "properties": {
         "conversion": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceConversion",
           "description": "conversion defines conversion settings for the CRD."
         },
         "group": {
@@ -18559,7 +18476,7 @@
           "type": "string"
         },
         "names": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames",
           "description": "names specify the resource and kind names for the custom resource."
         },
         "preserveUnknownFields": {
@@ -18573,7 +18490,7 @@
         "versions": {
           "description": "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -18586,13 +18503,13 @@
       "description": "CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition",
       "properties": {
         "acceptedNames": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionNames",
           "description": "acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec."
         },
         "conditions": {
           "description": "conditions indicate state for particular aspects of a CustomResourceDefinition",
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -18615,7 +18532,7 @@
         "additionalPrinterColumns": {
           "description": "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -18629,17 +18546,17 @@
           "type": "string"
         },
         "name": {
-          "description": "name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.",
+          "description": "name is the version name, e.g. \u201cv1\u201d, \u201cv2beta1\u201d, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.",
           "type": "string"
         },
         "schema": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceValidation",
           "description": "schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource."
         },
         "selectableFields": {
           "description": "selectableFields specifies paths to fields that may be used as field selectors. A maximum of 8 selectable fields are allowed. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors",
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.SelectableField"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.SelectableField"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -18653,7 +18570,7 @@
           "type": "boolean"
         },
         "subresources": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresources",
           "description": "subresources specify what subresources this version of the defined custom resource have."
         }
       },
@@ -18687,11 +18604,11 @@
       "description": "CustomResourceSubresources defines the status and scale subresources for CustomResources.",
       "properties": {
         "scale": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceScale",
           "description": "scale indicates the custom resource should serve a `/scale` subresource that returns an `autoscaling/v1` Scale object."
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceSubresourceStatus",
           "description": "status indicates the custom resource should serve a `/status` subresource. When enabled: 1. requests to the custom resource primary endpoint ignore changes to the `status` stanza of the object. 2. requests to the custom resource `/status` subresource ignore changes to anything other than the `status` stanza of the object."
         }
       },
@@ -18701,7 +18618,7 @@
       "description": "CustomResourceValidation is a list of validation methods for CustomResources.",
       "properties": {
         "openAPIV3Schema": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps",
           "description": "openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning."
         }
       },
@@ -18732,38 +18649,38 @@
           "type": "string"
         },
         "additionalItems": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
         },
         "additionalProperties": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrBool"
         },
         "allOf": {
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "anyOf": {
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "default": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON",
           "description": "default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. Defaulting requires spec.preserveUnknownFields to be false."
         },
         "definitions": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
           },
           "type": "object"
         },
         "dependencies": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrStringArray"
           },
           "type": "object"
         },
@@ -18772,13 +18689,13 @@
         },
         "enum": {
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "example": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSON"
         },
         "exclusiveMaximum": {
           "type": "boolean"
@@ -18787,7 +18704,7 @@
           "type": "boolean"
         },
         "externalDocs": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation"
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ExternalDocumentation"
         },
         "format": {
           "description": "format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:\n\n- bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like \"0321751043\" or \"978-0321751041\" - isbn10: an ISBN10 number string like \"0321751043\" - isbn13: an ISBN13 number string like \"978-0321751041\" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\\\d{3})\\\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\\\d{3}[- ]?\\\\d{2}[- ]?\\\\d{4}$ - hexcolor: an hexadecimal color code like \"#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like \"rgb(255,255,2559\" - byte: base64 encoded binary data - password: any kind of string - date: a date string like \"2006-01-02\" as defined by full-date in RFC3339 - duration: a duration string like \"22 ns\" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like \"2014-12-15T19:30:20.000Z\" as defined by date-time in RFC3339.",
@@ -18797,7 +18714,7 @@
           "type": "string"
         },
         "items": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray"
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaPropsOrArray"
         },
         "maxItems": {
           "format": "int64",
@@ -18836,14 +18753,14 @@
           "type": "number"
         },
         "not": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
         },
         "nullable": {
           "type": "boolean"
         },
         "oneOf": {
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -18853,13 +18770,13 @@
         },
         "patternProperties": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
           },
           "type": "object"
         },
         "properties": {
           "additionalProperties": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps"
           },
           "type": "object"
         },
@@ -18910,7 +18827,7 @@
         "x-kubernetes-validations": {
           "description": "x-kubernetes-validations describes a list of validation rules written in the CEL expression language.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule"
+            "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["rule"],
@@ -19005,7 +18922,7 @@
           "type": "string"
         },
         "service": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ServiceReference",
           "description": "service is a reference to the service for this webhook. Either service or url must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`."
         },
         "url": {
@@ -19019,7 +18936,7 @@
       "description": "WebhookConversion describes how to call a conversion webhook",
       "properties": {
         "clientConfig": {
-          "$ref": "#/$defs/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig",
+          "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.WebhookClientConfig",
           "description": "clientConfig is the instructions for how to call the webhook if strategy is `Webhook`."
         },
         "conversionReviewVersions": {
@@ -19053,21 +18970,21 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["APIGroup"],
-          "type": "string"
+          "type": "string",
+          "enum": ["APIGroup"]
         },
         "name": {
           "description": "name is the name of the group.",
           "type": "string"
         },
         "preferredVersion": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery",
           "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
         },
         "serverAddressByClientCIDRs": {
           "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -19075,7 +18992,7 @@
         "versions": {
           "description": "versions are the versions supported in this group.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -19101,15 +19018,15 @@
         "groups": {
           "description": "groups is a list of APIGroup.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["APIGroupList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["APIGroupList"]
         }
       },
       "required": ["groups"],
@@ -19193,13 +19110,13 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["APIResourceList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["APIResourceList"]
         },
         "resources": {
           "description": "resources contains the name of the resources and if they are namespaced.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -19224,13 +19141,13 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["APIVersions"],
-          "type": "string"
+          "type": "string",
+          "enum": ["APIVersions"]
         },
         "serverAddressByClientCIDRs": {
           "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -19258,7 +19175,7 @@
       "description": "Condition contains details for one aspect of the current state of this API Resource.",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable."
         },
         "message": {
@@ -19312,15 +19229,15 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["DeleteOptions"],
-          "type": "string"
+          "type": "string",
+          "enum": ["DeleteOptions"]
         },
         "orphanDependents": {
           "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
           "type": "boolean"
         },
         "preconditions": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions",
           "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned."
         },
         "propagationPolicy": {
@@ -19685,7 +19602,7 @@
         "matchExpressions": {
           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -19759,7 +19676,7 @@
           "type": "string"
         },
         "fieldsV1": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1",
           "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type."
         },
         "manager": {
@@ -19775,7 +19692,7 @@
           "type": "string"
         },
         "time": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over."
         }
       },
@@ -19797,7 +19714,7 @@
           "type": "object"
         },
         "creationTimestamp": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "deletionGracePeriodSeconds": {
@@ -19806,7 +19723,7 @@
           "type": "integer"
         },
         "deletionTimestamp": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "finalizers": {
@@ -19837,7 +19754,7 @@
         "managedFields": {
           "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -19853,7 +19770,7 @@
         "ownerReferences": {
           "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["uid"],
@@ -19954,21 +19871,21 @@
           "type": "integer"
         },
         "details": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails",
           "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
           "x-kubernetes-list-type": "atomic"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["Status"],
-          "type": "string"
+          "type": "string",
+          "enum": ["Status"]
         },
         "message": {
           "description": "A human-readable description of the status of this operation.",
           "type": "string"
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
         },
         "reason": {
@@ -20013,7 +19930,7 @@
         "causes": {
           "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
           "items": {
-            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
           },
           "type": "array",
           "x-kubernetes-list-type": "atomic"
@@ -20051,7 +19968,7 @@
       "description": "Event represents a single event to a watched resource.",
       "properties": {
         "object": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
           "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context."
         },
         "type": {
@@ -20453,19 +20370,19 @@
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["APIService"],
-          "type": "string"
+          "type": "string",
+          "enum": ["APIService"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
           "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         },
         "spec": {
-          "$ref": "#/$defs/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceSpec",
+          "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceSpec",
           "description": "Spec contains information for locating and communicating with a server"
         },
         "status": {
-          "$ref": "#/$defs/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceStatus",
+          "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceStatus",
           "description": "Status contains derived information about an API server"
         }
       },
@@ -20482,7 +20399,7 @@
       "description": "APIServiceCondition describes the state of an APIService at a particular point",
       "properties": {
         "lastTransitionTime": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
           "description": "Last time the condition transitioned from one status to another."
         },
         "message": {
@@ -20515,17 +20432,17 @@
         "items": {
           "description": "Items is the list of APIService",
           "items": {
-            "$ref": "#/$defs/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService"
+            "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService"
           },
           "type": "array"
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "enum": ["APIServiceList"],
-          "type": "string"
+          "type": "string",
+          "enum": ["APIServiceList"]
         },
         "metadata": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
           "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
         }
       },
@@ -20562,7 +20479,7 @@
           "type": "boolean"
         },
         "service": {
-          "$ref": "#/$defs/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ServiceReference",
+          "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ServiceReference",
           "description": "Service is a reference to the service for this API server.  It must communicate on port 443. If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled."
         },
         "version": {
@@ -20584,7 +20501,7 @@
         "conditions": {
           "description": "Current service state of apiService.",
           "items": {
-            "$ref": "#/$defs/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition"
+            "$ref": "#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": ["type"],
@@ -20614,1196 +20531,5 @@
       },
       "type": "object"
     }
-  },
-  "$id": "https://raw.githubusercontent.com/Cloudzero/cloudzero-agent/refs/heads/develop/helm/values.schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "additionalProperties": false,
-  "properties": {
-    "aggregator": {
-      "additionalProperties": false,
-      "properties": {
-        "affinity": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Affinity"
-        },
-        "cloudzero": {
-          "additionalProperties": false,
-          "properties": {
-            "rotateInterval": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration"
-            },
-            "sendInterval": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration"
-            },
-            "sendTimeout": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration"
-            }
-          },
-          "type": "object"
-        },
-        "collector": {
-          "additionalProperties": false,
-          "properties": {
-            "port": {
-              "type": "integer"
-            },
-            "resources": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
-            }
-          },
-          "type": "object"
-        },
-        "database": {
-          "additionalProperties": false,
-          "properties": {
-            "compressionLevel": {
-              "maximum": 11,
-              "minimum": 0,
-              "type": "integer"
-            },
-            "costMaxInterval": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration"
-            },
-            "emptyDir": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.EmptyDirVolumeSource"
-            },
-            "maxRecords": {
-              "type": "integer"
-            },
-            "observabilityMaxInterval": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration"
-            },
-            "purgeRules": {
-              "additionalProperties": false,
-              "properties": {
-                "lazy": {
-                  "type": "boolean"
-                },
-                "metricsOlderThan": {
-                  "$ref": "#/$defs/com.cloudzero.agent.duration"
-                },
-                "percent": {
-                  "type": "integer"
-                }
-              },
-              "type": "object"
-            }
-          },
-          "type": "object"
-        },
-        "image": {
-          "$ref": "#/$defs/com.cloudzero.agent.image",
-          "deprecated": true
-        },
-        "logging": {
-          "additionalProperties": false,
-          "properties": {
-            "level": {
-              "enum": ["debug", "info", "warn", "error"],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "mountRoot": {
-          "type": "string"
-        },
-        "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec/properties/nodeSelector"
-        },
-        "profiling": {
-          "type": "boolean"
-        },
-        "shipper": {
-          "additionalProperties": false,
-          "properties": {
-            "port": {
-              "type": "integer"
-            },
-            "resources": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
-            }
-          },
-          "type": "object"
-        },
-        "tolerations": {
-          "$ref": "#/$defs/com.cloudzero.agent.tolerations"
-        }
-      },
-      "type": "object"
-    },
-    "apiKey": {
-      "description": "The CloudZero API key.\n",
-      "type": ["string", "null"]
-    },
-    "cloudAccountId": {
-      "description": "The CloudZero Cloud Account ID.\n",
-      "minLength": 1,
-      "type": "string"
-    },
-    "clusterName": {
-      "description": "The name of the Kubernetes cluster.\n",
-      "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,251}[a-zA-Z0-9])?$",
-      "type": "string"
-    },
-    "commonMetaLabels": {
-      "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
-      "default": {},
-      "deprecated": true,
-      "description": "This field is deprecated. Please use `defaults.labels` instead.\n\nLabels to be added to all resources in the chart. These labels are merged\nwith `defaults.labels` and component-specific labels (e.g.,\n`components.aggregator.labels`).\n",
-      "examples": [
-        {
-          "environment": "production",
-          "team": "platform"
-        }
-      ],
-      "title": "Common labels applied to all resources"
-    },
-    "components": {
-      "additionalProperties": false,
-      "description": "Configuration for individual components of the CloudZero agent.\n",
-      "properties": {
-        "agent": {
-          "additionalProperties": false,
-          "description": "The CloudZero Agent.\nThe Agent is responsible for gathering metrics needed by CloudZero.\nThese metrics are then sent to the Aggregator.\n",
-          "properties": {
-            "image": {
-              "$ref": "#/$defs/com.cloudzero.agent.image",
-              "description": "Container image configuration for the agent.\n"
-            },
-            "podDisruptionBudget": {
-              "$ref": "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudget",
-              "description": "Pod disruption budget configuration for the agent.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/workloads/pods/disruptions/\n"
-            },
-            "replicas": {
-              "description": "Number of replicas to deploy.\n",
-              "type": "integer"
-            },
-            "tolerations": {
-              "$ref": "#/$defs/com.cloudzero.agent.tolerations",
-              "description": "Tolerations configuration for the agent pods.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/configuration/taint-and-toleration/\n"
-            }
-          },
-          "type": "object"
-        },
-        "aggregator": {
-          "additionalProperties": false,
-          "description": "The CloudZero Aggregator (\"Gator\"). The Aggregator provides a service\nwhich accepts metrics (e.g., from the Agent and the Webhook Server),\naggregates them, caches them, and sends them to CloudZero for\nprocessing.\n",
-          "properties": {
-            "podDisruptionBudget": {
-              "$ref": "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudget",
-              "description": "Pod disruption budget configuration for the aggregator.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/workloads/pods/disruptions/\n"
-            },
-            "replicas": {
-              "additionalProperties": false,
-              "description": "Number of replicas to deploy.\n",
-              "type": ["integer", "null"]
-            },
-            "tolerations": {
-              "$ref": "#/$defs/com.cloudzero.agent.tolerations",
-              "description": "Tolerations configuration for the aggregator pods.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/configuration/taint-and-toleration/\n"
-            }
-          },
-          "type": "object"
-        },
-        "kubectl": {
-          "additionalProperties": false,
-          "description": "A container which includes the `kubectl` executable. This is used\nmostly to gather information about the cluster during an\ninitialization phase.\n",
-          "properties": {
-            "image": {
-              "$ref": "#/$defs/com.cloudzero.agent.image",
-              "description": "Container image configuration for the kubectl container.\n"
-            }
-          },
-          "type": "object"
-        },
-        "prometheus": {
-          "additionalProperties": false,
-          "description": "Configuration for the Prometheus component.\n",
-          "properties": {
-            "image": {
-              "$ref": "#/$defs/com.cloudzero.agent.image",
-              "description": "Container image configuration for Prometheus.\n"
-            }
-          },
-          "type": "object"
-        },
-        "prometheusReloader": {
-          "additionalProperties": false,
-          "description": "Configuration for the Prometheus reloader component.\n",
-          "properties": {
-            "image": {
-              "$ref": "#/$defs/com.cloudzero.agent.image",
-              "description": "Container image configuration for the Prometheus reloader.\n"
-            }
-          },
-          "type": "object"
-        },
-        "webhookServer": {
-          "additionalProperties": false,
-          "description": "Configuration for the webhook server component.\n",
-          "properties": {
-            "podDisruptionBudget": {
-              "$ref": "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudget",
-              "description": "Pod disruption budget configuration for the webhook server.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/workloads/pods/disruptions/\n"
-            },
-            "replicas": {
-              "additionalProperties": false,
-              "description": "Number of replicas to deploy.\n",
-              "type": ["integer", "null"]
-            }
-          },
-          "type": "object"
-        }
-      },
-      "type": "object"
-    },
-    "configmapReload": {
-      "deprecated": true,
-      "description": "This field is deprecated.\n\nThis field is used to configure the reloading of ConfigMaps. It allows you\nto specify settings for how and when ConfigMaps should be reloaded.\n",
-      "properties": {
-        "prometheus": {
-          "additionalProperties": false,
-          "properties": {
-            "enabled": {
-              "default": true,
-              "type": "boolean"
-            },
-            "image": {
-              "$ref": "#/$defs/com.cloudzero.agent.image"
-            },
-            "resources": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "title": "Configuration for ConfigMap reloading",
-      "type": "object"
-    },
-    "defaults": {
-      "additionalProperties": false,
-      "description": "Default settings for components, and globals.\n",
-      "properties": {
-        "affinity": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Affinity",
-          "description": "Affinity settings to be added to all resources.\n"
-        },
-        "annotations": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-          "description": "Annotations to be added to all resources.\n"
-        },
-        "dns": {
-          "$ref": "#/$defs/com.cloudzero.agent.dns",
-          "description": "DNS settings for all pods.\n"
-        },
-        "federation": {
-          "additionalProperties": false,
-          "description": "Federated mode deploys the agent as a DaemonSet, with each node in the\ncluster running its own metrics collector.\n",
-          "properties": {
-            "enabled": {
-              "description": "Whether to enable federated mode.\n",
-              "type": "boolean"
-            }
-          },
-          "type": "object"
-        },
-        "image": {
-          "$ref": "#/$defs/com.cloudzero.agent.image",
-          "description": "The default image settings which will be fallen back on for all\ncomponents.\n"
-        },
-        "labels": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
-          "description": "Labels to be added to all resources.\n"
-        },
-        "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
-          "description": "Node Selector to be added to all resources.\n"
-        },
-        "priorityClassName": {
-          "description": "Priority class name to be used for all deployments and jobs.\n",
-          "type": ["string", "null"]
-        },
-        "tolerations": {
-          "$ref": "#/$defs/com.cloudzero.agent.tolerations",
-          "description": "Tolerations to be added to all resources.\n"
-        }
-      },
-      "type": "object"
-    },
-    "existingSecretName": {
-      "description": "The name of an existing Kubernetes secret containing the API key.\n",
-      "type": ["string", "null"]
-    },
-    "host": {
-      "description": "The CloudZero API host to connect to (e.g. api.cloudzero.com).\n",
-      "minLength": 1,
-      "type": "string"
-    },
-    "imagePullSecrets": {
-      "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec/properties/imagePullSecrets",
-      "deprecated": true,
-      "description": "This field is deprecated. Please use `defaults.image.pullSecrets` instead.\n"
-    },
-    "initBackfillJob": {
-      "additionalProperties": false,
-      "description": "Configuration for the init-backfill-job, which is used to backfill data\nfrom the cluster to CloudZero.\n",
-      "properties": {
-        "annotations": {
-          "additionalProperties": true,
-          "description": "Annotations to add to the init-backfill-job.\n",
-          "type": "object"
-        },
-        "enabled": {
-          "default": true,
-          "description": "Whether to enable the init-backfill-job.\n",
-          "type": "boolean"
-        },
-        "image": {
-          "$ref": "#/$defs/com.cloudzero.agent.image",
-          "description": "Container image configuration for the init-backfill-job.\n"
-        },
-        "tolerations": {
-          "$ref": "#/$defs/com.cloudzero.agent.tolerations",
-          "description": "Tolerations to be added to the init-backfill-job.\n"
-        }
-      },
-      "type": "object"
-    },
-    "initCertJob": {
-      "additionalProperties": false,
-      "description": "Configuration for the init-cert-job, which is used to initialize\ncertificates for the webhook server.\n",
-      "properties": {
-        "annotations": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-          "description": "Annotations to add to the init-cert-job.\n"
-        },
-        "enabled": {
-          "default": true,
-          "description": "Whether to enable the init-cert-job.\n",
-          "type": "boolean"
-        },
-        "image": {
-          "$ref": "#/$defs/com.cloudzero.agent.image",
-          "description": "Container image configuration for the init-cert-job.\n"
-        },
-        "rbac": {
-          "description": "RBAC configuration for the init-cert-job.\n",
-          "properties": {
-            "clusterRoleBindingName": {
-              "description": "Name of the cluster role binding to create.\n",
-              "type": "string"
-            },
-            "clusterRoleName": {
-              "description": "Name of the cluster role to create.\n",
-              "type": "string"
-            },
-            "create": {
-              "default": true,
-              "description": "Whether to create RBAC resources.\n",
-              "type": "boolean"
-            },
-            "serviceAccountName": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec/properties/serviceAccountName",
-              "description": "Name of the service account to create.\n"
-            }
-          },
-          "type": "object"
-        },
-        "tolerations": {
-          "$ref": "#/$defs/com.cloudzero.agent.tolerations",
-          "description": "Tolerations to be added to the init-cert-job.\n"
-        }
-      },
-      "type": "object"
-    },
-    "insightsController": {
-      "additionalProperties": false,
-      "description": "Configuration for the webhook server (née Insights Controller), which\ncollects and processes Kubernetes resource metadata for cost attribution\nand analysis.\n",
-      "properties": {
-        "ConfigMapNameOverride": {
-          "description": "Override the name of the ConfigMap used for configuration.\n",
-          "type": ["string", "null"]
-        },
-        "annotations": {
-          "additionalProperties": false,
-          "description": "Configuration for collecting annotations from Kubernetes resources.\n",
-          "properties": {
-            "enabled": {
-              "default": false,
-              "description": "Whether to enable collection of annotations for cost attribution\ndimensions.\n",
-              "type": "boolean"
-            },
-            "patterns": {
-              "description": "List of Go-style regular expressions used to filter desired\nannotations. Caution: The CloudZero system has a limit of 300\nlabels and annotations, so it is advisable to provide a specific\nlist of required annotations rather than a wildcard.\n",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "resources": {
-              "additionalProperties": false,
-              "description": "Specify which resources to collect annotations from.\n",
-              "properties": {
-                "cronjobs": {
-                  "default": false,
-                  "description": "Whether to collect annotations from CronJobs.\n",
-                  "type": "boolean"
-                },
-                "daemonsets": {
-                  "default": false,
-                  "description": "Whether to collect annotations from DaemonSets.\n",
-                  "type": "boolean"
-                },
-                "deployments": {
-                  "default": false,
-                  "description": "Whether to collect annotations from Deployments.\n",
-                  "type": "boolean"
-                },
-                "jobs": {
-                  "default": false,
-                  "description": "Whether to collect annotations from Jobs.\n",
-                  "type": "boolean"
-                },
-                "namespaces": {
-                  "default": true,
-                  "description": "Whether to collect annotations from Namespaces.\n",
-                  "type": "boolean"
-                },
-                "nodes": {
-                  "default": false,
-                  "description": "Whether to collect annotations from Nodes.\n",
-                  "type": "boolean"
-                },
-                "pods": {
-                  "default": true,
-                  "description": "Whether to collect annotations from Pods.\n",
-                  "type": "boolean"
-                },
-                "statefulsets": {
-                  "default": false,
-                  "description": "Whether to collect annotations from StatefulSets.\n",
-                  "type": "boolean"
-                }
-              },
-              "type": "object"
-            }
-          },
-          "type": "object"
-        },
-        "configurationMountPath": {
-          "description": "Path where the configuration will be mounted in the container.\n",
-          "type": ["string", "null"]
-        },
-        "enabled": {
-          "default": true,
-          "description": "Whether to enable the insights controller. It is strongly recommended\nthat this feature be enabled as it provides important functionality.\n",
-          "type": "boolean"
-        },
-        "labels": {
-          "additionalProperties": false,
-          "description": "Configuration for collecting labels from Kubernetes resources.\n",
-          "properties": {
-            "enabled": {
-              "default": true,
-              "description": "Whether to enable collection of specific labels for cost\nattribution dimensions. It is strongly recommended that this\nfeature be enabled as it provides important functionality.\n",
-              "type": "boolean"
-            },
-            "patterns": {
-              "description": "List of Go-style regular expressions used to filter desired\nlabels. Caution: The CloudZero system has a limit of 300 labels\nand annotations, so it is advisable to provide a specific list of\nrequired labels rather than a wildcard.\n",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "resources": {
-              "additionalProperties": false,
-              "description": "Specify which resources to collect labels from.\n",
-              "properties": {
-                "cronjobs": {
-                  "default": false,
-                  "description": "Whether to collect labels from CronJobs.\n",
-                  "type": "boolean"
-                },
-                "daemonsets": {
-                  "default": false,
-                  "description": "Whether to collect labels from DaemonSets.\n",
-                  "type": "boolean"
-                },
-                "deployments": {
-                  "default": false,
-                  "description": "Whether to collect labels from Deployments.\n",
-                  "type": "boolean"
-                },
-                "jobs": {
-                  "default": false,
-                  "description": "Whether to collect labels from Jobs.\n",
-                  "type": "boolean"
-                },
-                "namespaces": {
-                  "default": true,
-                  "description": "Whether to collect labels from Namespaces.\n",
-                  "type": "boolean"
-                },
-                "nodes": {
-                  "default": false,
-                  "description": "Whether to collect labels from Nodes.\n",
-                  "type": "boolean"
-                },
-                "pods": {
-                  "default": true,
-                  "description": "Whether to collect labels from Pods.\n",
-                  "type": "boolean"
-                },
-                "statefulsets": {
-                  "default": false,
-                  "description": "Whether to collect labels from StatefulSets.\n",
-                  "type": "boolean"
-                }
-              },
-              "type": "object"
-            }
-          },
-          "type": "object"
-        },
-        "podAnnotations": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-          "description": "Annotations to add to the insights controller pods.\n"
-        },
-        "podLabels": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels",
-          "description": "Labels to add to the insights controller pods.\n"
-        },
-        "resources": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements",
-          "description": "Resource requirements and limits for the insights controller.\n"
-        },
-        "server": {
-          "additionalProperties": false,
-          "description": "Configuration for the webhook server component.\n",
-          "properties": {
-            "affinity": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.Affinity",
-              "description": "Affinity rules for the webhook server pods.\n"
-            },
-            "deploymentAnnotations": {
-              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-              "description": "Annotations to add to the webhook server Deployment.\n"
-            },
-            "healthCheck": {
-              "additionalProperties": false,
-              "description": "Configuration for the health check endpoint.\n",
-              "properties": {
-                "enabled": {
-                  "default": true,
-                  "description": "Whether to enable the health check endpoint.\n",
-                  "type": "boolean"
-                },
-                "failureThreshold": {
-                  "default": 5,
-                  "description": "Number of failed checks before marking as unhealthy.\n",
-                  "type": "integer"
-                },
-                "initialDelaySeconds": {
-                  "default": 15,
-                  "description": "Initial delay before starting health checks.\n",
-                  "type": "integer"
-                },
-                "path": {
-                  "default": "/healthz",
-                  "description": "Path for the health check endpoint.\n",
-                  "type": "string"
-                },
-                "periodSeconds": {
-                  "default": 20,
-                  "description": "Interval between health checks.\n",
-                  "type": "integer"
-                },
-                "port": {
-                  "default": 8443,
-                  "description": "Port for the health check endpoint.\n",
-                  "type": "integer"
-                },
-                "successThreshold": {
-                  "default": 1,
-                  "description": "Number of successful checks required to mark as healthy.\n",
-                  "type": "integer"
-                },
-                "timeoutSeconds": {
-                  "default": 3,
-                  "description": "Timeout for health check requests.\n",
-                  "type": "integer"
-                }
-              },
-              "type": "object"
-            },
-            "idle_timeout": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration",
-              "default": "120s",
-              "description": "Timeout for idle connections.\n"
-            },
-            "image": {
-              "$ref": "#/$defs/com.cloudzero.agent.image",
-              "description": "Container image configuration for the webhook server.\n"
-            },
-            "logging": {
-              "additionalProperties": false,
-              "description": "Configuration for logging in the webhook server.\n",
-              "properties": {
-                "level": {
-                  "default": "info",
-                  "description": "Logging level for the webhook server.\n",
-                  "enum": ["debug", "info", "warn", "error"],
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "name": {
-              "default": "webhook-server",
-              "description": "Name of the webhook server component.\n",
-              "type": "string"
-            },
-            "nodeSelector": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
-              "description": "Node selector configuration for the webhook server pods.\n"
-            },
-            "podAnnotations": {
-              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-              "description": "Annotations to add to the webhook server pods.\n"
-            },
-            "port": {
-              "default": 8443,
-              "description": "Port that the webhook server listens on.\n",
-              "type": "integer"
-            },
-            "read_timeout": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration",
-              "default": "10s",
-              "description": "Timeout for reading HTTP requests.\n"
-            },
-            "replicaCount": {
-              "deprecated": true,
-              "description": "This field is deprecated. Please use `components.webhookServer.replicaCount` instead.\n\nNumber of replicas to run for the webhook server.\n",
-              "type": ["integer", "null"]
-            },
-            "send_interval": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration",
-              "default": "1m",
-              "description": "Interval between sending data to clients.\n"
-            },
-            "send_timeout": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration",
-              "default": "1m",
-              "description": "Timeout for sending data to clients.\n"
-            },
-            "tolerations": {
-              "$ref": "#/$defs/com.cloudzero.agent.tolerations",
-              "description": "Tolerations configuration for the webhook server pods.\n"
-            },
-            "write_timeout": {
-              "$ref": "#/$defs/com.cloudzero.agent.duration",
-              "default": "10s",
-              "description": "Timeout for writing HTTP responses.\n"
-            }
-          },
-          "type": "object"
-        },
-        "service": {
-          "additionalProperties": false,
-          "description": "Configuration for the insights controller Service.\n",
-          "properties": {
-            "port": {
-              "default": 443,
-              "description": "Port that the insights controller Service listens on.\n",
-              "type": "integer"
-            }
-          },
-          "type": "object"
-        },
-        "tls": {
-          "additionalProperties": false,
-          "description": "Configuration for TLS certificates used by the insights controller.\n",
-          "properties": {
-            "caBundle": {
-              "default": "",
-              "description": "CA bundle for validating admission webhook requests. If empty, the\ndefault self-signed certificate will be used.\n",
-              "type": "string"
-            },
-            "crt": {
-              "default": "",
-              "description": "TLS certificate in PEM format. If empty, a certificate will be\ngenerated.\n",
-              "type": "string"
-            },
-            "enabled": {
-              "default": true,
-              "description": "Whether to enable TLS certificate management.\n",
-              "type": "boolean"
-            },
-            "key": {
-              "default": "",
-              "description": "TLS private key in PEM format. If empty, a key will be generated.\n",
-              "type": "string"
-            },
-            "mountPath": {
-              "default": "/etc/certs",
-              "description": "Path where the TLS certificate and key will be mounted in the\ncontainer.\n",
-              "type": "string"
-            },
-            "secret": {
-              "additionalProperties": false,
-              "description": "Configuration for the TLS certificate Secret.\n",
-              "properties": {
-                "create": {
-                  "default": true,
-                  "description": "Whether to create a Secret to store the TLS certificate and\nkey.\n",
-                  "type": "boolean"
-                },
-                "name": {
-                  "default": "",
-                  "description": "Name of the Secret to create. If empty, a name will be\ngenerated.\n",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "useCertManager": {
-              "default": false,
-              "description": "Whether to use cert-manager for certificate management. If\ndisabled, a self-signed certificate will be used.\n",
-              "type": "boolean"
-            }
-          },
-          "type": "object"
-        },
-        "volumeMounts": {
-          "description": "Additional volume mounts to add to the insights controller pods.\n",
-          "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.VolumeMount"
-          },
-          "type": "array"
-        },
-        "volumes": {
-          "description": "Additional volumes to add to the insights controller pods.\n",
-          "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.Volume"
-          },
-          "type": "array"
-        },
-        "webhooks": {
-          "additionalProperties": false,
-          "description": "Configuration for the validating admission webhook.\n",
-          "properties": {
-            "annotations": {
-              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-              "description": "Annotations to add to the validating admission webhook.\n"
-            },
-            "caInjection": {
-              "description": "Configuration for CA injection in webhooks.\n",
-              "type": ["string", "null"]
-            },
-            "namespaceSelector": {
-              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
-              "description": "Namespace selector for the validating admission webhook.\n"
-            },
-            "path": {
-              "default": "/validate",
-              "description": "Path for the validating admission webhook.\n",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "type": "object"
-    },
-    "jobConfigID": {
-      "description": "We embed a hash of the configuration in some job names, most notably the\nbackfill job. This is done so we can make sure the job gets re-run\nwhenever the configuration changes, while also preserving the job in\nKubernetes since setting a TTL can interfere with systems which attempt to\nkeep the cluster synced to the chart, such as ArgoCD.\n\nUnfortunately this can result in a lot of noise in the generated manifests\n(see tests/helm/template/), so jobConfig ID provides a way to override\nthis behavior and instead generate the same hash every time. It shouldn't\nreally be used anywhere else.\n",
-      "type": "string"
-    },
-    "kubeStateMetrics": {
-      "description": "The configuration for the kube-state-metrics chart.\n\nFor details, please see the [kube-state-metrics\nchart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics).\n",
-      "type": "object"
-    },
-    "prometheusConfig": {
-      "additionalProperties": false,
-      "description": "Prometheus configuration settings.\n",
-      "properties": {
-        "configMapAnnotations": {
-          "additionalProperties": true,
-          "description": "Annotations to add to the ConfigMap.\n",
-          "type": "object"
-        },
-        "configMapNameOverride": {
-          "description": "Override the name of the ConfigMap.\n",
-          "type": "string"
-        },
-        "configOverride": {
-          "description": "Override the entire Prometheus configuration.\n",
-          "type": "string"
-        },
-        "globalScrapeInterval": {
-          "$ref": "#/$defs/com.cloudzero.agent.duration",
-          "description": "Global scrape interval for all jobs.\n"
-        },
-        "scrapeJobs": {
-          "additionalProperties": false,
-          "description": "Scrape job configurations.\n",
-          "properties": {
-            "additionalScrapeJobs": {
-              "description": "Additional scrape jobs to add to the configuration.\n",
-              "items": {
-                "type": "object"
-              },
-              "type": "array"
-            },
-            "aggregator": {
-              "additionalProperties": false,
-              "description": "aggregator scrape job configuration.\n",
-              "properties": {
-                "enabled": {
-                  "description": "Whether to enable the aggregator scrape job.\n",
-                  "type": "boolean"
-                },
-                "scrapeInterval": {
-                  "$ref": "#/$defs/com.cloudzero.agent.duration",
-                  "description": "Scrape interval for aggregator job.\n"
-                }
-              },
-              "type": "object"
-            },
-            "cadvisor": {
-              "additionalProperties": false,
-              "description": "cadvisor scrape job configuration.\n",
-              "properties": {
-                "enabled": {
-                  "description": "Whether to enable the cadvisor scrape job.\n",
-                  "enum": [true],
-                  "type": "boolean"
-                },
-                "scrapeInterval": {
-                  "$ref": "#/$defs/com.cloudzero.agent.duration",
-                  "description": "Scrape interval for nodesCadvisor job.\n"
-                }
-              },
-              "required": ["enabled"],
-              "type": "object"
-            },
-            "kubeStateMetrics": {
-              "additionalProperties": false,
-              "description": "kube-state-metrics scrape job configuration.\n",
-              "properties": {
-                "enabled": {
-                  "description": "Whether to enable the kube-state-metrics scrape job.\n",
-                  "type": "boolean"
-                },
-                "scrapeInterval": {
-                  "$ref": "#/$defs/com.cloudzero.agent.duration",
-                  "description": "Scrape interval for kubeStateMetrics job.\n"
-                }
-              },
-              "type": "object"
-            },
-            "prometheus": {
-              "additionalProperties": false,
-              "description": "prometheus scrape job configuration.\n",
-              "properties": {
-                "enabled": {
-                  "description": "Whether to enable the prometheus scrape job.\n",
-                  "type": "boolean"
-                },
-                "scrapeInterval": {
-                  "$ref": "#/$defs/com.cloudzero.agent.duration",
-                  "description": "Scrape interval for prometheus job.\n"
-                }
-              },
-              "type": "object"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "type": "object"
-    },
-    "rbac": {
-      "additionalProperties": false,
-      "description": "Configuration for the RBAC resources in the chart (e.g., ClusterRole,\nClusterRoleBinding, Role, RoleBinding, etc.).\n",
-      "properties": {
-        "create": {
-          "default": true,
-          "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
-    "region": {
-      "description": "The cloud provider region.\n",
-      "minLength": 1,
-      "type": "string"
-    },
-    "secretAnnotations": {
-      "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-      "additionalProperties": true,
-      "default": {},
-      "deprecated": true,
-      "description": "Annotations to be added to all Secret resources created by the chart.\nThese annotations are merged with `defaults.annotations` and\ncomponent-specific annotations.\n"
-    },
-    "server": {
-      "additionalProperties": false,
-      "description": "Configuration for the server component.\n",
-      "properties": {
-        "affinity": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.Affinity",
-          "description": "Affinity rules for pod scheduling.\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity\n"
-        },
-        "agentMode": {
-          "default": true,
-          "description": "Whether the server is running in agent mode.\n",
-          "type": "boolean"
-        },
-        "args": {
-          "default": [
-            "--config.file=/etc/config/prometheus/configmaps/prometheus.yml",
-            "--web.enable-lifecycle",
-            "--web.console.libraries=/etc/prometheus/console_libraries",
-            "--web.console.templates=/etc/prometheus/consoles"
-          ],
-          "description": "Command-line arguments to pass to the server.\n",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "deploymentAnnotations": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-          "description": "Annotations to add to the server Deployment.\n"
-        },
-        "emptyDir": {
-          "additionalProperties": false,
-          "description": "Configuration for emptyDir volume.\n",
-          "properties": {
-            "sizeLimit": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.EmptyDirVolumeSource/properties/sizeLimit",
-              "default": "8Gi",
-              "description": "Limit the size to lower impact on the cluster, and to provide a\nreasonable backup for the WAL.\n"
-            }
-          },
-          "type": "object"
-        },
-        "image": {
-          "$ref": "#/$defs/com.cloudzero.agent.image",
-          "deprecated": true,
-          "description": "This field is deprecated. Please use `components.agent.image` instead.\n\nContainer image configuration for the server.\n"
-        },
-        "livenessProbe": {
-          "additionalProperties": false,
-          "description": "Liveness probe configuration.\n",
-          "properties": {
-            "failureThreshold": {
-              "default": 3,
-              "description": "Number of failed checks before marking as not alive.\n",
-              "type": "integer"
-            },
-            "initialDelaySeconds": {
-              "default": 30,
-              "description": "Initial delay before starting liveness checks.\n",
-              "type": "integer"
-            },
-            "periodSeconds": {
-              "default": 15,
-              "description": "Interval between liveness checks.\n",
-              "type": "integer"
-            },
-            "successThreshold": {
-              "default": 1,
-              "description": "Number of successful checks required to mark as alive.\n",
-              "type": "integer"
-            },
-            "timeoutSeconds": {
-              "default": 10,
-              "description": "Timeout for liveness check requests.\n",
-              "type": "integer"
-            }
-          },
-          "type": "object"
-        },
-        "name": {
-          "default": "server",
-          "description": "Name of the server component.\n",
-          "type": "string"
-        },
-        "nodeSelector": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec/properties/nodeSelector",
-          "description": "Node selector configuration for the server pods.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/\n"
-        },
-        "persistentVolume": {
-          "additionalProperties": false,
-          "description": "Configuration for persistent storage.\n",
-          "properties": {
-            "accessModes": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimSpec/properties/accessModes",
-              "description": "Access modes for the PersistentVolumeClaim.\n"
-            },
-            "annotations": {
-              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-              "description": "Annotations to add to the PersistentVolumeClaim.\n"
-            },
-            "enabled": {
-              "default": false,
-              "description": "Whether to enable persistent storage.\n",
-              "type": "boolean"
-            },
-            "existingClaim": {
-              "default": "",
-              "description": "Name of an existing PersistentVolumeClaim to use.\n",
-              "type": "string"
-            },
-            "mountPath": {
-              "default": "/data",
-              "description": "Path where the volume will be mounted.\n",
-              "type": "string"
-            },
-            "size": {
-              "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity",
-              "description": "Size of the PersistentVolumeClaim.\n"
-            },
-            "storageClass": {
-              "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimSpec/properties/storageClassName",
-              "description": "Storage class to use for the PersistentVolumeClaim.\n"
-            },
-            "subPath": {
-              "default": "",
-              "description": "Sub-path within the volume to mount.\n",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "podAnnotations": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-          "description": "Annotations to add to the server pods.\n"
-        },
-        "readinessProbe": {
-          "additionalProperties": false,
-          "description": "Readiness probe configuration.\n",
-          "properties": {
-            "failureThreshold": {
-              "default": 3,
-              "description": "Number of failed checks before marking as not ready.\n",
-              "type": "integer"
-            },
-            "initialDelaySeconds": {
-              "default": 30,
-              "description": "Initial delay before starting readiness checks.\n",
-              "type": "integer"
-            },
-            "periodSeconds": {
-              "default": 5,
-              "description": "Interval between readiness checks.\n",
-              "type": "integer"
-            },
-            "successThreshold": {
-              "default": 1,
-              "description": "Number of successful checks required to mark as ready.\n",
-              "type": "integer"
-            },
-            "timeoutSeconds": {
-              "default": 4,
-              "description": "Timeout for readiness check requests.\n",
-              "type": "integer"
-            }
-          },
-          "type": "object"
-        },
-        "resources": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements",
-          "description": "Resource requirements and limits for the server.\n\nFor details, see the Kubernetes documentation on resource management:\nhttps://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\n"
-        },
-        "terminationGracePeriodSeconds": {
-          "default": 300,
-          "description": "Termination grace period in seconds.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination\n",
-          "type": "integer"
-        },
-        "tolerations": {
-          "$ref": "#/$defs/com.cloudzero.agent.tolerations",
-          "description": "Tolerations configuration for the server pods.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/configuration/taint-and-toleration/\n"
-        },
-        "topologySpreadConstraints": {
-          "description": "Topology spread constraints for pod scheduling. See the Kubernetes\ndocumentation for details:\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/\n",
-          "items": {
-            "$ref": "#/$defs/io.k8s.api.core.v1.TopologySpreadConstraint"
-          },
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "serverConfig": {
-      "additionalProperties": false,
-      "description": "General server settings that apply to both the prometheus agent server and\nthe webhook server.\n",
-      "properties": {
-        "containerSecretFileName": {
-          "default": "value",
-          "description": "The agent will look for a file with this name to get the CloudZero API\nkey.\n",
-          "type": "string"
-        },
-        "containerSecretFilePath": {
-          "default": "/etc/config/secrets/",
-          "description": "The agent will use this file path on the container filesystem to get\nthe CloudZero API key.\n",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "serviceAccount": {
-      "additionalProperties": false,
-      "description": "Configuration for the service account in the chart.\n",
-      "properties": {
-        "annotations": {
-          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
-          "description": "For more information, see the Kubernetes documentation:\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/\n"
-        },
-        "create": {
-          "default": true,
-          "description": "Whether to create the service account.\n",
-          "type": "boolean"
-        },
-        "name": {
-          "default": "",
-          "description": "Name of the service account to create. If not set, one will be\ngenerated automatically.\n",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "validator": {
-      "additionalProperties": false,
-      "description": "Environment validator image.\n",
-      "properties": {
-        "image": {
-          "$ref": "#/$defs/com.cloudzero.agent.image",
-          "description": "Container image configuration to use for the validator.\n"
-        },
-        "name": {
-          "default": "env-validator",
-          "description": "Name of the validator component.\n",
-          "type": "string"
-        },
-        "serviceEndpoints": {
-          "additionalProperties": false,
-          "description": "Configuration for service endpoints used by the validator.\n",
-          "properties": {
-            "kubeStateMetrics": {
-              "additionalProperties": true,
-              "description": "The hostname of the kube-state-metrics service.\n",
-              "type": ["string", "null"]
-            }
-          },
-          "type": "object"
-        }
-      },
-      "type": "object"
-    }
-  },
-  "required": ["cloudAccountId", "clusterName", "region", "host"],
-  "type": "object"
+  }
 }

--- a/helm/templates/validations.yaml
+++ b/helm/templates/validations.yaml
@@ -1,0 +1,10 @@
+{{- /*
+Validations which are not possible to integrate into the JSON schema
+due to limitations in Helm's schema validation capabilities and/or
+limitations in JSON Schema.
+*/ -}}
+
+{{- /* You must set either apiKey or existingSecretName. */ -}}
+{{- if and (not .Values.apiKey) (not .Values.existingSecretName) }}
+  {{- fail "Either apiKey or existingSecretName must be set" -}}
+{{- end -}}

--- a/helm/templates/webhook-pdb.yaml
+++ b/helm/templates/webhook-pdb.yaml
@@ -2,6 +2,6 @@
     "component" .Values.components.webhookServer
     "name" (include "cloudzero-agent.insightsController.deploymentName" .)
     "matchLabels" (include "cloudzero-agent.insightsController.server.matchLabels" .)
-    "replicas" .Values.insightsController.server.replicaCount
+    "replicas" (.Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas)
     "root" .
   ) }}

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1,0 +1,1363 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://raw.githubusercontent.com/Cloudzero/cloudzero-agent/refs/heads/develop/helm/values.schema.json
+
+# Common types used in multiple components.
+$defs:
+  com.cloudzero.agent.image:
+    description: |
+      A container image type similar to the Kubernetes image type, but with
+      additional support for pullSecrets. This type is used to specify container
+      images across the chart.
+    additionalProperties: false
+    properties:
+      pullPolicy:
+        description: |
+          Corresponds to the Kubernetes imagePullPolicy. For documentation, see
+          https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+        oneOf:
+          - $ref: "#/$defs/io.k8s.api.core.v1.Container/properties/imagePullPolicy"
+          - type: "null"
+
+      registry:
+        description: |
+          The container registry to pull the image from.
+        additionalProperties: false
+        type:
+          - string
+          - "null"
+
+      repository:
+        description: |
+          The name of the container image repository.
+        additionalProperties: false
+        type:
+          - string
+          - "null"
+
+      digest:
+        description: |
+          The digest of the container image.
+        additionalProperties: false
+        type:
+          - string
+          - "null"
+
+      tag:
+        description: |
+          The tag of the container image to use.
+        additionalProperties: false
+        type:
+          - string
+          - "null"
+
+      pullSecrets:
+        description: |
+          A list of image pull secrets to use.
+        oneOf:
+          - $ref: "#/$defs/io.k8s.api.core.v1.PodSpec/properties/imagePullSecrets"
+          - type: "null"
+    type: object
+
+  com.cloudzero.agent.dns:
+    description: |
+      Specifies DNS configurations, both the dnsPolicy and dnsConfig.
+      For documentation, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+    additionalProperties: false
+    type: object
+    properties:
+      policy:
+        description: |
+          DNS policy to use.
+          For documentation, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+        oneOf:
+          - $ref: "#/$defs/io.k8s.api.core.v1.PodSpec/properties/dnsPolicy"
+          - type: "null"
+      config:
+        description: |
+          DNS configuration to use.
+          For documentation, see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+        $ref: "#/$defs/io.k8s.api.core.v1.PodDNSConfig"
+
+  com.cloudzero.agent.tolerations:
+    description: |
+      Used to control pod scheduling with taints
+    type: array
+    items:
+      $ref: "#/$defs/io.k8s.api.core.v1.Toleration"
+
+  com.cloudzero.agent.duration:
+    description: |
+      A time duration in Go's time.ParseDuration format. Valid formats include:
+      "300ms", "1.5h", "2h45m", etc. Valid time units are: "ns", "us" (or "µs"),
+      "ms", "s", "m", "h"
+    type: string
+    pattern: '^[0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))*$'
+
+type: object
+additionalProperties: false
+required:
+  - cloudAccountId
+  - clusterName
+  - region
+  - host
+
+properties:
+  cloudAccountId:
+    type: string
+    minLength: 1
+    description: |
+      The CloudZero Cloud Account ID.
+  clusterName:
+    type: string
+    pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,251}[a-zA-Z0-9])?$
+    description: |
+      The name of the Kubernetes cluster.
+  region:
+    type: string
+    minLength: 1
+    description: |
+      The cloud provider region.
+  apiKey:
+    type:
+      - string
+      - "null"
+    description: |
+      The CloudZero API key.
+  host:
+    type: string
+    minLength: 1
+    description: |
+      The CloudZero API host to connect to (e.g. api.cloudzero.com).
+  existingSecretName:
+    type:
+      - string
+      - "null"
+    description: |
+      The name of an existing Kubernetes secret containing the API key.
+
+  # Default settings for components
+  defaults:
+    description: |
+      Default settings for components, and globals.
+    type: object
+    additionalProperties: false
+    properties:
+      federation:
+        description: |
+          Federated mode deploys the agent as a DaemonSet, with each node in the
+          cluster running its own metrics collector.
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            description: |
+              Whether to enable federated mode.
+            type: boolean
+      image:
+        description: |
+          The default image settings which will be fallen back on for all
+          components.
+        $ref: "#/$defs/com.cloudzero.agent.image"
+      dns:
+        description: |
+          DNS settings for all pods.
+        $ref: "#/$defs/com.cloudzero.agent.dns"
+      labels:
+        description: |
+          Labels to be added to all resources.
+        $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+      annotations:
+        description: |
+          Annotations to be added to all resources.
+        $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+      affinity:
+        description: |
+          Affinity settings to be added to all resources.
+        $ref: "#/$defs/io.k8s.api.core.v1.Affinity"
+      tolerations:
+        description: |
+          Tolerations to be added to all resources.
+        $ref: "#/$defs/com.cloudzero.agent.tolerations"
+      nodeSelector:
+        description: |
+          Node Selector to be added to all resources.
+        $ref: "#/$defs/io.k8s.api.core.v1.PodSpec/properties/nodeSelector"
+      priorityClassName:
+        description: |
+          Priority class name to be used for all deployments and jobs.
+        type:
+          - string
+          - "null"
+
+  components:
+    description: |
+      Configuration for individual components of the CloudZero agent.
+    additionalProperties: false
+    type: object
+    properties:
+      agent:
+        description: |
+          The CloudZero Agent.
+          The Agent is responsible for gathering metrics needed by CloudZero.
+          These metrics are then sent to the Aggregator.
+        additionalProperties: false
+        type: object
+        properties:
+          image:
+            description: |
+              Container image configuration for the agent.
+            $ref: "#/$defs/com.cloudzero.agent.image"
+          podDisruptionBudget:
+            description: |
+              Pod disruption budget configuration for the agent.
+
+              See the Kubernetes documentation for details:
+              https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+            $ref: "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudget"
+          replicas:
+            description: |
+              Number of replicas to deploy.
+            type: integer
+          tolerations:
+            description: |
+              Tolerations configuration for the agent pods.
+
+              See the Kubernetes documentation for details:
+              https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+            $ref: "#/$defs/com.cloudzero.agent.tolerations"
+
+      aggregator:
+        description: |
+          The CloudZero Aggregator ("Gator"). The Aggregator provides a service
+          which accepts metrics (e.g., from the Agent and the Webhook Server),
+          aggregates them, caches them, and sends them to CloudZero for
+          processing.
+        additionalProperties: false
+        type: object
+        properties:
+          podDisruptionBudget:
+            description: |
+              Pod disruption budget configuration for the aggregator.
+
+              See the Kubernetes documentation for details:
+              https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+            $ref: "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudget"
+          replicas:
+            description: |
+              Number of replicas to deploy.
+            additionalProperties: false
+            type:
+              - integer
+              - "null"
+          tolerations:
+            description: |
+              Tolerations configuration for the aggregator pods.
+
+              See the Kubernetes documentation for details:
+              https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+            $ref: "#/$defs/com.cloudzero.agent.tolerations"
+
+      kubectl:
+        description: |
+          A container which includes the `kubectl` executable. This is used
+          mostly to gather information about the cluster during an
+          initialization phase.
+        additionalProperties: false
+        type: object
+        properties:
+          image:
+            description: |
+              Container image configuration for the kubectl container.
+            $ref: "#/$defs/com.cloudzero.agent.image"
+
+      prometheus:
+        description: |
+          Configuration for the Prometheus component.
+        additionalProperties: false
+        type: object
+        properties:
+          image:
+            description: |
+              Container image configuration for Prometheus.
+            $ref: "#/$defs/com.cloudzero.agent.image"
+
+      prometheusReloader:
+        description: |
+          Configuration for the Prometheus reloader component.
+        additionalProperties: false
+        type: object
+        properties:
+          image:
+            description: |
+              Container image configuration for the Prometheus reloader.
+            $ref: "#/$defs/com.cloudzero.agent.image"
+
+      webhookServer:
+        description: |
+          Configuration for the webhook server component.
+        additionalProperties: false
+        type: object
+        properties:
+          podDisruptionBudget:
+            description: |
+              Pod disruption budget configuration for the webhook server.
+
+              See the Kubernetes documentation for details:
+              https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+            $ref: "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudget"
+          replicas:
+            description: |
+              Number of replicas to deploy.
+            additionalProperties: false
+            type:
+              - integer
+              - "null"
+
+  #######################################################################################
+  #######################################################################################
+  ####                                                                               ####
+  ####  Values below this point are not considered API stable. Use at your own risk. ####
+  ####  If you do require them for some reason, please let us know so we can work on ####
+  ####  covering your use case in the stable section.                                ####
+  ####                                                                               ####
+  #######################################################################################
+  #######################################################################################
+
+  aggregator:
+    additionalProperties: false
+    type: object
+    properties:
+      logging:
+        type: object
+        additionalProperties: false
+        properties:
+          # The log level to use
+          level:
+            type: string
+            enum:
+              - debug
+              - info
+              - warn
+              - error
+      mountRoot:
+        type: string
+      profiling:
+        type: boolean
+      image:
+        deprecated: true
+        $ref: "#/$defs/com.cloudzero.agent.image"
+      cloudzero:
+        type: object
+        additionalProperties: false
+        properties:
+          # The interval at which to send data
+          sendInterval:
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+          # The timeout for sending data
+          sendTimeout:
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+          # The interval at which to rotate data
+          rotateInterval:
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+      database:
+        type: object
+        additionalProperties: false
+        properties:
+          # The maximum number of records to store
+          maxRecords:
+            type: integer
+          # The maximum interval for cost data
+          costMaxInterval:
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+          # The maximum interval for observability data
+          observabilityMaxInterval:
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+          # The compression level to use for database operations
+          compressionLevel:
+            type: integer
+            minimum: 0
+            maximum: 11
+          # Rules for purging old data
+          purgeRules:
+            type: object
+            additionalProperties: false
+            properties:
+              metricsOlderThan:
+                $ref: "#/$defs/com.cloudzero.agent.duration"
+              lazy:
+                type: boolean
+              percent:
+                type: integer
+          # emptyDir volume configuration
+          emptyDir:
+            $ref: "#/$defs/io.k8s.api.core.v1.EmptyDirVolumeSource"
+      collector:
+        type: object
+        additionalProperties: false
+        properties:
+          port:
+            type: integer
+          # Resource requirements for the collector
+          resources:
+            $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+      shipper:
+        type: object
+        additionalProperties: false
+        properties:
+          port:
+            type: integer
+          # Resource requirements for the collector
+          resources:
+            $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+      # Node selector for the aggregator
+      nodeSelector:
+        $ref: "#/$defs/io.k8s.api.core.v1.PodSpec/properties/nodeSelector"
+      # Tolerations for the aggregator
+      tolerations:
+        $ref: "#/$defs/com.cloudzero.agent.tolerations"
+      # Affinity settings for the aggregator
+      affinity:
+        $ref: "#/$defs/io.k8s.api.core.v1.Affinity"
+
+  prometheusConfig:
+    description: |
+      Prometheus configuration settings.
+    type: object
+    additionalProperties: false
+    properties:
+      configMapNameOverride:
+        description: |
+          Override the name of the ConfigMap.
+        type: string
+      configMapAnnotations:
+        description: |
+          Annotations to add to the ConfigMap.
+        type: object
+        additionalProperties: true
+      configOverride:
+        description: |
+          Override the entire Prometheus configuration.
+        type: string
+      globalScrapeInterval:
+        description: |
+          Global scrape interval for all jobs.
+        $ref: "#/$defs/com.cloudzero.agent.duration"
+      scrapeJobs:
+        description: |
+          Scrape job configurations.
+        type: object
+        additionalProperties: false
+        properties:
+          kubeStateMetrics:
+            description: |
+              kube-state-metrics scrape job configuration.
+            type: object
+            additionalProperties: false
+            properties:
+              enabled:
+                description: |
+                  Whether to enable the kube-state-metrics scrape job.
+                type: boolean
+              scrapeInterval:
+                description: |
+                  Scrape interval for kubeStateMetrics job.
+                $ref: "#/$defs/com.cloudzero.agent.duration"
+          cadvisor:
+            description: |
+              cadvisor scrape job configuration.
+            type: object
+            additionalProperties: false
+            required:
+              - enabled
+            properties:
+              enabled:
+                description: |
+                  Whether to enable the cadvisor scrape job.
+                type: boolean
+                enum: [true]
+              scrapeInterval:
+                description: |
+                  Scrape interval for nodesCadvisor job.
+                $ref: "#/$defs/com.cloudzero.agent.duration"
+          prometheus:
+            description: |
+              prometheus scrape job configuration.
+            type: object
+            additionalProperties: false
+            properties:
+              enabled:
+                description: |
+                  Whether to enable the prometheus scrape job.
+                type: boolean
+              scrapeInterval:
+                description: |
+                  Scrape interval for prometheus job.
+                $ref: "#/$defs/com.cloudzero.agent.duration"
+          aggregator:
+            description: |
+              aggregator scrape job configuration.
+            type: object
+            additionalProperties: false
+            properties:
+              enabled:
+                description: |
+                  Whether to enable the aggregator scrape job.
+                type: boolean
+              scrapeInterval:
+                description: |
+                  Scrape interval for aggregator job.
+                $ref: "#/$defs/com.cloudzero.agent.duration"
+          additionalScrapeJobs:
+            description: |
+              Additional scrape jobs to add to the configuration.
+            type: array
+            items:
+              type: object
+
+  commonMetaLabels:
+    $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+    title: Common labels applied to all resources
+    description: |
+      This field is deprecated. Please use `defaults.labels` instead.
+
+      Labels to be added to all resources in the chart. These labels are merged
+      with `defaults.labels` and component-specific labels (e.g.,
+      `components.aggregator.labels`).
+    default: {}
+    examples:
+      - environment: production
+        team: platform
+    deprecated: true
+
+  configmapReload:
+    title: Configuration for ConfigMap reloading
+    type: object
+    deprecated: true
+    description: |
+      This field is deprecated.
+
+      This field is used to configure the reloading of ConfigMaps. It allows you
+      to specify settings for how and when ConfigMaps should be reloaded.
+    properties:
+      prometheus:
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            type: boolean
+            default: true
+          image:
+            $ref: "#/$defs/com.cloudzero.agent.image"
+          resources:
+            $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+
+  imagePullSecrets:
+    deprecated: true
+    description: |
+      This field is deprecated. Please use `defaults.image.pullSecrets` instead.
+    $ref: "#/$defs/io.k8s.api.core.v1.PodSpec/properties/imagePullSecrets"
+
+  initBackfillJob:
+    description: |
+      Configuration for the init-backfill-job, which is used to backfill data
+      from the cluster to CloudZero.
+    type: object
+    additionalProperties: false
+    properties:
+      enabled:
+        description: |
+          Whether to enable the init-backfill-job.
+        type: boolean
+        default: true
+      annotations:
+        description: |
+          Annotations to add to the init-backfill-job.
+        type: object
+        additionalProperties: true
+      tolerations:
+        description: |
+          Tolerations to be added to the init-backfill-job.
+        $ref: "#/$defs/com.cloudzero.agent.tolerations"
+      image:
+        description: |
+          Container image configuration for the init-backfill-job.
+        $ref: "#/$defs/com.cloudzero.agent.image"
+
+  initCertJob:
+    description: |
+      Configuration for the init-cert-job, which is used to initialize
+      certificates for the webhook server.
+    type: object
+    additionalProperties: false
+    properties:
+      enabled:
+        description: |
+          Whether to enable the init-cert-job.
+        type: boolean
+        default: true
+      annotations:
+        description: |
+          Annotations to add to the init-cert-job.
+        $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+      tolerations:
+        description: |
+          Tolerations to be added to the init-cert-job.
+        $ref: "#/$defs/com.cloudzero.agent.tolerations"
+      image:
+        description: |
+          Container image configuration for the init-cert-job.
+        $ref: "#/$defs/com.cloudzero.agent.image"
+      rbac:
+        description: |
+          RBAC configuration for the init-cert-job.
+        type: object
+        properties:
+          create:
+            description: |
+              Whether to create RBAC resources.
+            type: boolean
+            default: true
+          serviceAccountName:
+            description: |
+              Name of the service account to create.
+            $ref: "#/$defs/io.k8s.api.core.v1.PodSpec/properties/serviceAccountName"
+          clusterRoleName:
+            description: |
+              Name of the cluster role to create.
+            type: string
+          clusterRoleBindingName:
+            description: |
+              Name of the cluster role binding to create.
+            type: string
+
+  insightsController:
+    description: |
+      Configuration for the webhook server (née Insights Controller), which
+      collects and processes Kubernetes resource metadata for cost attribution
+      and analysis.
+    type: object
+    additionalProperties: false
+    properties:
+      enabled:
+        description: |
+          Whether to enable the insights controller. It is strongly recommended
+          that this feature be enabled as it provides important functionality.
+        type: boolean
+        default: true
+      labels:
+        description: |
+          Configuration for collecting labels from Kubernetes resources.
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            description: |
+              Whether to enable collection of specific labels for cost
+              attribution dimensions. It is strongly recommended that this
+              feature be enabled as it provides important functionality.
+            type: boolean
+            default: true
+          patterns:
+            description: |
+              List of Go-style regular expressions used to filter desired
+              labels. Caution: The CloudZero system has a limit of 300 labels
+              and annotations, so it is advisable to provide a specific list of
+              required labels rather than a wildcard.
+            type: array
+            items:
+              type: string
+          resources:
+            description: |
+              Specify which resources to collect labels from.
+            type: object
+            additionalProperties: false
+            properties:
+              cronjobs:
+                description: |
+                  Whether to collect labels from CronJobs.
+                type: boolean
+                default: false
+              daemonsets:
+                description: |
+                  Whether to collect labels from DaemonSets.
+                type: boolean
+                default: false
+              deployments:
+                description: |
+                  Whether to collect labels from Deployments.
+                type: boolean
+                default: false
+              jobs:
+                description: |
+                  Whether to collect labels from Jobs.
+                type: boolean
+                default: false
+              namespaces:
+                description: |
+                  Whether to collect labels from Namespaces.
+                type: boolean
+                default: true
+              nodes:
+                description: |
+                  Whether to collect labels from Nodes.
+                type: boolean
+                default: false
+              pods:
+                description: |
+                  Whether to collect labels from Pods.
+                type: boolean
+                default: true
+              statefulsets:
+                description: |
+                  Whether to collect labels from StatefulSets.
+                type: boolean
+                default: false
+      annotations:
+        description: |
+          Configuration for collecting annotations from Kubernetes resources.
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            description: |
+              Whether to enable collection of annotations for cost attribution
+              dimensions.
+            type: boolean
+            default: false
+          patterns:
+            description: |
+              List of Go-style regular expressions used to filter desired
+              annotations. Caution: The CloudZero system has a limit of 300
+              labels and annotations, so it is advisable to provide a specific
+              list of required annotations rather than a wildcard.
+            type: array
+            items:
+              type: string
+          resources:
+            description: |
+              Specify which resources to collect annotations from.
+            type: object
+            additionalProperties: false
+            properties:
+              cronjobs:
+                description: |
+                  Whether to collect annotations from CronJobs.
+                type: boolean
+                default: false
+              daemonsets:
+                description: |
+                  Whether to collect annotations from DaemonSets.
+                type: boolean
+                default: false
+              deployments:
+                description: |
+                  Whether to collect annotations from Deployments.
+                type: boolean
+                default: false
+              jobs:
+                description: |
+                  Whether to collect annotations from Jobs.
+                type: boolean
+                default: false
+              namespaces:
+                description: |
+                  Whether to collect annotations from Namespaces.
+                type: boolean
+                default: true
+              nodes:
+                description: |
+                  Whether to collect annotations from Nodes.
+                type: boolean
+                default: false
+              pods:
+                description: |
+                  Whether to collect annotations from Pods.
+                type: boolean
+                default: true
+              statefulsets:
+                description: |
+                  Whether to collect annotations from StatefulSets.
+                type: boolean
+                default: false
+      tls:
+        description: |
+          Configuration for TLS certificates used by the insights controller.
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            description: |
+              Whether to enable TLS certificate management.
+            type: boolean
+            default: true
+          crt:
+            description: |
+              TLS certificate in PEM format. If empty, a certificate will be
+              generated.
+            type: string
+            default: ""
+          key:
+            description: |
+              TLS private key in PEM format. If empty, a key will be generated.
+            type: string
+            default: ""
+          secret:
+            description: |
+              Configuration for the TLS certificate Secret.
+            type: object
+            additionalProperties: false
+            properties:
+              create:
+                description: |
+                  Whether to create a Secret to store the TLS certificate and
+                  key.
+                type: boolean
+                default: true
+              name:
+                description: |
+                  Name of the Secret to create. If empty, a name will be
+                  generated.
+                type: string
+                default: ""
+          mountPath:
+            description: |
+              Path where the TLS certificate and key will be mounted in the
+              container.
+            type: string
+            default: "/etc/certs"
+          caBundle:
+            description: |
+              CA bundle for validating admission webhook requests. If empty, the
+              default self-signed certificate will be used.
+            type: string
+            default: ""
+          useCertManager:
+            description: |
+              Whether to use cert-manager for certificate management. If
+              disabled, a self-signed certificate will be used.
+            type: boolean
+            default: false
+
+      server:
+        description: |
+          Configuration for the webhook server component.
+        type: object
+        additionalProperties: false
+        properties:
+          name:
+            description: |
+              Name of the webhook server component.
+            type: string
+            default: "webhook-server"
+          replicaCount:
+            deprecated: true
+            description: |
+              This field is deprecated. Please use `components.webhookServer.replicaCount` instead.
+
+              Number of replicas to run for the webhook server.
+            type:
+              - integer
+              - "null"
+          image:
+            description: |
+              Container image configuration for the webhook server.
+            $ref: "#/$defs/com.cloudzero.agent.image"
+          port:
+            description: |
+              Port that the webhook server listens on.
+            type: integer
+            default: 8443
+          read_timeout:
+            description: |
+              Timeout for reading HTTP requests.
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+            default: "10s"
+          write_timeout:
+            description: |
+              Timeout for writing HTTP responses.
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+            default: "10s"
+          send_timeout:
+            description: |
+              Timeout for sending data to clients.
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+            default: "1m"
+          send_interval:
+            description: |
+              Interval between sending data to clients.
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+            default: "1m"
+          idle_timeout:
+            description: |
+              Timeout for idle connections.
+            $ref: "#/$defs/com.cloudzero.agent.duration"
+            default: "120s"
+          logging:
+            description: |
+              Configuration for logging in the webhook server.
+            type: object
+            additionalProperties: false
+            properties:
+              level:
+                description: |
+                  Logging level for the webhook server.
+                type: string
+                enum: [debug, info, warn, error]
+                default: "info"
+          healthCheck:
+            description: |
+              Configuration for the health check endpoint.
+            type: object
+            additionalProperties: false
+            properties:
+              enabled:
+                description: |
+                  Whether to enable the health check endpoint.
+                type: boolean
+                default: true
+              path:
+                description: |
+                  Path for the health check endpoint.
+                type: string
+                default: "/healthz"
+              port:
+                description: |
+                  Port for the health check endpoint.
+                type: integer
+                default: 8443
+              initialDelaySeconds:
+                description: |
+                  Initial delay before starting health checks.
+                type: integer
+                default: 15
+              periodSeconds:
+                description: |
+                  Interval between health checks.
+                type: integer
+                default: 20
+              timeoutSeconds:
+                description: |
+                  Timeout for health check requests.
+                type: integer
+                default: 3
+              successThreshold:
+                description: |
+                  Number of successful checks required to mark as healthy.
+                type: integer
+                default: 1
+              failureThreshold:
+                description: |
+                  Number of failed checks before marking as unhealthy.
+                type: integer
+                default: 5
+          nodeSelector:
+            description: |
+              Node selector configuration for the webhook server pods.
+            $ref: "#/$defs/io.k8s.api.core.v1.PodSpec/properties/nodeSelector"
+          tolerations:
+            description: |
+              Tolerations configuration for the webhook server pods.
+            $ref: "#/$defs/com.cloudzero.agent.tolerations"
+          affinity:
+            description: |
+              Affinity rules for the webhook server pods.
+            $ref: "#/$defs/io.k8s.api.core.v1.Affinity"
+          deploymentAnnotations:
+            description: |
+              Annotations to add to the webhook server Deployment.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+          podAnnotations:
+            description: |
+              Annotations to add to the webhook server pods.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+      volumeMounts:
+        description: |
+          Additional volume mounts to add to the insights controller pods.
+        type: array
+        items:
+          $ref: "#/$defs/io.k8s.api.core.v1.VolumeMount"
+      volumes:
+        description: |
+          Additional volumes to add to the insights controller pods.
+        type: array
+        items:
+          $ref: "#/$defs/io.k8s.api.core.v1.Volume"
+      resources:
+        description: |
+          Resource requirements and limits for the insights controller.
+        $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+      podAnnotations:
+        description: |
+          Annotations to add to the insights controller pods.
+        $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+      podLabels:
+        description: |
+          Labels to add to the insights controller pods.
+        $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+      service:
+        description: |
+          Configuration for the insights controller Service.
+        type: object
+        additionalProperties: false
+        properties:
+          port:
+            description: |
+              Port that the insights controller Service listens on.
+            type: integer
+            default: 443
+      webhooks:
+        description: |
+          Configuration for the validating admission webhook.
+        type: object
+        additionalProperties: false
+        properties:
+          annotations:
+            description: |
+              Annotations to add to the validating admission webhook.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+          namespaceSelector:
+            description: |
+              Namespace selector for the validating admission webhook.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+          path:
+            description: |
+              Path for the validating admission webhook.
+            type: string
+            default: "/validate"
+          caInjection:
+            type:
+              - string
+              - "null"
+            description: |
+              Configuration for CA injection in webhooks.
+      configurationMountPath:
+        type:
+          - string
+          - "null"
+        description: |
+          Path where the configuration will be mounted in the container.
+      ConfigMapNameOverride:
+        type:
+          - string
+          - "null"
+        description: |
+          Override the name of the ConfigMap used for configuration.
+
+  kubeStateMetrics:
+    type: object
+    description: |
+      The configuration for the kube-state-metrics chart.
+
+      For details, please see the [kube-state-metrics
+      chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics).
+
+  rbac:
+    type: object
+    additionalProperties: false
+    description: |
+      Configuration for the RBAC resources in the chart (e.g., ClusterRole,
+      ClusterRoleBinding, Role, RoleBinding, etc.).
+    properties:
+      # Whether to create the RBAC resources.
+      create:
+        type: boolean
+        default: true
+
+  secretAnnotations:
+    additionalProperties: true
+    deprecated: true
+    description: |
+      Annotations to be added to all Secret resources created by the chart.
+      These annotations are merged with `defaults.annotations` and
+      component-specific annotations.
+    default: {}
+    $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+
+  server:
+    description: |
+      Configuration for the server component.
+    type: object
+    additionalProperties: false
+    properties:
+      name:
+        description: |
+          Name of the server component.
+        type: string
+        default: "server"
+      image:
+        deprecated: true
+        description: |
+          This field is deprecated. Please use `components.agent.image` instead.
+
+          Container image configuration for the server.
+        $ref: "#/$defs/com.cloudzero.agent.image"
+      nodeSelector:
+        $ref: "#/$defs/io.k8s.api.core.v1.PodSpec/properties/nodeSelector"
+        description: |
+          Node selector configuration for the server pods.
+
+          See the Kubernetes documentation for details:
+          https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+      resources:
+        $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+        description: |
+          Resource requirements and limits for the server.
+
+          For details, see the Kubernetes documentation on resource management:
+          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      deploymentAnnotations:
+        description: |
+          Annotations to add to the server Deployment.
+        $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+      podAnnotations:
+        description: |
+          Annotations to add to the server pods.
+        $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+      agentMode:
+        description: |
+          Whether the server is running in agent mode.
+        type: boolean
+        default: true
+      args:
+        description: |
+          Command-line arguments to pass to the server.
+        type: array
+        items:
+          type: string
+        default:
+          - --config.file=/etc/config/prometheus/configmaps/prometheus.yml
+          - --web.enable-lifecycle
+          - --web.console.libraries=/etc/prometheus/console_libraries
+          - --web.console.templates=/etc/prometheus/consoles
+      persistentVolume:
+        description: |
+          Configuration for persistent storage.
+        type: object
+        additionalProperties: false
+        properties:
+          existingClaim:
+            description: |
+              Name of an existing PersistentVolumeClaim to use.
+            type: string
+            default: ""
+          enabled:
+            description: |
+              Whether to enable persistent storage.
+            type: boolean
+            default: false
+          mountPath:
+            description: |
+              Path where the volume will be mounted.
+            type: string
+            default: "/data"
+          subPath:
+            description: |
+              Sub-path within the volume to mount.
+            type: string
+            default: ""
+          storageClass:
+            description: |
+              Storage class to use for the PersistentVolumeClaim.
+            $ref: "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimSpec/properties/storageClassName"
+          size:
+            description: |
+              Size of the PersistentVolumeClaim.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          accessModes:
+            description: |
+              Access modes for the PersistentVolumeClaim.
+            $ref: "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimSpec/properties/accessModes"
+          annotations:
+            description: |
+              Annotations to add to the PersistentVolumeClaim.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+      emptyDir:
+        description: |
+          Configuration for emptyDir volume.
+        type: object
+        additionalProperties: false
+        properties:
+          sizeLimit:
+            description: |
+              Limit the size to lower impact on the cluster, and to provide a
+              reasonable backup for the WAL.
+            $ref: "#/$defs/io.k8s.api.core.v1.EmptyDirVolumeSource/properties/sizeLimit"
+            default: 8Gi
+      affinity:
+        description: |
+          Affinity rules for pod scheduling.
+          See the Kubernetes documentation for details:
+          https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+        $ref: "#/$defs/io.k8s.api.core.v1.Affinity"
+      tolerations:
+        description: |
+          Tolerations configuration for the server pods.
+
+          See the Kubernetes documentation for details:
+          https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+        $ref: "#/$defs/com.cloudzero.agent.tolerations"
+      topologySpreadConstraints:
+        description: |
+          Topology spread constraints for pod scheduling. See the Kubernetes
+          documentation for details:
+          https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+        type: array
+        items:
+          $ref: "#/$defs/io.k8s.api.core.v1.TopologySpreadConstraint"
+      terminationGracePeriodSeconds:
+        description: |
+          Termination grace period in seconds.
+
+          See the Kubernetes documentation for details:
+          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+        type: integer
+        default: 300
+      readinessProbe:
+        description: |
+          Readiness probe configuration.
+        type: object
+        additionalProperties: false
+        properties:
+          initialDelaySeconds:
+            description: |
+              Initial delay before starting readiness checks.
+            type: integer
+            default: 30
+          periodSeconds:
+            description: |
+              Interval between readiness checks.
+            type: integer
+            default: 5
+          timeoutSeconds:
+            description: |
+              Timeout for readiness check requests.
+            type: integer
+            default: 4
+          failureThreshold:
+            description: |
+              Number of failed checks before marking as not ready.
+            type: integer
+            default: 3
+          successThreshold:
+            description: |
+              Number of successful checks required to mark as ready.
+            type: integer
+            default: 1
+      livenessProbe:
+        description: |
+          Liveness probe configuration.
+        type: object
+        additionalProperties: false
+        properties:
+          initialDelaySeconds:
+            description: |
+              Initial delay before starting liveness checks.
+            type: integer
+            default: 30
+          periodSeconds:
+            description: |
+              Interval between liveness checks.
+            type: integer
+            default: 15
+          timeoutSeconds:
+            description: |
+              Timeout for liveness check requests.
+            type: integer
+            default: 10
+          failureThreshold:
+            description: |
+              Number of failed checks before marking as not alive.
+            type: integer
+            default: 3
+          successThreshold:
+            description: |
+              Number of successful checks required to mark as alive.
+            type: integer
+            default: 1
+
+  serverConfig:
+    description: |
+      General server settings that apply to both the prometheus agent server and
+      the webhook server.
+    type: object
+    additionalProperties: false
+    properties:
+      containerSecretFilePath:
+        description: |
+          The agent will use this file path on the container filesystem to get
+          the CloudZero API key.
+        type: string
+        default: "/etc/config/secrets/"
+      containerSecretFileName:
+        description: |
+          The agent will look for a file with this name to get the CloudZero API
+          key.
+        type: string
+        default: "value"
+
+  serviceAccount:
+    description: |
+      Configuration for the service account in the chart.
+    type: object
+    additionalProperties: false
+    properties:
+      create:
+        description: |
+          Whether to create the service account.
+        type: boolean
+        default: true
+      name:
+        type: string
+        default: ""
+        description: |
+          Name of the service account to create. If not set, one will be
+          generated automatically.
+      # Annotations to add to the service account.
+      annotations:
+        $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+        description: |
+          For more information, see the Kubernetes documentation:
+          https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+
+  validator:
+    description: |
+      Environment validator image.
+    type: object
+    additionalProperties: false
+    properties:
+      serviceEndpoints:
+        description: |
+          Configuration for service endpoints used by the validator.
+        type: object
+        additionalProperties: false
+        properties:
+          kubeStateMetrics:
+            description: |
+              The hostname of the kube-state-metrics service.
+            type:
+              - string
+              - "null"
+            additionalProperties: true
+      name:
+        description: |
+          Name of the validator component.
+        type: string
+        default: "env-validator"
+      image:
+        $ref: "#/$defs/com.cloudzero.agent.image"
+        description: |
+          Container image configuration to use for the validator.
+
+  jobConfigID:
+    type: string
+    description: |
+      We embed a hash of the configuration in some job names, most notably the
+      backfill job. This is done so we can make sure the job gets re-run
+      whenever the configuration changes, while also preserving the job in
+      Kubernetes since setting a TTL can interfere with systems which attempt to
+      keep the cluster synced to the chart, such as ArgoCD.
+
+      Unfortunately this can result in a lot of noise in the generated manifests
+      (see tests/helm/template/), so jobConfig ID provides a way to override
+      this behavior and instead generate the same hash every time. It shouldn't
+      really be used anywhere else.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -155,10 +155,6 @@ components:
     podDisruptionBudget:
       minAvailable:
       maxUnavailable:
-    # Replicas to deploy.
-    #
-    # Note that in federated mode, this will be the number of replicas per node.
-    replicas: 1
 
   # kubectl contains details about where to find the kubectl image.  This chart
   # uses the kubectl image as part of the job to initialize certificates.
@@ -193,6 +189,7 @@ components:
     podDisruptionBudget:
       minAvailable:
       maxUnavailable:
+    tolerations: []
 
   # Settings for the webhook server.
   webhookServer:
@@ -331,9 +328,6 @@ initCertJob:
 secretAnnotations: {}
 imagePullSecrets: []
 
-scheme: https
-endpoint: /v1/container-metrics
-
 # environment validator image allows for CI to use a different image in testing
 validator:
   serviceEndpoints:
@@ -409,6 +403,24 @@ server:
   # See the Kubernetes documentation for details:
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
+  # Topology spread constraints for pod scheduling
+  topologySpreadConstraints: []
+  # Termination grace period in seconds
+  terminationGracePeriodSeconds: 300
+  # Readiness probe configuration
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    timeoutSeconds: 4
+    failureThreshold: 3
+    successThreshold: 1
+  # Liveness probe configuration
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
 
 # Configuration for the webhook server (née Insights Controller), which collects
 # and processes Kubernetes resource metadata for cost attribution and analysis.
@@ -603,6 +615,9 @@ insightsController:
     namespaceSelector: {}
     # Path for the validating admission webhook.
     path: /validate
+    caInjection:
+  configurationMountPath:
+  ConfigMapNameOverride:
 
 # Configuration for the service account in the chart.
 serviceAccount:
@@ -804,7 +819,7 @@ aggregator:
   #
   # See the Kubernetes documentation for details:
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-  tolerations: {}
+  tolerations: []
   # Affinity rules for the aggregator pods.
   #
   # See the Kubernetes documentation for details:

--- a/scripts/merge-json-schema.jq
+++ b/scripts/merge-json-schema.jq
@@ -1,0 +1,33 @@
+# This script merges the definitions from a JSON schema file (only tested with
+# https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/master/_definitions.json
+# which has been copied into this repository) into the $defs section and updates
+# any $ref paths to use the new $defs section.
+#
+# Usage:
+#
+#   gojq --yaml-input . helm/values.schema.yaml | \
+#     gojq --slurpfile k8s helm/schema/k8s.json -f scripts/merge-json-schema.jq > helm/values.schema.json
+#
+# Or, better yet, just use the Makefile target:
+#
+#   make helm/values.schema.json
+
+# Store the input in a variable for later use
+. as $input |
+
+# Start with the input and modify it
+$input |
+
+# Merge the definitions from k8s into the $defs section
+.["$defs"] = ($input["$defs"] + ($k8s[0].definitions)) |
+
+# Walk through the entire object and update any $ref paths
+#
+# The Kubernetes JSON Schema uses the obsolete `definitions` name, but we want
+# to put everything in `$defs`.
+walk(
+    if type == "object" and has("$ref") and (.["$ref"] | type) == "string"
+    then .["$ref"] |= sub("^#/definitions/"; "#/$defs/")
+    else .
+    end
+)

--- a/tests/helm/schema/aggregator.database.compressionLevel.invalid.fail.yaml
+++ b/tests/helm/schema/aggregator.database.compressionLevel.invalid.fail.yaml
@@ -1,0 +1,3 @@
+aggregator:
+  database:
+    compressionLevel: 12

--- a/tests/helm/schema/aggregator.database.compressionLevel.max.pass.yaml
+++ b/tests/helm/schema/aggregator.database.compressionLevel.max.pass.yaml
@@ -1,0 +1,3 @@
+aggregator:
+  database:
+    compressionLevel: 11

--- a/tests/helm/schema/aggregator.database.compressionLevel.min.pass.yaml
+++ b/tests/helm/schema/aggregator.database.compressionLevel.min.pass.yaml
@@ -1,0 +1,3 @@
+aggregator:
+  database:
+    compressionLevel: 0

--- a/tests/helm/schema/aggregator.database.compressionLevel.valid.pass.yaml
+++ b/tests/helm/schema/aggregator.database.compressionLevel.valid.pass.yaml
@@ -1,0 +1,3 @@
+aggregator:
+  database:
+    compressionLevel: 6

--- a/tests/helm/schema/aggregator.image.invalid.fail.yaml
+++ b/tests/helm/schema/aggregator.image.invalid.fail.yaml
@@ -1,0 +1,5 @@
+aggregator:
+  image:
+    registry: 123 # Should fail as it's not a string
+    repository: true # Should fail as it's not a string
+    tag: ["invalid"] # Should fail as it's not a string

--- a/tests/helm/schema/aggregator.image.valid.pass.yaml
+++ b/tests/helm/schema/aggregator.image.valid.pass.yaml
@@ -1,0 +1,5 @@
+aggregator:
+  image:
+    registry: "docker.io"
+    repository: "cloudzero/aggregator"
+    tag: "latest"

--- a/tests/helm/schema/commonMetaLabels.invalid.fail.yaml
+++ b/tests/helm/schema/commonMetaLabels.invalid.fail.yaml
@@ -1,0 +1,3 @@
+commonMetaLabels:
+  environment: production
+  replicas: 3

--- a/tests/helm/schema/commonMetaLabels.valid.pass.yaml
+++ b/tests/helm/schema/commonMetaLabels.valid.pass.yaml
@@ -1,0 +1,3 @@
+commonMetaLabels:
+  environment: production
+  team: platform

--- a/tests/helm/schema/components.agent.podDisruptionBudget.invalid.fail.yaml
+++ b/tests/helm/schema/components.agent.podDisruptionBudget.invalid.fail.yaml
@@ -1,0 +1,3 @@
+components:
+  agent:
+    podDisruptionBudget: true # Should fail as it's a boolean, not a PodDisruptionBudget object

--- a/tests/helm/schema/components.agent.podDisruptionBudget.null.pass.yaml
+++ b/tests/helm/schema/components.agent.podDisruptionBudget.null.pass.yaml
@@ -1,0 +1,5 @@
+components:
+  agent:
+    podDisruptionBudget:
+      maxUnavailable: null
+      minAvailable: null

--- a/tests/helm/schema/components.agent.podDisruptionBudget.valid.pass.yaml
+++ b/tests/helm/schema/components.agent.podDisruptionBudget.valid.pass.yaml
@@ -1,0 +1,5 @@
+components:
+  agent:
+    podDisruptionBudget:
+      maxUnavailable: 1
+      minAvailable: 2

--- a/tests/helm/schema/defaults.annotations.invalid.fail.yaml
+++ b/tests/helm/schema/defaults.annotations.invalid.fail.yaml
@@ -1,0 +1,9 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+
+defaults:
+  annotations:
+    - foo
+    - bar

--- a/tests/helm/schema/defaults.annotations.nested.fail.yaml
+++ b/tests/helm/schema/defaults.annotations.nested.fail.yaml
@@ -1,0 +1,10 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+
+defaults:
+  annotations:
+    foo: bar
+    nested:
+      key: value

--- a/tests/helm/schema/defaults.annotations.valid.pass.yaml
+++ b/tests/helm/schema/defaults.annotations.valid.pass.yaml
@@ -1,0 +1,4 @@
+defaults:
+  annotations:
+    kubernetes.io/description: "CloudZero Agent"
+    prometheus.io/scrape: "true"

--- a/tests/helm/schema/defaults.dns.invalid.fail.yaml
+++ b/tests/helm/schema/defaults.dns.invalid.fail.yaml
@@ -1,0 +1,15 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+
+defaults:
+  dns:
+    policy: "InvalidPolicy" # Invalid policy value
+    config:
+      nameservers:
+        - "1.1.1.1"
+      searches: "invalid" # Should be an array
+      option:
+        - name: "ndots"
+          value: 5 # Should be a string

--- a/tests/helm/schema/defaults.dns.minimal.pass.yaml
+++ b/tests/helm/schema/defaults.dns.minimal.pass.yaml
@@ -1,0 +1,8 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+
+defaults:
+  dns:
+    policy: "ClusterFirst"

--- a/tests/helm/schema/defaults.dns.policy.invalid.fail.yaml
+++ b/tests/helm/schema/defaults.dns.policy.invalid.fail.yaml
@@ -1,0 +1,7 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+defaults:
+  dns:
+    policy: 123

--- a/tests/helm/schema/defaults.dns.valid.pass.yaml
+++ b/tests/helm/schema/defaults.dns.valid.pass.yaml
@@ -1,0 +1,20 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+
+defaults:
+  dns:
+    policy: "ClusterFirst"
+    config:
+      nameservers:
+        - "1.1.1.1"
+        - "8.8.8.8"
+      searches:
+        - "svc.cluster.local"
+        - "cluster.local"
+      option:
+        - name: "ndots"
+          value: "5"
+        - name: "timeout"
+          value: "3"

--- a/tests/helm/schema/defaults.federation.enabled.invalid.fail.yaml
+++ b/tests/helm/schema/defaults.federation.enabled.invalid.fail.yaml
@@ -1,0 +1,7 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+defaults:
+  federation:
+    enabled: "yes"

--- a/tests/helm/schema/defaults.federation.enabled.valid.pass.yaml
+++ b/tests/helm/schema/defaults.federation.enabled.valid.pass.yaml
@@ -1,0 +1,7 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+defaults:
+  federation:
+    enabled: true

--- a/tests/helm/schema/defaults.image.tag.invalid.fail.yaml
+++ b/tests/helm/schema/defaults.image.tag.invalid.fail.yaml
@@ -1,0 +1,7 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+defaults:
+  image:
+    tag: 123

--- a/tests/helm/schema/defaults.labels.invalid.fail.yaml
+++ b/tests/helm/schema/defaults.labels.invalid.fail.yaml
@@ -1,0 +1,9 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+
+defaults:
+  labels:
+    - foo
+    - bar

--- a/tests/helm/schema/defaults.labels.nested.fail.yaml
+++ b/tests/helm/schema/defaults.labels.nested.fail.yaml
@@ -1,0 +1,10 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+
+defaults:
+  labels:
+    foo: bar
+    nested:
+      key: value

--- a/tests/helm/schema/defaults.labels.valid.pass.yaml
+++ b/tests/helm/schema/defaults.labels.valid.pass.yaml
@@ -1,0 +1,4 @@
+defaults:
+  labels:
+    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/instance: my-instance

--- a/tests/helm/schema/defaults.nodeSelector.invalid.fail.yaml
+++ b/tests/helm/schema/defaults.nodeSelector.invalid.fail.yaml
@@ -1,0 +1,4 @@
+defaults:
+  nodeSelector:
+    kubernetes.io/os: 123 # Should fail as it's not a string
+    node-role.kubernetes.io/worker: true # Should fail as it's not a string

--- a/tests/helm/schema/defaults.nodeSelector.nested.fail.yaml
+++ b/tests/helm/schema/defaults.nodeSelector.nested.fail.yaml
@@ -1,0 +1,4 @@
+defaults:
+  nodeSelector:
+    kubernetes.io/os:
+      nested: "value" # Should fail as it's a nested object, not a string

--- a/tests/helm/schema/defaults.nodeSelector.valid.pass.yaml
+++ b/tests/helm/schema/defaults.nodeSelector.valid.pass.yaml
@@ -1,0 +1,4 @@
+defaults:
+  nodeSelector:
+    kubernetes.io/os: "linux"
+    node-role.kubernetes.io/worker: "true"

--- a/tests/helm/schema/defaults.priorityClassName.invalid.fail.yaml
+++ b/tests/helm/schema/defaults.priorityClassName.invalid.fail.yaml
@@ -1,0 +1,6 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+defaults:
+  priorityClassName: 123

--- a/tests/helm/schema/defaults.priorityClassName.valid.pass.yaml
+++ b/tests/helm/schema/defaults.priorityClassName.valid.pass.yaml
@@ -1,0 +1,6 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+defaults:
+  priorityClassName: "high-priority"

--- a/tests/helm/schema/defaults.tolerations.empty.pass.yaml
+++ b/tests/helm/schema/defaults.tolerations.empty.pass.yaml
@@ -1,0 +1,2 @@
+defaults:
+  tolerations: []

--- a/tests/helm/schema/defaults.tolerations.invalid.fail.yaml
+++ b/tests/helm/schema/defaults.tolerations.invalid.fail.yaml
@@ -1,0 +1,7 @@
+defaults:
+  tolerations:
+    - key: 123 # Invalid: should be a string
+      operator: true # Invalid: should be a string
+      value: ["not", "a", "string"] # Invalid: should be a string
+      effect: 42 # Invalid: should be a string
+      tolerationSeconds: "notanumber" # Invalid: should be an integer or null

--- a/tests/helm/schema/defaults.tolerations.nested.fail.yaml
+++ b/tests/helm/schema/defaults.tolerations.nested.fail.yaml
@@ -1,0 +1,7 @@
+defaults:
+  tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "experimental"
+      effect: "NoSchedule"
+    - "not-an-object"

--- a/tests/helm/schema/defaults.tolerations.notarray.fail.yaml
+++ b/tests/helm/schema/defaults.tolerations.notarray.fail.yaml
@@ -1,0 +1,6 @@
+host: "test-host"
+clusterName: "test-cluster"
+cloudAccountId: "test-account"
+region: "us-west-2"
+defaults:
+  tolerations: {}

--- a/tests/helm/schema/defaults.tolerations.valid.pass.yaml
+++ b/tests/helm/schema/defaults.tolerations.valid.pass.yaml
@@ -1,0 +1,10 @@
+defaults:
+  tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "experimental"
+      effect: "NoSchedule"
+    - key: "workload"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 3600

--- a/tests/helm/schema/image.digest.invalid.fail.yaml
+++ b/tests/helm/schema/image.digest.invalid.fail.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      digest: 123 # Should fail as it's not a string

--- a/tests/helm/schema/image.digest.null.pass.yaml
+++ b/tests/helm/schema/image.digest.null.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      digest: null

--- a/tests/helm/schema/image.digest.valid.pass.yaml
+++ b/tests/helm/schema/image.digest.valid.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      digest: sha256:5c474275684bbf271ec40502ab50158b2f9826de5877d8feec27e22e8d6ee3d2

--- a/tests/helm/schema/image.pullPolicy.Always.pass.yaml
+++ b/tests/helm/schema/image.pullPolicy.Always.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      pullPolicy: Always

--- a/tests/helm/schema/image.pullPolicy.IfNotPresent.pass.yaml
+++ b/tests/helm/schema/image.pullPolicy.IfNotPresent.pass.yaml
@@ -1,0 +1,3 @@
+defaults:
+  image:
+    pullPolicy: IfNotPresent

--- a/tests/helm/schema/image.pullPolicy.Never.pass.yaml
+++ b/tests/helm/schema/image.pullPolicy.Never.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      pullPolicy: Never

--- a/tests/helm/schema/image.pullPolicy.null.pass.yaml
+++ b/tests/helm/schema/image.pullPolicy.null.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      pullPolicy: null

--- a/tests/helm/schema/image.pullSecrets.invalid.fail.yaml
+++ b/tests/helm/schema/image.pullSecrets.invalid.fail.yaml
@@ -1,0 +1,6 @@
+components:
+  agent:
+    image:
+      pullSecrets:
+        - 123 # Should fail as it's not a string
+        - true # Should fail as it's not a string

--- a/tests/helm/schema/image.pullSecrets.nested.fail.yaml
+++ b/tests/helm/schema/image.pullSecrets.nested.fail.yaml
@@ -1,0 +1,5 @@
+components:
+  agent:
+    image:
+      pullSecrets:
+        - ["nested", "list"] # Should fail as it's a nested list, not a string

--- a/tests/helm/schema/image.pullSecrets.null.pass.yaml
+++ b/tests/helm/schema/image.pullSecrets.null.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      pullSecrets: null

--- a/tests/helm/schema/image.pullSecrets.valid.pass.yaml
+++ b/tests/helm/schema/image.pullSecrets.valid.pass.yaml
@@ -1,0 +1,6 @@
+components:
+  agent:
+    image:
+      pullSecrets:
+        - name: "docker-registry-secret"
+        - name: "gcr-secret"

--- a/tests/helm/schema/image.registry.invalid.fail.yaml
+++ b/tests/helm/schema/image.registry.invalid.fail.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      registry: 123 # Should fail as it's not a string

--- a/tests/helm/schema/image.registry.null.pass.yaml
+++ b/tests/helm/schema/image.registry.null.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      registry: null

--- a/tests/helm/schema/image.registry.valid.pass.yaml
+++ b/tests/helm/schema/image.registry.valid.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      registry: docker.io

--- a/tests/helm/schema/image.repository.invalid.fail.yaml
+++ b/tests/helm/schema/image.repository.invalid.fail.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      repository: 123 # Should fail as it's not a string

--- a/tests/helm/schema/image.repository.null.pass.yaml
+++ b/tests/helm/schema/image.repository.null.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      repository: null

--- a/tests/helm/schema/image.repository.valid.pass.yaml
+++ b/tests/helm/schema/image.repository.valid.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      repository: cloudzero/agent

--- a/tests/helm/schema/image.tag.invalid.fail.yaml
+++ b/tests/helm/schema/image.tag.invalid.fail.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      tag: 123 # Should fail as it's not a string

--- a/tests/helm/schema/image.tag.null.pass.yaml
+++ b/tests/helm/schema/image.tag.null.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      tag: null

--- a/tests/helm/schema/image.tag.valid.pass.yaml
+++ b/tests/helm/schema/image.tag.valid.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    image:
+      tag: v1.0.0

--- a/tests/helm/schema/imagePullSecrets.nonobject.fail.yaml
+++ b/tests/helm/schema/imagePullSecrets.nonobject.fail.yaml
@@ -1,0 +1,2 @@
+imagePullSecrets:
+  - "just-a-string"

--- a/tests/helm/schema/imagePullSecrets.null.pass.yaml
+++ b/tests/helm/schema/imagePullSecrets.null.pass.yaml
@@ -1,0 +1,1 @@
+imagePullSecrets: null

--- a/tests/helm/schema/imagePullSecrets.string.fail.yaml
+++ b/tests/helm/schema/imagePullSecrets.string.fail.yaml
@@ -1,0 +1,1 @@
+imagePullSecrets: "not-a-list"

--- a/tests/helm/schema/initBackfillJob.invalid.fail.yaml
+++ b/tests/helm/schema/initBackfillJob.invalid.fail.yaml
@@ -1,0 +1,9 @@
+initBackfillJob:
+  # enabled should be a boolean, not a string
+  enabled: "true"
+  # annotations should be an object, not an array
+  annotations: []
+  # tolerations should be an array of objects, not a string
+  tolerations: "invalid"
+  # image should be an object with specific properties, not a string
+  image: "invalid"

--- a/tests/helm/schema/initCertJob.invalid.fail.yaml
+++ b/tests/helm/schema/initCertJob.invalid.fail.yaml
@@ -1,0 +1,19 @@
+initCertJob:
+  # enabled should be a boolean, not a string
+  enabled: "true"
+  # annotations should be an object, not an array
+  annotations: []
+  # tolerations should be an array of objects, not a string
+  tolerations: "invalid"
+  # image should be an object with specific properties, not a string
+  image: "invalid"
+  # rbac should be an object with specific properties
+  rbac:
+    # create should be a boolean, not a string
+    create: "true"
+    # serviceAccountName should be a string, not a number
+    serviceAccountName: 123
+    # clusterRoleName should be a string, not a boolean
+    clusterRoleName: true
+    # clusterRoleBindingName should be a string, not an array
+    clusterRoleBindingName: []

--- a/tests/helm/schema/podDisruptionBudget.maxUnavailable.1.pass.yaml
+++ b/tests/helm/schema/podDisruptionBudget.maxUnavailable.1.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    podDisruptionBudget:
+      maxUnavailable: 1

--- a/tests/helm/schema/podDisruptionBudget.maxUnavailable.invalid.fail.yaml
+++ b/tests/helm/schema/podDisruptionBudget.maxUnavailable.invalid.fail.yaml
@@ -1,0 +1,3 @@
+components:
+  agent:
+    podDisruptionBudget: true # Should fail as it's a boolean, not a PodDisruptionBudget object

--- a/tests/helm/schema/podDisruptionBudget.maxUnavailable.percent.pass.yaml
+++ b/tests/helm/schema/podDisruptionBudget.maxUnavailable.percent.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    podDisruptionBudget:
+      maxUnavailable: 10%

--- a/tests/helm/schema/podDisruptionBudget.minAvailable.2.pass.yaml
+++ b/tests/helm/schema/podDisruptionBudget.minAvailable.2.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    podDisruptionBudget:
+      minAvailable: 2

--- a/tests/helm/schema/podDisruptionBudget.minAvailable.invalid.fail.yaml
+++ b/tests/helm/schema/podDisruptionBudget.minAvailable.invalid.fail.yaml
@@ -1,0 +1,3 @@
+components:
+  agent:
+    podDisruptionBudget: true # Should fail as it's a boolean, not a PodDisruptionBudget object

--- a/tests/helm/schema/podDisruptionBudget.minAvailable.percent.pass.yaml
+++ b/tests/helm/schema/podDisruptionBudget.minAvailable.percent.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    podDisruptionBudget:
+      minAvailable: 20%

--- a/tests/helm/schema/prometheusConfig.cadvisor.disabled.fail.yaml
+++ b/tests/helm/schema/prometheusConfig.cadvisor.disabled.fail.yaml
@@ -1,0 +1,6 @@
+prometheusConfig:
+  globalScrapeInterval: 60s
+  scrapeJobs:
+    cadvisor:
+      enabled: false
+      scrapeInterval: 60s

--- a/tests/helm/schema/prometheusConfig.invalid.duration.fail.yaml
+++ b/tests/helm/schema/prometheusConfig.invalid.duration.fail.yaml
@@ -1,0 +1,6 @@
+prometheusConfig:
+  globalScrapeInterval: "invalid"
+  scrapeJobs:
+    kubeStateMetrics:
+      enabled: true
+      scrapeInterval: 60s

--- a/tests/helm/schema/prometheusConfig.invalid.job.fail.yaml
+++ b/tests/helm/schema/prometheusConfig.invalid.job.fail.yaml
@@ -1,0 +1,6 @@
+prometheusConfig:
+  globalScrapeInterval: 60s
+  scrapeJobs:
+    unknownJob:
+      enabled: true
+      scrapeInterval: 60s

--- a/tests/helm/schema/prometheusConfig.minimal.pass.yaml
+++ b/tests/helm/schema/prometheusConfig.minimal.pass.yaml
@@ -1,0 +1,6 @@
+prometheusConfig:
+  globalScrapeInterval: 60s
+  scrapeJobs:
+    kubeStateMetrics:
+      enabled: true
+      scrapeInterval: 60s

--- a/tests/helm/schema/prometheusConfig.valid.pass.yaml
+++ b/tests/helm/schema/prometheusConfig.valid.pass.yaml
@@ -1,0 +1,23 @@
+prometheusConfig:
+  configMapNameOverride: "custom-config"
+  configMapAnnotations:
+    my.annotation: value
+  configOverride: "custom config"
+  globalScrapeInterval: 60s
+  scrapeJobs:
+    kubeStateMetrics:
+      enabled: true
+      scrapeInterval: 60s
+    cadvisor:
+      enabled: true
+      scrapeInterval: 60s
+    prometheus:
+      enabled: true
+      scrapeInterval: 120s
+    aggregator:
+      enabled: true
+      scrapeInterval: 120s
+    additionalScrapeJobs:
+      - job_name: custom-job
+        static_configs:
+          - targets: ["localhost:9090"]

--- a/tools.go
+++ b/tools.go
@@ -6,6 +6,7 @@
 package tools
 
 import (
+	_ "github.com/itchyny/gojq/cmd/gojq"
 	_ "go.uber.org/mock/mockgen"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 	_ "honnef.co/go/tools/cmd/staticcheck"


### PR DESCRIPTION
## What

This adds a lot of additional validation to the values.yaml schema, as well as some supporting infrastructure. Specifically, lots of tests and the schema is now written in YAML, which is automatically processed to JSON (as Helm expects) in the Makefile.

There is also a script to merge the JSON Schema for Kubernetes (see https://github.com/yannh/kubernetes-json-schema) into our schema, so we can reference the Kubernetes types instead of redefining a ton of stuff. They're not as strict as I'd like, but they are very complete as they are auto-generated from Kubernetes. In other words, virtually zero false positives, but false negatives are possible.

This also add several missing properties to values.yaml and schema. These properties are referenced in the Helm chart, but were not previously mentioned in the values.yaml, nor included in the schema.

Oh, and I added a helm/validations.yaml to check some things we can't really validate in the schema. For example, the only test in there currently is one to ensure that either an `apiKey` or `existingSecretName` is set.

## Why?

This provides a couple of big advantages. First, it documents the format of a lot of stuff in the Helm chart, which was honestly a bit tricky to figure out.

Because Helm will perform validation against the schema by default, it also allows us to catch many configuration errors much sooner. In particular, because we use `additionalProperties: false` pretty much everywhere, it protects against users providing configuration which isn't actually used anywhere, but that they expect to be.

This also provides a significantly improved upgrade path for customers who are currently relying on deprecated, unstable APIs... at some point in the future, we can simply remove the deprecated items from the schema and customers will get an error message instead of their configuration overrides just silently no longer working.

I also have some ideas for things we could do with this moving forward. For example, Helm doesn't currently warn if you use a property marked as deprecated in the schema, but I believe it would be possible to use jq/gojq to extract a list of deprecated properties from the schema and create a Helm template to compare them to their default values and, if they don't match, emit a warning (or error, depending on the config). That way we can mark properties as deprecated and give customers time to update before we remove them entirely.

## How Tested

At its core, testing is pretty straightforward; just do what you would normally do with the chart! Helm will run the validations when you use the template, lint, install, etc. commands.

Beyond that, I also added a bunch of tests to the tests/helm/schema/ directory, as well as the code to run those tests to the Makefile (`make helm-test-schema`). This are all pretty simple, and can be either positive or negative tests based on their extension (*.pass.yaml vs *.fail.yaml).