### PR TITLE
CP-29248: clean up and document Prometheus config

### DIFF
--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -136,6 +136,12 @@ remote_write:
 
 {{/* Define static-kube-state-metrics scrape job configuration */}}
 {{- define "cloudzero-agent.prometheus.scrapeKubeStateMetrics" -}}
+# Kube State Metrics Scrape Job
+# static-kube-state-metrics
+#
+# Kube State Metrics provides the CloudZero Agent with information
+# regarding the configuration and state of various Kubernetes objects
+# (nodes, pods, etc.), including where they are located in the cluster.
 - job_name: static-kube-state-metrics
   honor_timestamps: true
   track_timestamps_staleness: false
@@ -150,37 +156,76 @@ remote_write:
   enable_compression: true
   follow_redirects: true
   enable_http2: true
+
+  # Given a Kubernetes resource with a structure like:
+  #
+  #   apiVersion: v1
+  #   kind: Service
+  #   metadata:
+  #     name: my-service
+  #     namespace: my-namespace
+  #     labels:
+  #       app: my-app
+  #       environment: production
+  #
+  # Kube State Metrics should provide labels such as:
+  #
+  #   __meta_kubernetes_service_name:               my-name
+  #   __meta_kubernetes_namespace:                  my-namespace
+  #   __meta_kubernetes_service_label_app:          my-app
+  #   __meta_kubernetes_service_label_environment:  production
+  #
+  # We read these into the CloudZero Agent as:
+  #
+  #   service: my-name
+  #   namespace: my-namespace
+  #   app: my-app
+  #   environment: production
   relabel_configs:
+
+    # Relabel __meta_kubernetes_service_label_(.+) labels to $1.
     - separator: ;
       regex: __meta_kubernetes_service_label_(.+)
       replacement: $1
       action: labelmap
+
+    # Replace __meta_kubernetes_namespace labels with "namespace"
     - source_labels: [__meta_kubernetes_namespace]
       separator: ;
       regex: (.*)
       target_label: namespace
       replacement: $1
       action: replace
+
+    # Replace __meta_kubernetes_service_name labels with "service"
     - source_labels: [__meta_kubernetes_service_name]
       separator: ;
       regex: (.*)
       target_label: service
       replacement: $1
       action: replace
+
+    # Replace "__meta_kubernetes_pod_node_name" labels to "node"
     - source_labels: [__meta_kubernetes_pod_node_name]
       separator: ;
       regex: (.*)
       target_label: node
       replacement: $1
       action: replace
+  # We filter out all but a select few metrics and labels.
   metric_relabel_configs:
+
+    # Metric names to keep.
     - source_labels: [__name__]
       regex: {{ printf "^(%s)$" (join "|" (include "cloudzero-agent.defaults" . | fromYaml).kubeMetrics) }}
       action: keep
+
+    # Metric labels to keep.
     - separator: ;
       regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
       replacement: $1
       action: labelkeep
+
   static_configs:
     - targets:
       - {{ include "cloudzero-agent.kubeStateMetrics.kubeStateMetricsSvcTargetName" . }}
@@ -201,11 +246,15 @@ remote_write:
       kubeconfig_file: ""
       follow_redirects: true
       enable_http2: true
+
   relabel_configs:
+    # Keep __meta_kubernetes_endpoints_name labels.
     - source_labels: [__meta_kubernetes_endpoints_name]
       action: keep
       regex: {{ include "cloudzero-agent.insightsController.server.webhookFullname" . }}-svc
+
   metric_relabel_configs:
+    # Metrics to keep.
     - source_labels: [__name__]
       regex: "^({{ join "|" (include "cloudzero-agent.defaults" . | fromYaml).insightsMetrics }})$"
       action: keep
@@ -214,6 +263,10 @@ remote_write:
 {{/* Define cloudzero-nodes-cAdvisor scrape job configuration */}}
 {{- define "cloudzero-agent.prometheus.scrapeCAdvisor" -}}
 {{- $scrapeLocal := .scrapeLocalNodeOnly | default false -}}
+# cAdvisor Scrape Job cloudzero-nodes-cadvisor
+#
+# This job scrapes metrics about container resource usage (CPU, memory,
+# network, etc.).
 - job_name: cloudzero-nodes-cadvisor # container_* metrics
   honor_timestamps: true
   track_timestamps_staleness: false
@@ -225,36 +278,61 @@ remote_write:
   - PrometheusText0.0.4
   scheme: https
   enable_compression: true
+
+  # cAdvisor endpoints are protected. In order to access them we need the
+  # credentials for the ServiceAccount.
   authorization:
     type: Bearer
     credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
+
   follow_redirects: true
   enable_http2: true
   {{- if $scrapeLocal }}
-  metrics_path: /metrics/cadvisor # Direct kubelet cAdvisor path
+  # Scrape metrics directly from cAdvisor endpoint.
+  metrics_path: /metrics/cadvisor
+
+  # Scrape metrics from cAdvisor
   relabel_configs:
+
+    # Replace "__meta_kubernetes_node_name" labels with "node_name"
     - source_labels: [__meta_kubernetes_node_name]
       target_label: node_name
       action: replace
+
+    # Only scrape metrics for the node we are running on.
+    #
+    #
+    # Note that Prometheus does not handle the regex being a variable. In order
+    # to get this to work, we run a sed command in an initContainer to replace
+    # '${NODE_NAME}' with the name of the node we are running on. See the agent
+    # DaemonSet configuration for details.
     - source_labels: [__meta_kubernetes_node_name]
       regex: ${NODE_NAME}
       action: keep
+
+    # Add port number to __address__ in "__meta_kubernetes_node_address_InternalIP"
     - source_labels: [__meta_kubernetes_node_address_InternalIP]
       action: replace
       target_label: __address__
       replacement: ${1}:10250
   {{- else }}
   metrics_path: /metrics
+
+  # Scrape metrics from cAdvisor.
   relabel_configs:
-    # Specific to proxied scrape (via Kubernetes API server)
+
+    # Replace the value of __address__ labels with "kubernetes.default.svc:443"
     - separator: ;
       regex: (.*)
       target_label: __address__
       replacement: kubernetes.default.svc:443
       action: replace
+
+    # Replace the value of __metrics_path__ in __meta_kubernetes_node_name with
+    # "/api/v1/nodes/$1/proxy/metrics/cadvisor"
     - source_labels: [__meta_kubernetes_node_name]
       separator: ;
       regex: (.+)
@@ -262,20 +340,30 @@ remote_write:
       replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
       action: replace
   {{- end }}
-    # Common relabel_configs
+
+    # Remove "__meta_kubernetes_node_label_" prefix from labels.
     - separator: ;
       regex: __meta_kubernetes_node_label_(.+)
       replacement: $1
       action: labelmap
+
+    # Replace __meta_kubernetes_node_name labels with "node"
     - source_labels: [__meta_kubernetes_node_name]
       target_label: node
       action: replace
+
+  # We only want to keep a select few labels.
   metric_relabel_configs:
+
+    # Labels to keep.
     - action: labelkeep
       regex: {{ printf "^(%s)$" (include "cloudzero-agent.requiredMetricLabels" .root) }}
+
+    # Metrics to keep.
     - source_labels: [__name__]
       regex: {{ printf "^(%s)$" (join "|" (include "cloudzero-agent.defaults" .root | fromYaml).containerMetrics) }}
       action: keep
+
   kubernetes_sd_configs:
     - role: node
       kubeconfig_file: ""

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -151,38 +151,38 @@ remote_write:
   follow_redirects: true
   enable_http2: true
   relabel_configs:
-  - separator: ;
-    regex: __meta_kubernetes_service_label_(.+)
-    replacement: $1
-    action: labelmap
-  - source_labels: [__meta_kubernetes_namespace]
-    separator: ;
-    regex: (.*)
-    target_label: namespace
-    replacement: $1
-    action: replace
-  - source_labels: [__meta_kubernetes_service_name]
-    separator: ;
-    regex: (.*)
-    target_label: service
-    replacement: $1
-    action: replace
-  - source_labels: [__meta_kubernetes_pod_node_name]
-    separator: ;
-    regex: (.*)
-    target_label: node
-    replacement: $1
-    action: replace
+    - separator: ;
+      regex: __meta_kubernetes_service_label_(.+)
+      replacement: $1
+      action: labelmap
+    - source_labels: [__meta_kubernetes_namespace]
+      separator: ;
+      regex: (.*)
+      target_label: namespace
+      replacement: $1
+      action: replace
+    - source_labels: [__meta_kubernetes_service_name]
+      separator: ;
+      regex: (.*)
+      target_label: service
+      replacement: $1
+      action: replace
+    - source_labels: [__meta_kubernetes_pod_node_name]
+      separator: ;
+      regex: (.*)
+      target_label: node
+      replacement: $1
+      action: replace
   metric_relabel_configs:
-  - source_labels: [__name__]
-    regex: {{ printf "^(%s)$" (join "|" (include "cloudzero-agent.defaults" . | fromYaml).kubeMetrics) }}
-    action: keep
-  - separator: ;
-    regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
-    replacement: $1
-    action: labelkeep
+    - source_labels: [__name__]
+      regex: {{ printf "^(%s)$" (join "|" (include "cloudzero-agent.defaults" . | fromYaml).kubeMetrics) }}
+      action: keep
+    - separator: ;
+      regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+      replacement: $1
+      action: labelkeep
   static_configs:
-  - targets:
+    - targets:
       - {{ include "cloudzero-agent.kubeStateMetrics.kubeStateMetricsSvcTargetName" . }}
 {{- end -}}
 
@@ -236,49 +236,49 @@ remote_write:
   {{- if $scrapeLocal }}
   metrics_path: /metrics/cadvisor # Direct kubelet cAdvisor path
   relabel_configs:
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: node_name
-    action: replace
-  - source_labels: [__meta_kubernetes_node_name]
-    regex: ${NODE_NAME}
-    action: keep
-  - source_labels: [__meta_kubernetes_node_address_InternalIP]
-    action: replace
-    target_label: __address__
-    replacement: ${1}:10250
+    - source_labels: [__meta_kubernetes_node_name]
+      target_label: node_name
+      action: replace
+    - source_labels: [__meta_kubernetes_node_name]
+      regex: ${NODE_NAME}
+      action: keep
+    - source_labels: [__meta_kubernetes_node_address_InternalIP]
+      action: replace
+      target_label: __address__
+      replacement: ${1}:10250
   {{- else }}
   metrics_path: /metrics
   relabel_configs:
-  # Specific to proxied scrape (via Kubernetes API server)
-  - separator: ;
-    regex: (.*)
-    target_label: __address__
-    replacement: kubernetes.default.svc:443
-    action: replace
-  - source_labels: [__meta_kubernetes_node_name]
-    separator: ;
-    regex: (.+)
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
-    action: replace
+    # Specific to proxied scrape (via Kubernetes API server)
+    - separator: ;
+      regex: (.*)
+      target_label: __address__
+      replacement: kubernetes.default.svc:443
+      action: replace
+    - source_labels: [__meta_kubernetes_node_name]
+      separator: ;
+      regex: (.+)
+      target_label: __metrics_path__
+      replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+      action: replace
   {{- end }}
-  # Common relabel_configs
-  - separator: ;
-    regex: __meta_kubernetes_node_label_(.+)
-    replacement: $1
-    action: labelmap
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: node
-    action: replace
+    # Common relabel_configs
+    - separator: ;
+      regex: __meta_kubernetes_node_label_(.+)
+      replacement: $1
+      action: labelmap
+    - source_labels: [__meta_kubernetes_node_name]
+      target_label: node
+      action: replace
   metric_relabel_configs:
-  - action: labelkeep
-    regex: {{ printf "^(%s)$" (include "cloudzero-agent.requiredMetricLabels" .root) }}
-  - source_labels: [__name__]
-    regex: {{ printf "^(%s)$" (join "|" (include "cloudzero-agent.defaults" .root | fromYaml).containerMetrics) }}
-    action: keep
+    - action: labelkeep
+      regex: {{ printf "^(%s)$" (include "cloudzero-agent.requiredMetricLabels" .root) }}
+    - source_labels: [__name__]
+      regex: {{ printf "^(%s)$" (join "|" (include "cloudzero-agent.defaults" .root | fromYaml).containerMetrics) }}
+      action: keep
   kubernetes_sd_configs:
-  - role: node
-    kubeconfig_file: ""
-    follow_redirects: true
-    enable_http2: true
+    - role: node
+      kubeconfig_file: ""
+      follow_redirects: true
+      enable_http2: true
 {{- end -}}

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -104,6 +104,12 @@ data:
       scrape_interval: 60s
 
     scrape_configs:
+      # Kube State Metrics Scrape Job
+      # static-kube-state-metrics
+      #
+      # Kube State Metrics provides the CloudZero Agent with information
+      # regarding the configuration and state of various Kubernetes objects
+      # (nodes, pods, etc.), including where they are located in the cluster.
       - job_name: static-kube-state-metrics
         honor_timestamps: true
         track_timestamps_staleness: false
@@ -118,37 +124,76 @@ data:
         enable_compression: true
         follow_redirects: true
         enable_http2: true
+      
+        # Given a Kubernetes resource with a structure like:
+        #
+        #   apiVersion: v1
+        #   kind: Service
+        #   metadata:
+        #     name: my-service
+        #     namespace: my-namespace
+        #     labels:
+        #       app: my-app
+        #       environment: production
+        #
+        # Kube State Metrics should provide labels such as:
+        #
+        #   __meta_kubernetes_service_name:               my-name
+        #   __meta_kubernetes_namespace:                  my-namespace
+        #   __meta_kubernetes_service_label_app:          my-app
+        #   __meta_kubernetes_service_label_environment:  production
+        #
+        # We read these into the CloudZero Agent as:
+        #
+        #   service: my-name
+        #   namespace: my-namespace
+        #   app: my-app
+        #   environment: production
         relabel_configs:
+      
+          # Relabel __meta_kubernetes_service_label_(.+) labels to $1.
           - separator: ;
             regex: __meta_kubernetes_service_label_(.+)
             replacement: $1
             action: labelmap
+      
+          # Replace __meta_kubernetes_namespace labels with "namespace"
           - source_labels: [__meta_kubernetes_namespace]
             separator: ;
             regex: (.*)
             target_label: namespace
             replacement: $1
             action: replace
+      
+          # Replace __meta_kubernetes_service_name labels with "service"
           - source_labels: [__meta_kubernetes_service_name]
             separator: ;
             regex: (.*)
             target_label: service
             replacement: $1
             action: replace
+      
+          # Replace "__meta_kubernetes_pod_node_name" labels to "node"
           - source_labels: [__meta_kubernetes_pod_node_name]
             separator: ;
             regex: (.*)
             target_label: node
             replacement: $1
             action: replace
+        # We filter out all but a select few metrics and labels.
         metric_relabel_configs:
+      
+          # Metric names to keep.
           - source_labels: [__name__]
             regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info)$
             action: keep
+      
+          # Metric labels to keep.
           - separator: ;
             regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
             replacement: $1
             action: labelkeep
+      
         static_configs:
           - targets:
             - cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080
@@ -165,11 +210,15 @@ data:
             kubeconfig_file: ""
             follow_redirects: true
             enable_http2: true
+      
         relabel_configs:
+          # Keep __meta_kubernetes_endpoints_name labels.
           - source_labels: [__meta_kubernetes_endpoints_name]
             action: keep
             regex: cz-agent-cloudzero-agent-webhook-server-svc
+      
         metric_relabel_configs:
+          # Metrics to keep.
           - source_labels: [__name__]
             regex: "^(go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_idle_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_objects|go_memstats_last_gc_time_seconds|go_memstats_alloc_bytes|go_memstats_stack_inuse_bytes|go_goroutines|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|process_virtual_memory_max_bytes|remote_write_timeseries_total|remote_write_response_codes_total|remote_write_payload_size_bytes|remote_write_failures_total|remote_write_records_processed_total|remote_write_db_failures_total|http_requests_total|storage_write_failure_total|czo_webhook_types_total|czo_storage_types_total|czo_ingress_types_total|czo_gateway_types_total)$"
             action: keep
@@ -237,6 +286,10 @@ data:
       scrape_interval: 60s
 
     scrape_configs:
+      # cAdvisor Scrape Job cloudzero-nodes-cadvisor
+      #
+      # This job scrapes metrics about container resource usage (CPU, memory,
+      # network, etc.).
       - job_name: cloudzero-nodes-cadvisor # container_* metrics
         honor_timestamps: true
         track_timestamps_staleness: false
@@ -248,40 +301,69 @@ data:
         - PrometheusText0.0.4
         scheme: https
         enable_compression: true
+      
+        # cAdvisor endpoints are protected. In order to access them we need the
+        # credentials for the ServiceAccount.
         authorization:
           type: Bearer
           credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           insecure_skip_verify: true
+      
         follow_redirects: true
         enable_http2: true
-        metrics_path: /metrics/cadvisor # Direct kubelet cAdvisor path
+        # Scrape metrics directly from cAdvisor endpoint.
+        metrics_path: /metrics/cadvisor
+      
+        # Scrape metrics from cAdvisor
         relabel_configs:
+      
+          # Replace "__meta_kubernetes_node_name" labels with "node_name"
           - source_labels: [__meta_kubernetes_node_name]
             target_label: node_name
             action: replace
+      
+          # Only scrape metrics for the node we are running on.
+          #
+          #
+          # Note that Prometheus does not handle the regex being a variable. In order
+          # to get this to work, we run a sed command in an initContainer to replace
+          # '${NODE_NAME}' with the name of the node we are running on. See the agent
+          # DaemonSet configuration for details.
           - source_labels: [__meta_kubernetes_node_name]
             regex: ${NODE_NAME}
             action: keep
+      
+          # Add port number to __address__ in "__meta_kubernetes_node_address_InternalIP"
           - source_labels: [__meta_kubernetes_node_address_InternalIP]
             action: replace
             target_label: __address__
             replacement: ${1}:10250
-          # Common relabel_configs
+      
+          # Remove "__meta_kubernetes_node_label_" prefix from labels.
           - separator: ;
             regex: __meta_kubernetes_node_label_(.+)
             replacement: $1
             action: labelmap
+      
+          # Replace __meta_kubernetes_node_name labels with "node"
           - source_labels: [__meta_kubernetes_node_name]
             target_label: node
             action: replace
+      
+        # We only want to keep a select few labels.
         metric_relabel_configs:
+      
+          # Labels to keep.
           - action: labelkeep
             regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+      
+          # Metrics to keep.
           - source_labels: [__name__]
             regex: ^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
             action: keep
+      
         kubernetes_sd_configs:
           - role: node
             kubeconfig_file: ""

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -119,38 +119,38 @@ data:
         follow_redirects: true
         enable_http2: true
         relabel_configs:
-        - separator: ;
-          regex: __meta_kubernetes_service_label_(.+)
-          replacement: $1
-          action: labelmap
-        - source_labels: [__meta_kubernetes_namespace]
-          separator: ;
-          regex: (.*)
-          target_label: namespace
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_service_name]
-          separator: ;
-          regex: (.*)
-          target_label: service
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_node_name]
-          separator: ;
-          regex: (.*)
-          target_label: node
-          replacement: $1
-          action: replace
+          - separator: ;
+            regex: __meta_kubernetes_service_label_(.+)
+            replacement: $1
+            action: labelmap
+          - source_labels: [__meta_kubernetes_namespace]
+            separator: ;
+            regex: (.*)
+            target_label: namespace
+            replacement: $1
+            action: replace
+          - source_labels: [__meta_kubernetes_service_name]
+            separator: ;
+            regex: (.*)
+            target_label: service
+            replacement: $1
+            action: replace
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            separator: ;
+            regex: (.*)
+            target_label: node
+            replacement: $1
+            action: replace
         metric_relabel_configs:
-        - source_labels: [__name__]
-          regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info)$
-          action: keep
-        - separator: ;
-          regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
-          replacement: $1
-          action: labelkeep
+          - source_labels: [__name__]
+            regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info)$
+            action: keep
+          - separator: ;
+            regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+            replacement: $1
+            action: labelkeep
         static_configs:
-        - targets:
+          - targets:
             - cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080
       - job_name: cloudzero-webhook-job
         metrics_path: /metrics
@@ -258,35 +258,35 @@ data:
         enable_http2: true
         metrics_path: /metrics/cadvisor # Direct kubelet cAdvisor path
         relabel_configs:
-        - source_labels: [__meta_kubernetes_node_name]
-          target_label: node_name
-          action: replace
-        - source_labels: [__meta_kubernetes_node_name]
-          regex: ${NODE_NAME}
-          action: keep
-        - source_labels: [__meta_kubernetes_node_address_InternalIP]
-          action: replace
-          target_label: __address__
-          replacement: ${1}:10250
-        # Common relabel_configs
-        - separator: ;
-          regex: __meta_kubernetes_node_label_(.+)
-          replacement: $1
-          action: labelmap
-        - source_labels: [__meta_kubernetes_node_name]
-          target_label: node
-          action: replace
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: node_name
+            action: replace
+          - source_labels: [__meta_kubernetes_node_name]
+            regex: ${NODE_NAME}
+            action: keep
+          - source_labels: [__meta_kubernetes_node_address_InternalIP]
+            action: replace
+            target_label: __address__
+            replacement: ${1}:10250
+          # Common relabel_configs
+          - separator: ;
+            regex: __meta_kubernetes_node_label_(.+)
+            replacement: $1
+            action: labelmap
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: node
+            action: replace
         metric_relabel_configs:
-        - action: labelkeep
-          regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
-        - source_labels: [__name__]
-          regex: ^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
-          action: keep
+          - action: labelkeep
+            regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+          - source_labels: [__name__]
+            regex: ^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
+            action: keep
         kubernetes_sd_configs:
-        - role: node
-          kubeconfig_file: ""
-          follow_redirects: true
-          enable_http2: true
+          - role: node
+            kubeconfig_file: ""
+            follow_redirects: true
+            enable_http2: true
       - job_name: static-prometheus
         scrape_interval: 120s
         static_configs:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -111,19 +111,7 @@ data:
       # regarding the configuration and state of various Kubernetes objects
       # (nodes, pods, etc.), including where they are located in the cluster.
       - job_name: static-kube-state-metrics
-        honor_timestamps: true
-        track_timestamps_staleness: false
         scrape_interval: 60s
-        scrape_timeout: 10s
-        scrape_protocols:
-        - OpenMetricsText1.0.0
-        - OpenMetricsText0.0.1
-        - PrometheusText0.0.4
-        metrics_path: /metrics
-        scheme: http
-        enable_compression: true
-        follow_redirects: true
-        enable_http2: true
       
         # Given a Kubernetes resource with a structure like:
         #
@@ -152,34 +140,20 @@ data:
         relabel_configs:
       
           # Relabel __meta_kubernetes_service_label_(.+) labels to $1.
-          - separator: ;
-            regex: __meta_kubernetes_service_label_(.+)
-            replacement: $1
+          - regex: __meta_kubernetes_service_label_(.+)
             action: labelmap
       
           # Replace __meta_kubernetes_namespace labels with "namespace"
           - source_labels: [__meta_kubernetes_namespace]
-            separator: ;
-            regex: (.*)
             target_label: namespace
-            replacement: $1
-            action: replace
       
           # Replace __meta_kubernetes_service_name labels with "service"
           - source_labels: [__meta_kubernetes_service_name]
-            separator: ;
-            regex: (.*)
             target_label: service
-            replacement: $1
-            action: replace
       
           # Replace "__meta_kubernetes_pod_node_name" labels to "node"
           - source_labels: [__meta_kubernetes_pod_node_name]
-            separator: ;
-            regex: (.*)
             target_label: node
-            replacement: $1
-            action: replace
         # We filter out all but a select few metrics and labels.
         metric_relabel_configs:
       
@@ -189,27 +163,20 @@ data:
             action: keep
       
           # Metric labels to keep.
-          - separator: ;
-            regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
-            replacement: $1
+          - regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
             action: labelkeep
       
         static_configs:
           - targets:
             - cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080
       - job_name: cloudzero-webhook-job
-        metrics_path: /metrics
         scheme: https
-        enable_compression: true
         tls_config:
           insecure_skip_verify: true
-        follow_redirects: true
-        enable_http2: true
+      
         kubernetes_sd_configs:
           - role: endpoints
             kubeconfig_file: ""
-            follow_redirects: true
-            enable_http2: true
       
         relabel_configs:
           # Keep __meta_kubernetes_endpoints_name labels.
@@ -227,8 +194,6 @@ data:
         kubernetes_sd_configs:
           - role: endpoints
             kubeconfig_file: ""
-            follow_redirects: true
-            enable_http2: true
             namespaces:
               names:
                 - cz-agent
@@ -248,7 +213,6 @@ data:
         static_configs:
           - targets:
               - localhost:9090
-        metrics_path: /metrics
         metric_relabel_configs:
           - source_labels: [__name__]
             regex: "^(go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_idle_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_objects|go_memstats_last_gc_time_seconds|go_memstats_alloc_bytes|go_memstats_stack_inuse_bytes|go_goroutines|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|process_virtual_memory_max_bytes|prometheus_agent_corruptions_total|prometheus_api_remote_read_queries|prometheus_http_requests_total|prometheus_notifications_alertmanagers_discovered|prometheus_notifications_dropped_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_histograms_failed_total|prometheus_remote_storage_histograms_total|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_metadata_failed_total|prometheus_remote_storage_metadata_retried_total|prometheus_remote_storage_metadata_total|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_in_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_sd_azure_cache_hit_total|prometheus_sd_azure_failures_total|prometheus_sd_discovered_targets|prometheus_sd_dns_lookup_failures_total|prometheus_sd_failed_configs|prometheus_sd_file_read_errors_total|prometheus_sd_file_scan_duration_seconds|prometheus_sd_file_watcher_errors_total|prometheus_sd_http_failures_total|prometheus_sd_kubernetes_events_total|prometheus_sd_kubernetes_http_request_duration_seconds|prometheus_sd_kubernetes_http_request_total|prometheus_sd_kubernetes_workqueue_depth|prometheus_sd_kubernetes_workqueue_items_total|prometheus_sd_kubernetes_workqueue_latency_seconds|prometheus_sd_kubernetes_workqueue_longest_running_processor_seconds|prometheus_sd_kubernetes_workqueue_unfinished_work_seconds|prometheus_sd_kubernetes_workqueue_work_duration_seconds|prometheus_sd_received_updates_total|prometheus_sd_updates_delayed_total|prometheus_sd_updates_total|prometheus_target_scrape_pool_reloads_failed_total|prometheus_target_scrape_pool_reloads_total|prometheus_target_scrape_pool_sync_total|prometheus_target_scrape_pools_failed_total|prometheus_target_scrape_pools_total|prometheus_target_sync_failed_total|prometheus_target_sync_length_seconds)$"
@@ -290,17 +254,10 @@ data:
       #
       # This job scrapes metrics about container resource usage (CPU, memory,
       # network, etc.).
-      - job_name: cloudzero-nodes-cadvisor # container_* metrics
-        honor_timestamps: true
-        track_timestamps_staleness: false
+      - job_name: cloudzero-nodes-cadvisor
+      
         scrape_interval: 60s
-        scrape_timeout: 10s
-        scrape_protocols:
-        - OpenMetricsText1.0.0
-        - OpenMetricsText0.0.1
-        - PrometheusText0.0.4
         scheme: https
-        enable_compression: true
       
         # cAdvisor endpoints are protected. In order to access them we need the
         # credentials for the ServiceAccount.
@@ -310,9 +267,6 @@ data:
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           insecure_skip_verify: true
-      
-        follow_redirects: true
-        enable_http2: true
         # Scrape metrics directly from cAdvisor endpoint.
         metrics_path: /metrics/cadvisor
       
@@ -322,7 +276,6 @@ data:
           # Replace "__meta_kubernetes_node_name" labels with "node_name"
           - source_labels: [__meta_kubernetes_node_name]
             target_label: node_name
-            action: replace
       
           # Only scrape metrics for the node we are running on.
           #
@@ -337,20 +290,16 @@ data:
       
           # Add port number to __address__ in "__meta_kubernetes_node_address_InternalIP"
           - source_labels: [__meta_kubernetes_node_address_InternalIP]
-            action: replace
             target_label: __address__
             replacement: ${1}:10250
       
           # Remove "__meta_kubernetes_node_label_" prefix from labels.
-          - separator: ;
-            regex: __meta_kubernetes_node_label_(.+)
-            replacement: $1
+          - regex: __meta_kubernetes_node_label_(.+)
             action: labelmap
       
           # Replace __meta_kubernetes_node_name labels with "node"
           - source_labels: [__meta_kubernetes_node_name]
             target_label: node
-            action: replace
       
         # We only want to keep a select few labels.
         metric_relabel_configs:
@@ -367,14 +316,11 @@ data:
         kubernetes_sd_configs:
           - role: node
             kubeconfig_file: ""
-            follow_redirects: true
-            enable_http2: true
       - job_name: static-prometheus
         scrape_interval: 120s
         static_configs:
           - targets:
               - localhost:9090
-        metrics_path: /metrics
         metric_relabel_configs:
           - source_labels: [__name__]
             regex: "^(go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_idle_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_objects|go_memstats_last_gc_time_seconds|go_memstats_alloc_bytes|go_memstats_stack_inuse_bytes|go_goroutines|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|process_virtual_memory_max_bytes|prometheus_agent_corruptions_total|prometheus_api_remote_read_queries|prometheus_http_requests_total|prometheus_notifications_alertmanagers_discovered|prometheus_notifications_dropped_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_histograms_failed_total|prometheus_remote_storage_histograms_total|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_metadata_failed_total|prometheus_remote_storage_metadata_retried_total|prometheus_remote_storage_metadata_total|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_in_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_sd_azure_cache_hit_total|prometheus_sd_azure_failures_total|prometheus_sd_discovered_targets|prometheus_sd_dns_lookup_failures_total|prometheus_sd_failed_configs|prometheus_sd_file_read_errors_total|prometheus_sd_file_scan_duration_seconds|prometheus_sd_file_watcher_errors_total|prometheus_sd_http_failures_total|prometheus_sd_kubernetes_events_total|prometheus_sd_kubernetes_http_request_duration_seconds|prometheus_sd_kubernetes_http_request_total|prometheus_sd_kubernetes_workqueue_depth|prometheus_sd_kubernetes_workqueue_items_total|prometheus_sd_kubernetes_workqueue_latency_seconds|prometheus_sd_kubernetes_workqueue_longest_running_processor_seconds|prometheus_sd_kubernetes_workqueue_unfinished_work_seconds|prometheus_sd_kubernetes_workqueue_work_duration_seconds|prometheus_sd_received_updates_total|prometheus_sd_updates_delayed_total|prometheus_sd_updates_total|prometheus_target_scrape_pool_reloads_failed_total|prometheus_target_scrape_pool_reloads_total|prometheus_target_scrape_pool_sync_total|prometheus_target_scrape_pools_failed_total|prometheus_target_scrape_pools_total|prometheus_target_sync_failed_total|prometheus_target_sync_length_seconds)$"

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -111,19 +111,7 @@ data:
       # regarding the configuration and state of various Kubernetes objects
       # (nodes, pods, etc.), including where they are located in the cluster.
       - job_name: static-kube-state-metrics
-        honor_timestamps: true
-        track_timestamps_staleness: false
         scrape_interval: 60s
-        scrape_timeout: 10s
-        scrape_protocols:
-        - OpenMetricsText1.0.0
-        - OpenMetricsText0.0.1
-        - PrometheusText0.0.4
-        metrics_path: /metrics
-        scheme: http
-        enable_compression: true
-        follow_redirects: true
-        enable_http2: true
       
         # Given a Kubernetes resource with a structure like:
         #
@@ -152,34 +140,20 @@ data:
         relabel_configs:
       
           # Relabel __meta_kubernetes_service_label_(.+) labels to $1.
-          - separator: ;
-            regex: __meta_kubernetes_service_label_(.+)
-            replacement: $1
+          - regex: __meta_kubernetes_service_label_(.+)
             action: labelmap
       
           # Replace __meta_kubernetes_namespace labels with "namespace"
           - source_labels: [__meta_kubernetes_namespace]
-            separator: ;
-            regex: (.*)
             target_label: namespace
-            replacement: $1
-            action: replace
       
           # Replace __meta_kubernetes_service_name labels with "service"
           - source_labels: [__meta_kubernetes_service_name]
-            separator: ;
-            regex: (.*)
             target_label: service
-            replacement: $1
-            action: replace
       
           # Replace "__meta_kubernetes_pod_node_name" labels to "node"
           - source_labels: [__meta_kubernetes_pod_node_name]
-            separator: ;
-            regex: (.*)
             target_label: node
-            replacement: $1
-            action: replace
         # We filter out all but a select few metrics and labels.
         metric_relabel_configs:
       
@@ -189,9 +163,7 @@ data:
             action: keep
       
           # Metric labels to keep.
-          - separator: ;
-            regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
-            replacement: $1
+          - regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
             action: labelkeep
       
         static_configs:
@@ -201,17 +173,10 @@ data:
       #
       # This job scrapes metrics about container resource usage (CPU, memory,
       # network, etc.).
-      - job_name: cloudzero-nodes-cadvisor # container_* metrics
-        honor_timestamps: true
-        track_timestamps_staleness: false
+      - job_name: cloudzero-nodes-cadvisor
+      
         scrape_interval: 60s
-        scrape_timeout: 10s
-        scrape_protocols:
-        - OpenMetricsText1.0.0
-        - OpenMetricsText0.0.1
-        - PrometheusText0.0.4
         scheme: https
-        enable_compression: true
       
         # cAdvisor endpoints are protected. In order to access them we need the
         # credentials for the ServiceAccount.
@@ -222,39 +187,26 @@ data:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           insecure_skip_verify: true
       
-        follow_redirects: true
-        enable_http2: true
-        metrics_path: /metrics
-      
         # Scrape metrics from cAdvisor.
         relabel_configs:
       
           # Replace the value of __address__ labels with "kubernetes.default.svc:443"
-          - separator: ;
-            regex: (.*)
-            target_label: __address__
+          - target_label: __address__
             replacement: kubernetes.default.svc:443
-            action: replace
       
           # Replace the value of __metrics_path__ in __meta_kubernetes_node_name with
           # "/api/v1/nodes/$1/proxy/metrics/cadvisor"
           - source_labels: [__meta_kubernetes_node_name]
-            separator: ;
-            regex: (.+)
             target_label: __metrics_path__
             replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
-            action: replace
       
           # Remove "__meta_kubernetes_node_label_" prefix from labels.
-          - separator: ;
-            regex: __meta_kubernetes_node_label_(.+)
-            replacement: $1
+          - regex: __meta_kubernetes_node_label_(.+)
             action: labelmap
       
           # Replace __meta_kubernetes_node_name labels with "node"
           - source_labels: [__meta_kubernetes_node_name]
             target_label: node
-            action: replace
       
         # We only want to keep a select few labels.
         metric_relabel_configs:
@@ -271,21 +223,14 @@ data:
         kubernetes_sd_configs:
           - role: node
             kubeconfig_file: ""
-            follow_redirects: true
-            enable_http2: true
       - job_name: cloudzero-webhook-job
-        metrics_path: /metrics
         scheme: https
-        enable_compression: true
         tls_config:
           insecure_skip_verify: true
-        follow_redirects: true
-        enable_http2: true
+      
         kubernetes_sd_configs:
           - role: endpoints
             kubeconfig_file: ""
-            follow_redirects: true
-            enable_http2: true
       
         relabel_configs:
           # Keep __meta_kubernetes_endpoints_name labels.
@@ -303,8 +248,6 @@ data:
         kubernetes_sd_configs:
           - role: endpoints
             kubeconfig_file: ""
-            follow_redirects: true
-            enable_http2: true
             namespaces:
               names:
                 - cz-agent
@@ -324,7 +267,6 @@ data:
         static_configs:
           - targets:
               - localhost:9090
-        metrics_path: /metrics
         metric_relabel_configs:
           - source_labels: [__name__]
             regex: "^(go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_idle_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_objects|go_memstats_last_gc_time_seconds|go_memstats_alloc_bytes|go_memstats_stack_inuse_bytes|go_goroutines|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|process_virtual_memory_max_bytes|prometheus_agent_corruptions_total|prometheus_api_remote_read_queries|prometheus_http_requests_total|prometheus_notifications_alertmanagers_discovered|prometheus_notifications_dropped_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_histograms_failed_total|prometheus_remote_storage_histograms_total|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_metadata_failed_total|prometheus_remote_storage_metadata_retried_total|prometheus_remote_storage_metadata_total|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_in_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_sd_azure_cache_hit_total|prometheus_sd_azure_failures_total|prometheus_sd_discovered_targets|prometheus_sd_dns_lookup_failures_total|prometheus_sd_failed_configs|prometheus_sd_file_read_errors_total|prometheus_sd_file_scan_duration_seconds|prometheus_sd_file_watcher_errors_total|prometheus_sd_http_failures_total|prometheus_sd_kubernetes_events_total|prometheus_sd_kubernetes_http_request_duration_seconds|prometheus_sd_kubernetes_http_request_total|prometheus_sd_kubernetes_workqueue_depth|prometheus_sd_kubernetes_workqueue_items_total|prometheus_sd_kubernetes_workqueue_latency_seconds|prometheus_sd_kubernetes_workqueue_longest_running_processor_seconds|prometheus_sd_kubernetes_workqueue_unfinished_work_seconds|prometheus_sd_kubernetes_workqueue_work_duration_seconds|prometheus_sd_received_updates_total|prometheus_sd_updates_delayed_total|prometheus_sd_updates_total|prometheus_target_scrape_pool_reloads_failed_total|prometheus_target_scrape_pool_reloads_total|prometheus_target_scrape_pool_sync_total|prometheus_target_scrape_pools_failed_total|prometheus_target_scrape_pools_total|prometheus_target_sync_failed_total|prometheus_target_sync_length_seconds)$"

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -104,6 +104,12 @@ data:
       scrape_interval: 60s
 
     scrape_configs:
+      # Kube State Metrics Scrape Job
+      # static-kube-state-metrics
+      #
+      # Kube State Metrics provides the CloudZero Agent with information
+      # regarding the configuration and state of various Kubernetes objects
+      # (nodes, pods, etc.), including where they are located in the cluster.
       - job_name: static-kube-state-metrics
         honor_timestamps: true
         track_timestamps_staleness: false
@@ -118,40 +124,83 @@ data:
         enable_compression: true
         follow_redirects: true
         enable_http2: true
+      
+        # Given a Kubernetes resource with a structure like:
+        #
+        #   apiVersion: v1
+        #   kind: Service
+        #   metadata:
+        #     name: my-service
+        #     namespace: my-namespace
+        #     labels:
+        #       app: my-app
+        #       environment: production
+        #
+        # Kube State Metrics should provide labels such as:
+        #
+        #   __meta_kubernetes_service_name:               my-name
+        #   __meta_kubernetes_namespace:                  my-namespace
+        #   __meta_kubernetes_service_label_app:          my-app
+        #   __meta_kubernetes_service_label_environment:  production
+        #
+        # We read these into the CloudZero Agent as:
+        #
+        #   service: my-name
+        #   namespace: my-namespace
+        #   app: my-app
+        #   environment: production
         relabel_configs:
+      
+          # Relabel __meta_kubernetes_service_label_(.+) labels to $1.
           - separator: ;
             regex: __meta_kubernetes_service_label_(.+)
             replacement: $1
             action: labelmap
+      
+          # Replace __meta_kubernetes_namespace labels with "namespace"
           - source_labels: [__meta_kubernetes_namespace]
             separator: ;
             regex: (.*)
             target_label: namespace
             replacement: $1
             action: replace
+      
+          # Replace __meta_kubernetes_service_name labels with "service"
           - source_labels: [__meta_kubernetes_service_name]
             separator: ;
             regex: (.*)
             target_label: service
             replacement: $1
             action: replace
+      
+          # Replace "__meta_kubernetes_pod_node_name" labels to "node"
           - source_labels: [__meta_kubernetes_pod_node_name]
             separator: ;
             regex: (.*)
             target_label: node
             replacement: $1
             action: replace
+        # We filter out all but a select few metrics and labels.
         metric_relabel_configs:
+      
+          # Metric names to keep.
           - source_labels: [__name__]
             regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info)$
             action: keep
+      
+          # Metric labels to keep.
           - separator: ;
             regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
             replacement: $1
             action: labelkeep
+      
         static_configs:
           - targets:
             - cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080
+      # cAdvisor Scrape Job cloudzero-nodes-cadvisor
+      #
+      # This job scrapes metrics about container resource usage (CPU, memory,
+      # network, etc.).
       - job_name: cloudzero-nodes-cadvisor # container_* metrics
         honor_timestamps: true
         track_timestamps_staleness: false
@@ -163,42 +212,62 @@ data:
         - PrometheusText0.0.4
         scheme: https
         enable_compression: true
+      
+        # cAdvisor endpoints are protected. In order to access them we need the
+        # credentials for the ServiceAccount.
         authorization:
           type: Bearer
           credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           insecure_skip_verify: true
+      
         follow_redirects: true
         enable_http2: true
         metrics_path: /metrics
+      
+        # Scrape metrics from cAdvisor.
         relabel_configs:
-          # Specific to proxied scrape (via Kubernetes API server)
+      
+          # Replace the value of __address__ labels with "kubernetes.default.svc:443"
           - separator: ;
             regex: (.*)
             target_label: __address__
             replacement: kubernetes.default.svc:443
             action: replace
+      
+          # Replace the value of __metrics_path__ in __meta_kubernetes_node_name with
+          # "/api/v1/nodes/$1/proxy/metrics/cadvisor"
           - source_labels: [__meta_kubernetes_node_name]
             separator: ;
             regex: (.+)
             target_label: __metrics_path__
             replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
             action: replace
-          # Common relabel_configs
+      
+          # Remove "__meta_kubernetes_node_label_" prefix from labels.
           - separator: ;
             regex: __meta_kubernetes_node_label_(.+)
             replacement: $1
             action: labelmap
+      
+          # Replace __meta_kubernetes_node_name labels with "node"
           - source_labels: [__meta_kubernetes_node_name]
             target_label: node
             action: replace
+      
+        # We only want to keep a select few labels.
         metric_relabel_configs:
+      
+          # Labels to keep.
           - action: labelkeep
             regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+      
+          # Metrics to keep.
           - source_labels: [__name__]
             regex: ^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
             action: keep
+      
         kubernetes_sd_configs:
           - role: node
             kubeconfig_file: ""
@@ -217,11 +286,15 @@ data:
             kubeconfig_file: ""
             follow_redirects: true
             enable_http2: true
+      
         relabel_configs:
+          # Keep __meta_kubernetes_endpoints_name labels.
           - source_labels: [__meta_kubernetes_endpoints_name]
             action: keep
             regex: cz-agent-cloudzero-agent-webhook-server-svc
+      
         metric_relabel_configs:
+          # Metrics to keep.
           - source_labels: [__name__]
             regex: "^(go_memstats_alloc_bytes|go_memstats_heap_alloc_bytes|go_memstats_heap_idle_bytes|go_memstats_heap_inuse_bytes|go_memstats_heap_objects|go_memstats_last_gc_time_seconds|go_memstats_alloc_bytes|go_memstats_stack_inuse_bytes|go_goroutines|process_cpu_seconds_total|process_max_fds|process_open_fds|process_resident_memory_bytes|process_start_time_seconds|process_virtual_memory_bytes|process_virtual_memory_max_bytes|remote_write_timeseries_total|remote_write_response_codes_total|remote_write_payload_size_bytes|remote_write_failures_total|remote_write_records_processed_total|remote_write_db_failures_total|http_requests_total|storage_write_failure_total|czo_webhook_types_total|czo_storage_types_total|czo_ingress_types_total|czo_gateway_types_total)$"
             action: keep

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -119,38 +119,38 @@ data:
         follow_redirects: true
         enable_http2: true
         relabel_configs:
-        - separator: ;
-          regex: __meta_kubernetes_service_label_(.+)
-          replacement: $1
-          action: labelmap
-        - source_labels: [__meta_kubernetes_namespace]
-          separator: ;
-          regex: (.*)
-          target_label: namespace
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_service_name]
-          separator: ;
-          regex: (.*)
-          target_label: service
-          replacement: $1
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_node_name]
-          separator: ;
-          regex: (.*)
-          target_label: node
-          replacement: $1
-          action: replace
+          - separator: ;
+            regex: __meta_kubernetes_service_label_(.+)
+            replacement: $1
+            action: labelmap
+          - source_labels: [__meta_kubernetes_namespace]
+            separator: ;
+            regex: (.*)
+            target_label: namespace
+            replacement: $1
+            action: replace
+          - source_labels: [__meta_kubernetes_service_name]
+            separator: ;
+            regex: (.*)
+            target_label: service
+            replacement: $1
+            action: replace
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            separator: ;
+            regex: (.*)
+            target_label: node
+            replacement: $1
+            action: replace
         metric_relabel_configs:
-        - source_labels: [__name__]
-          regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info)$
-          action: keep
-        - separator: ;
-          regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
-          replacement: $1
-          action: labelkeep
+          - source_labels: [__name__]
+            regex: ^(kube_node_info|kube_node_status_capacity|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_labels|kube_pod_info)$
+            action: keep
+          - separator: ;
+            regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+            replacement: $1
+            action: labelkeep
         static_configs:
-        - targets:
+          - targets:
             - cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080
       - job_name: cloudzero-nodes-cadvisor # container_* metrics
         honor_timestamps: true
@@ -173,37 +173,37 @@ data:
         enable_http2: true
         metrics_path: /metrics
         relabel_configs:
-        # Specific to proxied scrape (via Kubernetes API server)
-        - separator: ;
-          regex: (.*)
-          target_label: __address__
-          replacement: kubernetes.default.svc:443
-          action: replace
-        - source_labels: [__meta_kubernetes_node_name]
-          separator: ;
-          regex: (.+)
-          target_label: __metrics_path__
-          replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
-          action: replace
-        # Common relabel_configs
-        - separator: ;
-          regex: __meta_kubernetes_node_label_(.+)
-          replacement: $1
-          action: labelmap
-        - source_labels: [__meta_kubernetes_node_name]
-          target_label: node
-          action: replace
+          # Specific to proxied scrape (via Kubernetes API server)
+          - separator: ;
+            regex: (.*)
+            target_label: __address__
+            replacement: kubernetes.default.svc:443
+            action: replace
+          - source_labels: [__meta_kubernetes_node_name]
+            separator: ;
+            regex: (.+)
+            target_label: __metrics_path__
+            replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+            action: replace
+          # Common relabel_configs
+          - separator: ;
+            regex: __meta_kubernetes_node_label_(.+)
+            replacement: $1
+            action: labelmap
+          - source_labels: [__meta_kubernetes_node_name]
+            target_label: node
+            action: replace
         metric_relabel_configs:
-        - action: labelkeep
-          regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
-        - source_labels: [__name__]
-          regex: ^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
-          action: keep
+          - action: labelkeep
+            regex: ^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$
+          - source_labels: [__name__]
+            regex: ^(container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total)$
+            action: keep
         kubernetes_sd_configs:
-        - role: node
-          kubeconfig_file: ""
-          follow_redirects: true
-          enable_http2: true
+          - role: node
+            kubeconfig_file: ""
+            follow_redirects: true
+            enable_http2: true
       - job_name: cloudzero-webhook-job
         metrics_path: /metrics
         scheme: https


### PR DESCRIPTION
## Why?

When looking at a recent customer issue, I thought there was a possibility that it was related to the Prometheus configuration, so I started looking at the configuration to understand it. As part of the process of figuring out how it worked, I decided to just document it in-place.

Once I was doing that, I noticed that there were also a lot of properties we were setting to the same values as the defaults, which was just creating a lot of extra complexity and cognitive load.

## What

This adds a lot of documentation to the configuration, which honestly should make things a lot easier on us (well, at least me) in the future when we need to work on the configuration. It also removes properties which needn't be set as they are already the defaults.

## How Tested

Deploying and verifying that we're still getting all the metrics was the big testing thing.

However, It's also useful to note that I tried to do this in three stages, with one commit each, to make reviewing substantially easier.

1. Add some indentation. There were no "real" changes in this commit, I just indented some list items a bit more to prepare it for some documentation.
2. Add documentation. Again, no actual changes; just adding a bunch of comments.
3. Remove superfluous properties. I went through the various properties, and checked the [Prometheus config documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) to see if we actually needed the property, and removed the ones where we were just setting the value to the default.

Therefore, I would strongly recommend reviewing this commit-by-commit. It looks big and nasty when you view everything together, but when you look at each commit individually things will look a *lot* cleaner and you'll see that I didn't really do anything.