### PR TITLE
CP-29602: retain metrics for 7d by default, instead of 90d

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -771,15 +771,16 @@ aggregator:
       # the storage required by the collector/shipper architecture on your
       # nodes.
       #
-      # `2160h` is 90 days, and is a reasonable default. This can reasonably be
-      # any value, as the application will force remove files if space is
-      # constrained.
+      # Note that, regardless of this option, if disk pressure is detected,
+      # files will be deleted (oldest first) to free space.
+      #
+      # `168h` is 7 days, and is a reasonable default for most clusters.
       #
       # `0s` is also a valid option and can signify that you do not want to keep
       # uploaded files at all. Though do note that this could possibly result in
       # data loss if there are transient upload failures during the lifecycle of
       # the application.
-      metricsOlderThan: 2160h
+      metricsOlderThan: 168h
       # If set to true (default), then files older than `metricsOlderThan` will
       # not be deleted unless there is detected storage pressure. For example,
       # if there are files older than `metricsOlderThan` but only 30% of storage

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -722,7 +722,7 @@ data:
       observability_max_interval: 30m
       compression_level: 8
       purge_rules:
-        metrics_older_than: 2160h
+        metrics_older_than: 168h
         lazy: true
         percent: 20
       available_storage: 
@@ -772,7 +772,7 @@ data:
         observabilityMaxInterval: 30m
         purgeRules:
           lazy: true
-          metricsOlderThan: 2160h
+          metricsOlderThan: 168h
           percent: 20
       image:
         digest: null

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -669,7 +669,7 @@ data:
       observability_max_interval: 30m
       compression_level: 8
       purge_rules:
-        metrics_older_than: 2160h
+        metrics_older_than: 168h
         lazy: true
         percent: 20
       available_storage: 
@@ -719,7 +719,7 @@ data:
         observabilityMaxInterval: 30m
         purgeRules:
           lazy: true
-          metricsOlderThan: 2160h
+          metricsOlderThan: 168h
           percent: 20
       image:
         digest: null


### PR DESCRIPTION
## Why?

90d will be a good default the files are stored on a PV. However, with an emptyDir and all the data living on the node, 7d seems like a much more reasonable default.

## What

Change the default retention time to 7d.

## How Tested

Just look at the generated manifests.