### PR TITLE
CP-29589: add configuration parameter for Prometheus log level

### DIFF
--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -109,6 +109,7 @@ spec:
             {{- if .Values.server.agentMode }}
             - --enable-feature=agent
             {{- end }}
+            - --log.level={{ .Values.server.logging.level | default "info" }}
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -21635,6 +21635,19 @@
           },
           "type": "object"
         },
+        "logging": {
+          "additionalProperties": false,
+          "description": "Logging configuration settings for the Prometheus server.\n",
+          "properties": {
+            "level": {
+              "default": "info",
+              "description": "The log level to use for the server.\n",
+              "enum": ["debug", "info", "warn", "error", null],
+              "type": ["string", "null"]
+            }
+          },
+          "type": "object"
+        },
         "name": {
           "default": "server",
           "description": "Name of the server component.\n",

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1129,6 +1129,23 @@ properties:
           Whether the server is running in agent mode.
         type: boolean
         default: true
+      logging:
+        description: |
+          Logging configuration settings for the Prometheus server.
+        type: object
+        additionalProperties: false
+        properties:
+          level:
+            description: |
+              The log level to use for the server.
+            type: [string, "null"]
+            enum:
+              - debug
+              - info
+              - warn
+              - error
+              - null
+            default: info
       args:
         description: |
           Command-line arguments to pass to the server.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -389,6 +389,8 @@ server:
     - --web.enable-lifecycle
     - --web.console.libraries=/etc/prometheus/console_libraries
     - --web.console.templates=/etc/prometheus/consoles
+  logging:
+    level:
   # Configuration for persistent storage.
   persistentVolume:
     existingClaim: ""

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -1171,6 +1171,8 @@ data:
         periodSeconds: 15
         successThreshold: 1
         timeoutSeconds: 10
+      logging:
+        level: null
       name: server
       nodeSelector: {}
       persistentVolume:
@@ -2163,6 +2165,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=agent
+            - --log.level=info
           ports:
             - containerPort: 9090
           readinessProbe:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1118,6 +1118,8 @@ data:
         periodSeconds: 15
         successThreshold: 1
         timeoutSeconds: 10
+      logging:
+        level: null
       name: server
       nodeSelector: {}
       persistentVolume:
@@ -1958,6 +1960,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --enable-feature=agent
+            - --log.level=info
           ports:
             - containerPort: 9090
           readinessProbe:


### PR DESCRIPTION
## Why?

This just provides an easy way to set the Prometheus log level without have to recreate the argument list.

## What

Add a server.logging.level config option

## How Tested

You can see the results in the generated manifests.