### PR TITLE
CP-29735: allow 'global' top-level property, for subcharts

### DIFF
--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -20963,6 +20963,11 @@
       "description": "The name of an existing Kubernetes secret containing the API key.\n",
       "type": ["string", "null"]
     },
+    "global": {
+      "additionalProperties": true,
+      "description": "Global values that can be accessed by all charts and subcharts. When this chart\nis used as a subchart, Helm automatically creates this property to share values\nbetween parent and child charts.\n\nFor more information, see: https://helm.sh/docs/chart_template_guide/subcharts_and_globals/\n",
+      "type": "object"
+    },
     "host": {
       "description": "The CloudZero API host to connect to (e.g. api.cloudzero.com).\n",
       "minLength": 1,

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1410,3 +1410,13 @@ properties:
       (see tests/helm/template/), so jobConfig ID provides a way to override
       this behavior and instead generate the same hash every time. It shouldn't
       really be used anywhere else.
+
+  global:
+    type: object
+    additionalProperties: true
+    description: |
+      Global values that can be accessed by all charts and subcharts. When this chart
+      is used as a subchart, Helm automatically creates this property to share values
+      between parent and child charts.
+
+      For more information, see: https://helm.sh/docs/chart_template_guide/subcharts_and_globals/

--- a/tests/helm/schema/global.empty.pass.yaml
+++ b/tests/helm/schema/global.empty.pass.yaml
@@ -1,0 +1,5 @@
+cloudAccountId: "123456789"
+clusterName: "test-cluster"
+region: "us-east-1"
+host: "api.cloudzero.com"
+global: {}

--- a/tests/helm/schema/global.valid.pass.yaml
+++ b/tests/helm/schema/global.valid.pass.yaml
@@ -1,0 +1,8 @@
+cloudAccountId: "123456789"
+clusterName: "test-cluster"
+region: "us-east-1"
+host: "api.cloudzero.com"
+global:
+  someGlobalValue: "shared-value"
+  environment: "production"
+  namespace: "monitoring"

--- a/tests/helm/subchart/.gitignore
+++ b/tests/helm/subchart/.gitignore
@@ -1,0 +1,7 @@
+# Ignore generated Helm chart files
+*/chart/Chart.lock
+*/chart/charts/
+
+# Ignore any temporary test files
+*.tmp
+*.temp

--- a/tests/helm/subchart/basic/chart/Chart.yaml
+++ b/tests/helm/subchart/basic/chart/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: parent-chart
+description: A Helm chart for testing subchart dependencies
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+
+dependencies:
+  - name: cloudzero-agent
+    version: ">=0.0.0-0"
+    repository: "file://../../../../../helm"

--- a/tests/helm/subchart/basic/global.empty.subchart.pass.yaml
+++ b/tests/helm/subchart/basic/global.empty.subchart.pass.yaml
@@ -1,0 +1,9 @@
+# Test that an empty global object works when the chart is used as a subchart
+global: {}
+
+cloudzero-agent:
+  cloudAccountId: "123456789"
+  clusterName: "test-cluster"
+  region: "us-east-1"
+  host: "api.cloudzero.com"
+  apiKey: "test-key"

--- a/tests/helm/subchart/basic/global.string.subchart.fail.yaml
+++ b/tests/helm/subchart/basic/global.string.subchart.fail.yaml
@@ -1,0 +1,6 @@
+# Test that subchart fails validation when required fields are missing
+global: {}
+
+cloudzero-agent:
+  # Missing required fields: cloudAccountId, clusterName, region, host, apiKey
+  invalidField: "this-should-cause-failure"

--- a/tests/helm/subchart/basic/global.subchart.pass.yaml
+++ b/tests/helm/subchart/basic/global.subchart.pass.yaml
@@ -1,0 +1,12 @@
+# Test that global values work when the chart is used as a subchart
+global:
+  environment: "test"
+  region: "us-east-1"
+  team: "platform"
+
+cloudzero-agent:
+  cloudAccountId: "123456789"
+  clusterName: "test-cluster"
+  region: "us-east-1"
+  host: "api.cloudzero.com"
+  apiKey: "test-key"


### PR DESCRIPTION
## Why?

When the cloudzero-agent Helm chart is used as a subchart, Helm will automatically add a top-level 'global' property (for detais, see https://helm.sh/docs/chart_template_guide/subcharts_and_globals/).

What I didn't anticipate is that Helm will also include that property in the JSON Schema it is checking against, meaning that previously any use of the cloudzero-agent chart as a subchart would cause a schema validation error.

## What

This tweaks the JSON Schema to allow for a 'global' property, with any contents. It also adds a test which would have caught this issues, to ensure that there are no regressions.

## How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile
