### PR TITLE
CP-29618: support setting aggregator-specific annotations

### DIFF
--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -3,7 +3,10 @@ kind: Deployment
 metadata:
   name: {{ include "cloudzero-agent.aggregator.name" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge
+      (deepCopy .Values.defaults.annotations)
+      .Values.components.aggregator.annotations
+    ) | nindent 2 }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "globals" .
       "labels" (merge (include "cloudzero-agent.aggregator.matchLabels" . | fromYaml) .Values.commonMetaLabels)

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -20794,6 +20794,10 @@
           "additionalProperties": false,
           "description": "The CloudZero Aggregator (\"Gator\"). The Aggregator provides a service\nwhich accepts metrics (e.g., from the Agent and the Webhook Server),\naggregates them, caches them, and sends them to CloudZero for\nprocessing.\n",
           "properties": {
+            "annotations": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations",
+              "description": "Annotations to be added to the aggregator deployment.\n"
+            },
             "podDisruptionBudget": {
               "$ref": "#/$defs/io.k8s.api.policy.v1.PodDisruptionBudget",
               "description": "Pod disruption budget configuration for the aggregator.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/workloads/pods/disruptions/\n"

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -239,6 +239,10 @@ properties:
         additionalProperties: false
         type: object
         properties:
+          annotations:
+            description: |
+              Annotations to be added to the aggregator deployment.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           podDisruptionBudget:
             description: |
               Pod disruption budget configuration for the aggregator.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -200,6 +200,7 @@ components:
       minAvailable:
       maxUnavailable:
     tolerations: []
+    annotations: {}
 
   # Settings for the webhook server.
   webhookServer:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -808,6 +808,7 @@ data:
           maxUnavailable: null
           minAvailable: null
       aggregator:
+        annotations: {}
         podDisruptionBudget:
           maxUnavailable: null
           minAvailable: null

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -755,6 +755,7 @@ data:
           maxUnavailable: null
           minAvailable: null
       aggregator:
+        annotations: {}
         podDisruptionBudget:
           maxUnavailable: null
           minAvailable: null


### PR DESCRIPTION
## Why?

Previously, the annotations on the aggregator would only use the default annotations. Customers would like to be able to provide annotations specific to the Aggregator.

This was a change requested by @moensch in Cloudzero/cloudzero-charts#205, thanks @moensch!

## What

Created a `components.aggregator.annotations`, which is added to the `defaults.annotations` when writing the Aggregator's annotations in the template.

## How Tested

Added an annotation to my overrides, checked to make sure it appeared in the output.