### PR TITLE
CP-29706: install tools to resolve dependency on gojq in release-to-main

### DIFF
--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -33,6 +33,14 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install tools
+        run: make install-tools
+
       - name: Update image version in Helm chart
         run: |
           sed -ri "s/^( *[a-z]*): +[^ ]+  (# <- Software release corresponding to this chart version.)$/\1: ${{ github.event.inputs.version }}  \2/" helm/values.yaml helm/templates/_helpers.tpl


### PR DESCRIPTION
## Why?

The release-to-main workflow is currently failing because `make helm-generate-tests` now requires gojq, which isn't installed in this workflow.

## What

This patch just installs go, then runs `make install-tools` prior to `make helm-generate-tests`

## How Tested

YOLO.
