### PR TITLE
CP-29492: clean up generation of annotation checksums

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -518,8 +518,20 @@ Map for initBackfillJob values; this allows us to preferably use initBackfillJob
 Name for a job resource
 */}}
 {{- define "cloudzero-agent.jobName" -}}
-{{- printf "%s-%s-%s" .Release .Name (.Values.jobConfigID | default (. | toYaml | sha256sum)) | trunc 61 -}}
+{{- printf "%s-%s-%s" .Release .Name (include "cloudzero-agent.configurationChecksum" .) | trunc 61 -}}
 {{- end }}
+
+{{/*
+Return a hash of the configuration, unless overridden.
+
+Note that jobConfigID *only* exists so we can avoid lots of commit noise when
+regenerating the manifests in tests/helm/template. It should never be set in
+production, as it will break important functionality to automatically reload
+things when a ConfigMap changes.
+*/}}
+{{- define "cloudzero-agent.configurationChecksum" -}}
+{{ .Values.jobConfigID | default (. | toYaml | sha256sum) }}
+{{- end -}}
 
 {{/*
 Name for the backfill job resource

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -16,7 +16,10 @@ spec:
   replicas: {{ .Values.components.aggregator.replicas }}
   template:
     metadata:
-      {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations (dict "checksum/config" (include "cloudzero-agent.aggregator.configuration" . | sha256sum))) | nindent 6 }}
+      {{- include "cloudzero-agent.generateAnnotations" (merge
+          (deepCopy .Values.defaults.annotations)
+          (dict "checksum/config" (include "cloudzero-agent.configurationChecksum" .))
+        ) | nindent 6 }}
       {{- include "cloudzero-agent.generateLabels" (dict
           "globals" .
           "labels" (merge (include "cloudzero-agent.aggregator.matchLabels" . | fromYaml) .Values.commonMetaLabels)

--- a/helm/templates/validator-job.yaml
+++ b/helm/templates/validator-job.yaml
@@ -3,8 +3,10 @@ kind: Job
 metadata:
   name: {{ include "cloudzero-agent.validatorJobName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
-    checksum/values: {{ (.Values.jobConfigID | default (. | toYaml | sha256sum)) | default (.Values | toYaml | sha256sum) }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge
+      (deepCopy .Values.defaults.annotations)
+      (dict "checksum/values" (include "cloudzero-agent.configurationChecksum" .))
+    ) | nindent 2 }}
   labels:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
 spec:

--- a/helm/templates/webhook-deploy.yaml
+++ b/helm/templates/webhook-deploy.yaml
@@ -19,7 +19,11 @@ spec:
         {{- with .Values.insightsController.server.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.insightsController.server.podAnnotations (dict "checksum/config" (include "cloudzero-agent.insightsController.configuration" . | sha256sum))) | nindent 6 }}
+      {{- include "cloudzero-agent.generateAnnotations" (merge
+          (deepCopy .Values.defaults.annotations)
+          .Values.insightsController.server.podAnnotations
+          (dict "checksum/config" (include "cloudzero-agent.configurationChecksum" .))
+        ) | nindent 6 }}
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}
       {{- include "cloudzero-agent.insightsController.server.imagePullSecrets" . | nindent 6 }}

--- a/tests/helm/template/federated-overrides.yml
+++ b/tests/helm/template/federated-overrides.yml
@@ -1,9 +1,10 @@
 cloudAccountId: "1234567890"
 clusterName: "my-cluster"
 region: "us-east-1"
-apiKey: "049a3c8b-7259-4ad3-931a-73596c647cf8"
+apiKey: "not-a-real-api-key"
 
-jobConfigID: "3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12"
+# For testing only, you should never use this property in production.
+jobConfigID: "DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E"
 
 defaults:
   federation:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -88,8 +88,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-server
   namespace: cz-agent
 ---
@@ -120,13 +119,12 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-api-key
   namespace: cz-agent
 data:
   value:
-          "MDQ5YTNjOGItNzI1OS00YWQzLTkzMWEtNzM1OTZjNjQ3Y2Y4"
+          "bm90LWEtcmVhbC1hcGkta2V5"
 ---
 # Source: cloudzero-agent/templates/webhook-tls-secret.yaml
 apiVersion: v1
@@ -158,8 +156,7 @@ metadata:
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-configuration
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   prometheus.yml: |-
     global:
@@ -304,8 +301,7 @@ metadata:
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-daemonset-cm
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   prometheus.yml.in: |-
     global:
@@ -409,8 +405,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   config.yml: |-
     cloud_account_id: 1234567890
@@ -748,8 +743,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   values.yaml: |-
     aggregator:
@@ -845,8 +839,7 @@ data:
         resources: {}
     defaults:
       affinity: {}
-      annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+      annotations: {}
       dns:
         config: {}
         policy: null
@@ -968,7 +961,7 @@ data:
         caInjection: null
         namespaceSelector: {}
         path: /validate
-    jobConfigID: 3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+    jobConfigID: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
     kubeStateMetrics:
       affinity: {}
       annotations: {}
@@ -1236,8 +1229,7 @@ metadata:
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-validator-configuration
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   validator.yml: |-
     versions:
@@ -1320,8 +1312,7 @@ metadata:
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-webhook-configuration
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   server-config.yaml: |-
     cloud_account_id: 1234567890
@@ -1539,8 +1530,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: cloudzero-agent
@@ -1636,8 +1626,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-webhook-server-init-cert
   namespace: cz-agent
 rules:
@@ -1705,8 +1694,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-server
 subjects:
   - kind: ServiceAccount
@@ -1729,8 +1717,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-webhook-server-init-cert
 subjects:
   - kind: ServiceAccount
@@ -1834,8 +1821,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-daemonset
   namespace: cz-agent
 spec:
@@ -2058,8 +2044,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-server
   namespace: cz-agent
 spec:
@@ -2251,8 +2236,7 @@ kind: Deployment
 metadata:
   name: cz-agent-aggregator
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   labels:
     app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
@@ -2271,7 +2255,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+        checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
         app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
@@ -2436,7 +2420,7 @@ spec:
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+        checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       
@@ -2518,10 +2502,9 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cz-agent-backfill-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+  name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   labels:
     app.kubernetes.io/component: webhook-server
     app.kubernetes.io/name: cloudzero-agent
@@ -2533,14 +2516,13 @@ metadata:
 spec:
   template:
     metadata:
-      name: cz-agent-backfill-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+      name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: cz-agent-backfill-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+        app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
         app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
-      annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+      
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       restartPolicy: OnFailure
@@ -2582,10 +2564,9 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cz-agent-init-cert-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+  name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   labels:
     app.kubernetes.io/component: webhook-server
     app.kubernetes.io/name: cloudzero-agent
@@ -2597,13 +2578,12 @@ metadata:
 spec:
   template:
     metadata:
-      name: cz-agent-init-cert-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+      name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: cz-agent-init-cert-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+        app.kubernetes.io/component: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
         app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
-      annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+      
     spec:
       
       
@@ -2696,11 +2676,10 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cz-agent-validator-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+  name: cz-agent-validator-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   namespace: cz-agent
   annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
-    checksum/values: 3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+    checksum/values: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   labels:
     app.kubernetes.io/component: webhook-server
     app.kubernetes.io/name: cloudzero-agent
@@ -2712,14 +2691,13 @@ metadata:
 spec:
   template:
     metadata:
-      name: cz-agent-validator-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+      name: cz-agent-validator-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: cz-agent-validator-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+        app.kubernetes.io/component: cz-agent-validator-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
         app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
-      annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+      
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       restartPolicy: OnFailure

--- a/tests/helm/template/manifest-overrides.yml
+++ b/tests/helm/template/manifest-overrides.yml
@@ -1,6 +1,7 @@
 cloudAccountId: "1234567890"
 clusterName: "my-cluster"
 region: "us-east-1"
-apiKey: "049a3c8b-7259-4ad3-931a-73596c647cf8"
+apiKey: "not-a-real-api-key"
 
-jobConfigID: "3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12"
+# For testing only, you should never use this property in production.
+jobConfigID: "DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E"

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -88,8 +88,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-server
   namespace: cz-agent
 ---
@@ -120,13 +119,12 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-api-key
   namespace: cz-agent
 data:
   value:
-          "MDQ5YTNjOGItNzI1OS00YWQzLTkzMWEtNzM1OTZjNjQ3Y2Y4"
+          "bm90LWEtcmVhbC1hcGkta2V5"
 ---
 # Source: cloudzero-agent/templates/webhook-tls-secret.yaml
 apiVersion: v1
@@ -158,8 +156,7 @@ metadata:
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-configuration
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   prometheus.yml: |-
     global:
@@ -355,8 +352,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   config.yml: |-
     cloud_account_id: 1234567890
@@ -694,8 +690,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   values.yaml: |-
     aggregator:
@@ -791,8 +786,7 @@ data:
         resources: {}
     defaults:
       affinity: {}
-      annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+      annotations: {}
       dns:
         config: {}
         policy: null
@@ -914,7 +908,7 @@ data:
         caInjection: null
         namespaceSelector: {}
         path: /validate
-    jobConfigID: 3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+    jobConfigID: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
     kubeStateMetrics:
       affinity: {}
       annotations: {}
@@ -1182,8 +1176,7 @@ metadata:
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-validator-configuration
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   validator.yml: |-
     versions:
@@ -1266,8 +1259,7 @@ metadata:
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-webhook-configuration
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
 data:
   server-config.yaml: |-
     cloud_account_id: 1234567890
@@ -1485,8 +1477,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: cloudzero-agent
@@ -1582,8 +1573,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-webhook-server-init-cert
   namespace: cz-agent
 rules:
@@ -1651,8 +1641,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-server
 subjects:
   - kind: ServiceAccount
@@ -1675,8 +1664,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-webhook-server-init-cert
 subjects:
   - kind: ServiceAccount
@@ -1851,8 +1839,7 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   name: cz-agent-cloudzero-agent-server
   namespace: cz-agent
 spec:
@@ -2044,8 +2031,7 @@ kind: Deployment
 metadata:
   name: cz-agent-aggregator
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   labels:
     app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
@@ -2064,7 +2050,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+        checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
         app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
@@ -2229,7 +2215,7 @@ spec:
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+        checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       
@@ -2311,10 +2297,9 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cz-agent-backfill-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+  name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   labels:
     app.kubernetes.io/component: webhook-server
     app.kubernetes.io/name: cloudzero-agent
@@ -2326,14 +2311,13 @@ metadata:
 spec:
   template:
     metadata:
-      name: cz-agent-backfill-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+      name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: cz-agent-backfill-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+        app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
         app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
-      annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+      
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       restartPolicy: OnFailure
@@ -2375,10 +2359,9 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cz-agent-init-cert-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+  name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   namespace: cz-agent
-  annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+  
   labels:
     app.kubernetes.io/component: webhook-server
     app.kubernetes.io/name: cloudzero-agent
@@ -2390,13 +2373,12 @@ metadata:
 spec:
   template:
     metadata:
-      name: cz-agent-init-cert-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+      name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: cz-agent-init-cert-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+        app.kubernetes.io/component: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
         app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
-      annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+      
     spec:
       
       
@@ -2489,11 +2471,10 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cz-agent-validator-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+  name: cz-agent-validator-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   namespace: cz-agent
   annotations:
-    checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
-    checksum/values: 3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+    checksum/values: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   labels:
     app.kubernetes.io/component: webhook-server
     app.kubernetes.io/name: cloudzero-agent
@@ -2505,14 +2486,13 @@ metadata:
 spec:
   template:
     metadata:
-      name: cz-agent-validator-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+      name: cz-agent-validator-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: cz-agent-validator-3e4c0c56-e932-4c5a-88f7-0dcaa0ff6b12
+        app.kubernetes.io/component: cz-agent-validator-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
         app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
-      annotations:
-        checksum/config: 28bf2e5c1e7aeb797e9370f5e86cc970f9cfffbe5d86a6be37c0c08ffbf934ca
+      
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       restartPolicy: OnFailure


### PR DESCRIPTION
## Why?

Previously, we didn't always allow jobConfigID to override the checksum when adding it to annotations. This resulted in some unnecessary noise sometimes when regenerating the manifests.

## What

I added a template to include for the checksum, including handling jobConfigID, and started using it in places it made sense.

I've also changed the value we use use in the overrides files, of both jobConfigID and apiKey, to make it clear that they are not, in fact, secrets that we're leaking, but just dummy values.

Finally, instead in a few places we were merging stuff into the default annotations, since the merge function in Helm will actually merge into the destination instead of merging everything into a new map. Using a deepCopy of the destination instead takes care of this. The effect is that in many places we will no longer be including annotations we didn't intend to.

## How Tested

Mostly relying on the generated manifests here.