### PR TITLE
CP-28568: add Renovate GitHub Action

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,25 @@
+{
+  "packageRules": [
+    {
+      "matchPackageNames": ["*"],
+      "postUpgradeTasks": {
+        "commands": ["make install-tools generate format"],
+        "fileFilters": ["tests/helm/template/*.yaml"]
+      }
+    }
+  ],
+  "baseBranches": ["develop"],
+  "rebaseWhen": "conflicted",
+  "labels": ["dependencies"],
+  "prHourlyLimit": 0,
+  "commitMessagePrefix": "CP-29639: ",
+  "ignorePaths": [
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+    "**/go.mod",
+    "**/Dockerfile",
+    "**/Dockerfile.*",
+    ".tools/package.json"
+  ],
+  "onboarding": false
+}

--- a/.github/renovate/entrypoint.sh
+++ b/.github/renovate/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script is run in the Renovate container, before the `renovate` command.
+# It is used to install dependencies for the postUpgradeTasks (which are run
+# after a dependency is upgraded).
+#
+# This is only really necessary because we store some generated content in
+# version control, and for some dependencies (mostly those related to the Helm
+# chart), updating the dependencies can yield slightly different output.
+#
+# While we run `make install-tools` to install most of our dependencies, there
+# are a few tools we just assume are available, that are not available in the
+# Renovate image.
+
+apt update && apt install -y \
+  golang-go \
+  npm \
+  patch \
+  ${NULL}
+
+# Run the Renovate command.
+runuser -u ubuntu renovate

--- a/.github/renovate/global-config.json
+++ b/.github/renovate/global-config.json
@@ -1,0 +1,4 @@
+{
+  "repositories": ["Cloudzero/cloudzero-agent"],
+  "allowedPostUpgradeCommands": ["^make "]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,46 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * WED"
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Get token
+        id: get_token
+        uses: actions/create-github-app-token@v1
+        with:
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v41.0.22
+        env:
+          LOG_LEVEL: debug
+        with:
+          # The entrypoint script is used to install some dependencies for our
+          # postUpgradeTasks, and shouldn't be necessary for repositories which
+          # don't require such custom tasks.
+          docker-cmd-file: .github/renovate/entrypoint.sh
+          # So we can use apt to install stuff. Then we run renovate as 'ubuntu'
+          # in the entrypoint script.
+          docker-user: root
+          # Self-Hosted Configuration File
+          #
+          # This is where options that are only available in the self-hosted
+          # version go; most things can/should go in a normal configuration
+          # file. For details, see:
+          #
+          # https://docs.renovatebot.com/self-hosted-configuration/
+          # https://docs.renovatebot.com/configuration-options/
+          configurationFile: .github/renovate/global-config.json
+          token: "${{ steps.get_token.outputs.token }}"


### PR DESCRIPTION
## Why?

Renovate is a bit like Dependabot, but it tends to be more configurable (though less easy to use) and doesn't integrate as quite as well with GitHub (perhaps related to the fact that Dependabot is owned by GitHub).

Renovate provides us with a few notable advantages:

 * It supports updating images in Helm charts, unlike Dependabot
 * It can run commands after an update (i.e., `make generate`)
 * As a GitHub action, we can trigger it manually, e.g. before a release, instead of waiting for it to run on its own.

## What

Adds a GitHub Action for Renovate which will open PRs for out-of-date dependencies in the Helm chart.

## How Tested

https://github.com/evan-cz/cloudzero-agent

Push to develop, manually run the action. Change the PR titles (so subsequent runs aren't detected as dupes), close the PRs, delete the corresponding branches. Repeat. Many, many times.