### PR TITLE
CP-29472: Add documentation for use of ValidatingWebhookConfiguration, s3 egress requirement

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -216,10 +216,11 @@ Additional Notes:
 - For both labels and annotations, the `patterns` array applies across all resource types; i.e., setting `['^foo']` for `insightsController.labels.patterns` will match label keys that start with `foo` for all resource types set to `true` in `insightsController.labels.resources`.
 
 #### Use of ValidatingWebhookConfiguration
+
 The chart deploys a single ValidatingWebhookConfiguration in order to capture important information on the state of the cluster, including details about labels/annotations as they are created, updated, or deleted. While this functionality can technically be disabled, this is strongly discouraged and can create issues with data quality and comprehensiveness.
 
 It's important to note that CloudZero has taken great care to ensure that the server does not, and cannot, cause problems for your cluster. Specifically:
-Some important notes about the `ValidatingWebhookConfiguration`:
+
 - The server component only ever returns true, and no request will ever be denied.
 - In the case where the `webhook-server` becomes unresponsive, the API server will ignore the timeout and allow the `AdmissionRequest`. See the [Kubernetes documentation for details](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) on the `failurePolicy: Ignore` setting.
 - Because the `ValidatingWebhookConfiguration` sends a request from the Kubernetes API server to the `webhook-server` Service, **it is advisable to ensure no `NetworkPolicy` resources are restricting this traffic.**

--- a/helm/README.md
+++ b/helm/README.md
@@ -216,10 +216,11 @@ Additional Notes:
 - For both labels and annotations, the `patterns` array applies across all resource types; i.e., setting `['^foo']` for `insightsController.labels.patterns` will match label keys that start with `foo` for all resource types set to `true` in `insightsController.labels.resources`.
 
 #### Use of ValidatingWebhookConfiguration
-Unless the labels/annotations feature is intentionally disabled, the chart deploys a single `ValidatingWebhookConfiguration`. This is done to record changes as labels/annotations are created, updated, or deleted.
+The chart deploys a single ValidatingWebhookConfiguration in order to capture important information on the state of the cluster, including details about labels/annotations as they are created, updated, or deleted. While this functionality can technically be disabled, this is strongly discouraged and can create issues with data quality and comprehensiveness.
 
+It's important to note that CloudZero has taken great care to ensure that the server does not, and cannot, cause problems for your cluster. Specifically:
 Some important notes about the `ValidatingWebhookConfiguration`:
-- While the purpose of the `ValidatingWebhookConfiguration` resource is to validate if resources should be allowed be added to the cluster, **the `webhook-server` component that handles the `AdmissionRequest` requests will only ever return `true`**. Because the purpose of the configuration is only to gather information, no `AdmissionRequest` will ever be denied.
+- The server component only ever returns true, and no request will ever be denied.
 - In the case where the `webhook-server` becomes unresponsive, the API server will ignore the timeout and allow the `AdmissionRequest`. See the [Kubernetes documentation for details](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) on the `failurePolicy: Ignore` setting.
 - Because the `ValidatingWebhookConfiguration` sends a request from the Kubernetes API server to the `webhook-server` Service, **it is advisable to ensure no `NetworkPolicy` resources are restricting this traffic.**
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -18,8 +18,10 @@ For the latest release, see [Releases](https://github.com/Cloudzero/cloudzero-ch
   - `container-metrics_v1:legacy`
   - `container-metrics_v1:upload`
   - `insights:read_insights`
-- Each Kubernetes cluster must have a route to the internet and a rule that allows egress from the agent to the CloudZero collector endpoint at https://api.cloudzero.com on port 443
-- Each Kubernetes cluster must allow traffic from the Kubernetes API server to Services in the `cloudzero-agent` namespace.
+- Each Kubernetes cluster must permit egress traffic from the agent to the following endpoints on port 443:
+  - CloudZero collector endpoint: `https://api.cloudzero.com`
+  - AWS S3 addresses: `*.s3.amazonaws.com`
+- Each Kubernetes cluster must allow traffic from the Kubernetes API server to services in the `cloudzero-agent` namespace.
 
 ### Recommended Knowledge
 
@@ -217,7 +219,7 @@ Additional Notes:
 Unless the labels/annotations feature is intentionally disabled, the chart deploys a single `ValidatingWebhookConfiguration`. This is done to record changes as labels/annotations are created, updated, or deleted.
 
 Some important notes about `ValidatingWebhookConfiguration`:
-- While the purpose of the `ValidatingWebhookConfiguration` resource is to validate if resources can be added to the cluster, the **`webhook-server` that handles the `AdmissionRequest` requests will only ever return `true`**. Because the purpose of the configuration is only to gather information, no `AdmissionRequest` will ever be denied.
+- While the purpose of the `ValidatingWebhookConfiguration` resource is to validate if resources should be allowed be added to the cluster, **the `webhook-server` component that handles the `AdmissionRequest` requests will only ever return `true`**. Because the purpose of the configuration is only to gather information, no `AdmissionRequest` will ever be denied.
 - In the case where the `webhook-server` becomes unresponsive, the API server will ignore the timeout and allow the `AdmissionRequest`. See the [Kubernetes documentation for details](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) on the `failurePolicy: Ignore` setting.
 - Because the `ValidatingWebhookConfiguration` sends a request from the Kubernetes API server to the `webhook-server` Service, **it is advisable to ensure no `NetworkPolicy` resources are restricting this traffic.**
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -218,7 +218,7 @@ Additional Notes:
 #### Use of ValidatingWebhookConfiguration
 Unless the labels/annotations feature is intentionally disabled, the chart deploys a single `ValidatingWebhookConfiguration`. This is done to record changes as labels/annotations are created, updated, or deleted.
 
-Some important notes about `ValidatingWebhookConfiguration`:
+Some important notes about the `ValidatingWebhookConfiguration`:
 - While the purpose of the `ValidatingWebhookConfiguration` resource is to validate if resources should be allowed be added to the cluster, **the `webhook-server` component that handles the `AdmissionRequest` requests will only ever return `true`**. Because the purpose of the configuration is only to gather information, no `AdmissionRequest` will ever be denied.
 - In the case where the `webhook-server` becomes unresponsive, the API server will ignore the timeout and allow the `AdmissionRequest`. See the [Kubernetes documentation for details](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) on the `failurePolicy: Ignore` setting.
 - Because the `ValidatingWebhookConfiguration` sends a request from the Kubernetes API server to the `webhook-server` Service, **it is advisable to ensure no `NetworkPolicy` resources are restricting this traffic.**

--- a/helm/README.md
+++ b/helm/README.md
@@ -19,6 +19,7 @@ For the latest release, see [Releases](https://github.com/Cloudzero/cloudzero-ch
   - `container-metrics_v1:upload`
   - `insights:read_insights`
 - Each Kubernetes cluster must have a route to the internet and a rule that allows egress from the agent to the CloudZero collector endpoint at https://api.cloudzero.com on port 443
+- Each Kubernetes cluster must allow traffic from the Kubernetes API server to Services in the `cloudzero-agent` namespace.
 
 ### Recommended Knowledge
 
@@ -211,6 +212,14 @@ Additional Notes:
 - To disambiguate labels/annotations between resources, a prefix representing the resource type is prepended to the label key in the [CloudZero Explorer](https://app.cloudzero.com/explorer). For example, a `foo=bar` node label would be presented as `node:foo: bar`. The exception is pod labels which do not have resource prefixes for backward compatibility with previous versions.
 - Annotations are not exported by default; see the `insightsController.annotations.enabled` setting to enable. To disambiguate annotations from labels, an `annotation` prefix is prepended to the annotation key; i.e., an `foo: bar` annotation on a namespace would be represented in the Explorer as `node:annotation:foo: bar`
 - For both labels and annotations, the `patterns` array applies across all resource types; i.e., setting `['^foo']` for `insightsController.labels.patterns` will match label keys that start with `foo` for all resource types set to `true` in `insightsController.labels.resources`.
+
+#### Use of ValidatingWebhookConfiguration
+Unless the labels/annotations feature is intentionally disabled, the chart deploys a single `ValidatingWebhookConfiguration`. This is done to record changes as labels/annotations are created, updated, or deleted.
+
+Some important notes about `ValidatingWebhookConfiguration`:
+- While the purpose of the `ValidatingWebhookConfiguration` resource is to validate if resources can be added to the cluster, the **`webhook-server` that handles the `AdmissionRequest` requests will only ever return `true`**. Because the purpose of the configuration is only to gather information, no `AdmissionRequest` will ever be denied.
+- In the case where the `webhook-server` becomes unresponsive, the API server will ignore the timeout and allow the `AdmissionRequest`. See the [Kubernetes documentation for details](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) on the `failurePolicy: Ignore` setting.
+- Because the `ValidatingWebhookConfiguration` sends a request from the Kubernetes API server to the `webhook-server` Service, **it is advisable to ensure no `NetworkPolicy` resources are restricting this traffic.**
 
 ### Secret Management
 


### PR DESCRIPTION
## Why?

Users often ask about why we need a `ValidatingWebhookConfiguration`, and they often experience issues when using `NetworkPolicies` that deny traffic from the API server to the agent components. This documentation should help with that.

We were also missing a requirement regarding egress traffic to s3 endpoints.

## What

Added documentation to the README

## How Tested

N/A
