### PR TITLE
CP-29051: if Go tests fail in the merge queue, rerun them

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -3,6 +3,15 @@ name: CI
 on: [push]
 
 jobs:
+  # Dump the GitHub context for debugging purposes.
+  dump-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT" | jq '.'
+
   custom-checks: # Assorted custom checks
     runs-on: ubuntu-latest
     steps:
@@ -135,7 +144,15 @@ jobs:
         run: |
           go mod download
       - name: Run go tests
-        run: make test
+        uses: nick-fields/retry@v3
+        with:
+          # Retry up to 3 times if we are running in the merge queue to
+          # (hopefully) get past any flaky tests. Otherwise, only try once. We
+          # can easily re-run tests when we're not in the merge queue, and it's
+          # a good reminder to fix any flaky tests.
+          max_attempts: ${{ startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && 3 || 1 }}
+          timeout_minutes: 30
+          command: make test
 
   integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why?

A few of our Go tests are a bit flaky. Normally this isn't a major problem since it's pretty straightforward to re-run the failed tests, and honestly it's a good reminder to fix those flaky tests.

However, with the merge queue this is extremely annoying, since if *any* test fails it gets kicked out of the queue and we have to re-add it manually, at which point it runs *all* the tests again.

## What

So I thought it might be a good idea to tweak the CI setup a bit so that, if we're running in the merge queue, `make test` failures will simply be re-run (up to thrice). However, if we aren't in the merge queue only make a single attempt.

Hopefully this becomes less important as time goes on and we are able to fix these tests, but in the meantime this should be quite useful.

## How Tested

By letting the action run. This will at least make sure we don't break the non-merge-queue behavior. Unfortunately I'm not sure there is a good way to test the merge queue except by just trying to merge this...