### PR TITLE
CP-29585: periodically close HTTP connections

### DIFF
--- a/app/config/gator/settings.go
+++ b/app/config/gator/settings.go
@@ -80,9 +80,10 @@ type PurgeRules struct {
 }
 
 type Server struct {
-	Mode      string `yaml:"mode" default:"http" env:"SERVER_MODE" env-description:"server mode such as http, https"`
-	Port      uint   `yaml:"port" default:"8080" env:"SERVER_PORT" env-description:"server port"`
-	Profiling bool   `yaml:"profiling" default:"false" env:"SERVER_PROFILING" env-description:"enable profiling"`
+	Mode               string `yaml:"mode" default:"http" env:"SERVER_MODE" env-description:"server mode such as http, https"`
+	Port               uint   `yaml:"port" default:"8080" env:"SERVER_PORT" env-description:"server port"`
+	Profiling          bool   `yaml:"profiling" default:"false" env:"SERVER_PROFILING" env-description:"enable profiling"`
+	ReconnectFrequency int    `yaml:"reconnect_frequency" default:"16" env:"SERVER_RECONNECT_FREQUENCY" env-description:"how frequently to close HTTP connections from clients, to distribute the load. 0=never, otherwise 1/N probability."`
 }
 
 type Cloudzero struct {

--- a/app/domain/metric_collector.go
+++ b/app/domain/metric_collector.go
@@ -77,6 +77,10 @@ type MetricCollector struct {
 	cancelFunc         context.CancelFunc
 }
 
+func (d *MetricCollector) Settings() *config.Settings {
+	return d.settings
+}
+
 // NewMetricCollector creates a new MetricCollector and starts the flushing goroutine.
 func NewMetricCollector(s *config.Settings, clock types.TimeProvider, costStore types.WritableStore, observabilityStore types.WritableStore) (*MetricCollector, error) {
 	filter, err := NewMetricFilter(&s.Metrics)

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -58,6 +58,7 @@ server:
   mode: http
   port: {{ .Values.aggregator.collector.port }}
   profiling: {{ .Values.aggregator.profiling }}
+  reconnect_frequency: {{ .Values.aggregator.reconnectFrequency }}
 logging:
   level: "{{ .Values.aggregator.logging.level }}"
 database:

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -20713,6 +20713,11 @@
         "profiling": {
           "type": "boolean"
         },
+        "reconnectFrequency": {
+          "description": "How frequently to close HTTP connections from clients, to help\ndistribute the load across the various collector replicas. 0=never,\notherwise 1/N probability.\n",
+          "minimum": 0,
+          "type": "integer"
+        },
         "shipper": {
           "additionalProperties": false,
           "properties": {

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -347,6 +347,13 @@ properties:
         type: string
       profiling:
         type: boolean
+      reconnectFrequency:
+        type: integer
+        minimum: 0
+        description: |
+          How frequently to close HTTP connections from clients, to help
+          distribute the load across the various collector replicas. 0=never,
+          otherwise 1/N probability.
       image:
         deprecated: true
         $ref: "#/$defs/com.cloudzero.agent.image"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -708,6 +708,10 @@ aggregator:
   # Whether to enable the profiling endpoint (/debug/pprof/). This should
   # generally be disabled in production.
   profiling: false
+  # Frequency to close HTTP connections from clients, to help distribute the
+  # load across the various collector replicas. 0=never, otherwise 1/N
+  # probability.
+  reconnectFrequency: 16
   # Container image configuration for the aggregator components.
   #
   # Deprecated. Please use components.aggregator.image instead.

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -712,6 +712,7 @@ data:
       mode: http
       port: 8080
       profiling: false
+      reconnect_frequency: 16
     logging:
       level: "info"
     database:
@@ -783,6 +784,7 @@ data:
       mountRoot: /cloudzero
       nodeSelector: {}
       profiling: false
+      reconnectFrequency: 16
       shipper:
         port: 8081
         resources:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -659,6 +659,7 @@ data:
       mode: http
       port: 8080
       profiling: false
+      reconnect_frequency: 16
     logging:
       level: "info"
     database:
@@ -730,6 +731,7 @@ data:
       mountRoot: /cloudzero
       nodeSelector: {}
       profiling: false
+      reconnectFrequency: 16
       shipper:
         port: 8081
         resources:


### PR DESCRIPTION
## Why?

When Prometheus sends data to the Collector, it uses the standard Go HTTP client library, which reuses the connection as an optimization.

Unfortunately, the round robin to distribute the load across the k8s service happens when the initial connection is made, and since in non-federated mode we really only receive data from Prometheus and the Webhook server, which means we just have two things that create an initial connection, then always send data over those connections.

Luckily, and somewhat surprisingly (at least to me), Prometheus seems to be using HTTP/1.1 to send the data, which means we can just add a Connection: close periodically to get it to close the connection and go through the load balancing again.

## What

This will randomly (according to a configurable probability) add a `Connection: close` header to the HTTP response from the metrics collector endpoint.

## How Tested

Deploy; instead of seeing most of the activity in the logs of a singe pod it should now be a bit more evenly distributed. Set the reconnectFrequency to a lower value if you want it to be more aggressive, especially useful in a small cluster.