### PR TITLE
CP-29684: add Jira issue prefix to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "CP-29639: "
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -18,21 +20,29 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "CP-29639: "
 
   - package-ecosystem: "docker"
     directory: "/docker/"
     schedule:
       interval: "weekly"
       day: "friday"
+    commit-message:
+      prefix: "CP-29639: "
 
   - package-ecosystem: "npm"
     directory: "/.tools/"
     schedule:
       interval: "weekly"
       day: "friday"
+    commit-message:
+      prefix: "CP-29639: "
 
   - package-ecosystem: "helm"
     directory: "/helm/"
     schedule:
       interval: "weekly"
       day: "friday"
+    commit-message:
+      prefix: "CP-29639: "


### PR DESCRIPTION
## Why?

SOC 2 compliance.

## What

Add a hard-coded Jira issue to every dependabot PR. I think it technically checks the box for SOC 2, so better than nothing even if a bit silly...

## How Tested

Mostly have to wait for Dependabot to run 🤷. It does make it through the dependabot-validator CI check, though.