### PR TITLE
CP-29055: add support for setting Prometheus out_of_order_time_window

### DIFF
--- a/helm/templates/agent-cm.yaml
+++ b/helm/templates/agent-cm.yaml
@@ -13,6 +13,11 @@ data:
     {{- else }}
     global:
       scrape_interval: {{ .Values.prometheusConfig.globalScrapeInterval }}
+    {{ if .Values.prometheusConfig.outOfOrderTimeWindow }}
+    storage:
+      tsdb:
+        out_of_order_time_window: {{ .Values.prometheusConfig.outOfOrderTimeWindow }}
+    {{- end }}
 
     scrape_configs:
       {{- if .Values.prometheusConfig.scrapeJobs.kubeStateMetrics.enabled }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -21458,6 +21458,11 @@
           "$ref": "#/$defs/com.cloudzero.agent.duration",
           "description": "Global scrape interval for all jobs.\n"
         },
+        "outOfOrderTimeWindow": {
+          "description": "Out of order time window for cadvisor scrape job.\n",
+          "pattern": "^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$",
+          "type": ["string", "null"]
+        },
         "scrapeJobs": {
           "additionalProperties": false,
           "description": "Scrape job configurations.\n",

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -457,6 +457,11 @@ properties:
         description: |
           Global scrape interval for all jobs.
         $ref: "#/$defs/com.cloudzero.agent.duration"
+      outOfOrderTimeWindow:
+        description: |
+          Out of order time window for cadvisor scrape job.
+        type: [string, "null"]
+        pattern: "^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$"
       scrapeJobs:
         description: |
           Scrape job configurations.
@@ -494,6 +499,7 @@ properties:
                 description: |
                   Scrape interval for nodesCadvisor job.
                 $ref: "#/$defs/com.cloudzero.agent.duration"
+
           prometheus:
             description: |
               prometheus scrape job configuration.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -260,6 +260,7 @@ prometheusConfig:
   configMapAnnotations: {}
   configOverride: ""
   globalScrapeInterval: 60s
+  outOfOrderTimeWindow: 5m
   scrapeJobs:
     # -- Enables the kube-state-metrics scrape job.
     kubeStateMetrics:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -162,6 +162,10 @@ data:
   prometheus.yml: |-
     global:
       scrape_interval: 60s
+    
+    storage:
+      tsdb:
+        out_of_order_time_window: 5m
 
     scrape_configs:
       # Kube State Metrics Scrape Job
@@ -1215,6 +1219,7 @@ data:
       configMapNameOverride: ""
       configOverride: ""
       globalScrapeInterval: 60s
+      outOfOrderTimeWindow: 5m
       scrapeJobs:
         additionalScrapeJobs: []
         aggregator:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -162,6 +162,10 @@ data:
   prometheus.yml: |-
     global:
       scrape_interval: 60s
+    
+    storage:
+      tsdb:
+        out_of_order_time_window: 5m
 
     scrape_configs:
       # Kube State Metrics Scrape Job
@@ -1162,6 +1166,7 @@ data:
       configMapNameOverride: ""
       configOverride: ""
       globalScrapeInterval: 60s
+      outOfOrderTimeWindow: 5m
       scrapeJobs:
         additionalScrapeJobs: []
         aggregator:


### PR DESCRIPTION
## Why?

We are occasionally seeing errors from Prometheus: "Error on ingesting out-of-order samples". We haven't had much luck reproducing the issue, but based on some searches we're hoping this provides a way to get rid of them.

## What

This provides an easy way to configure the `out_of_order_time_window` property for Prometheus, and sets it to 5m by default.

## How Tested

Install the Helm chart to make sure it doesn't break anything. Whether it fixes the issue or not, we're not sure yet. Hence a draft PR for now.