### PR TITLE
CP-29610: add /debug/pprof/ endpoint to shipper when profiling enabled

### DIFF
--- a/app/functions/shipper/main.go
+++ b/app/functions/shipper/main.go
@@ -117,6 +117,10 @@ func main() {
 		handlers.NewShipperAPI("/", domain),
 	}
 
+	if settings.Server.Profiling {
+		apis = append(apis, handlers.NewProfilingAPI("/debug/pprof/"))
+	}
+
 	logger.Info().Msg("Starting service")
 	server.New(build.Version()).
 		WithAddress(fmt.Sprintf(":%d", settings.Server.Port)).


### PR DESCRIPTION
## Why?

We want to be able to access pprof data on the shipper.

## What

Make the shipper obey the (existing) `profiling` flag.

## How Tested

Deploy, then something like `kubectl -n cza port-forward pod/cz-agent-aggregator-67b58d99d8-vxzgb 8081:8081` to port forward to the HTTP server on the shipper, then point your browser at http://localhost:8081/debug/pprof/