### PR TITLE
CP-29706: run `format` make target after regenerating manifests

### DIFF
--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Update image version in Helm chart
         run: |
           sed -ri "s/^( *[a-z]*): +[^ ]+  (# <- Software release corresponding to this chart version.)$/\1: ${{ github.event.inputs.version }}  \2/" helm/values.yaml helm/templates/_helpers.tpl
-          make helm-generate-tests
+          make helm-generate-tests format
           git add helm/values.yaml helm/templates/*.tpl tests/helm/template/*.yaml
           git commit -m "Update image version in Helm chart to ${{ github.event.inputs.version }}"
 


### PR DESCRIPTION
## Why?

I'm not entirely sure why, but `make` detects that helm/values.schema.json needs to be regenerated when running in CI. This is handled automatically in the Makefile, but reformatting the result (using prettier) is not.

## What

Since we should already have prettier installed due to the `install-tools` target, we can just add the `format` target when running `helm-generate-tests` and reformat the output before committing. This should basically turn the regeneration of the JSON schema into a no-op, but without the release-to-main workflow will fail due to uncommitted changes in `helm/values.schema.json`.

## How Tested

Touch `helm/values.schema.yaml` so `helm/values.schema.json` gets regenerated, then run the commands in the release-to-main workflow. Note that the sed on macos won't work, but if you've installed the GNU utils from homebrew then by default you'll have GNU sed installed as `gsed`, so just use that instead of `sed`.
