### PR TITLE
CP-29619: fix issue where argocd would have a perma-diff

### DIFF
--- a/helm/templates/webhook-certificate.yaml
+++ b/helm/templates/webhook-certificate.yaml
@@ -16,8 +16,10 @@ spec:
     algorithm: RSA
     encoding: PKCS1
     size: 2048
-  duration: 2160h0m0s # 90d
-  renewBefore: 360h0m0s # 15d
+  # Because sometimes this will get rendered as `2160h` it will cause a permadiff with ArgoCD when the chart says `2160h0m0s`
+  # Explicitly force it to be rendered as a non-truncatable value
+  duration: 2159h59m59s # 90d
+  renewBefore: 359h59m59s # 15d
   dnsNames:
     - {{ include "cloudzero-agent.serviceName" . }}.{{ .Release.Namespace }}.svc
   issuerRef:


### PR DESCRIPTION
Thanks to @MarkSRobinson, who opened this up as Cloudzero/cloudzero-charts#203. All I did was steal his patch (and description, which I also added to the commit message) and move it over to this repo.

## Why?

The k8s API server will sometimes truncate 360h0m0s into 360h. This breaks ArgoCD because it does a text diff and can't reconcile the change.

## What

This change forces a time period which cannot be abbreviated or converted. This will ensure that diff don't generate spurious changes.

## How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile
