### PR TITLE
CP-29742: emit logs periodically from the collector and shipper

### DIFF
--- a/app/domain/shipper/shipper.go
+++ b/app/domain/shipper/shipper.go
@@ -155,7 +155,7 @@ func (m *MetricShipper) runShipper(ctx context.Context) error {
 
 		// used as a marker in tests to signify that the shipper was complete.
 		// if you change this string, then change in the smoke tests as well.
-		logger.Debug().Msg("Successfully ran the shipper cycle") // WARNING -- THIS IS USED AS A MARKER STRING IN SMOKE TESTS
+		logger.Info().Msg("Successfully ran the shipper cycle") // WARNING -- THIS IS USED AS A MARKER STRING IN SMOKE TESTS
 
 		return err
 	})

--- a/app/storage/disk/disk.go
+++ b/app/storage/disk/disk.go
@@ -19,10 +19,11 @@ import (
 	"github.com/go-obvious/timestamp"
 	"github.com/google/uuid"
 	"github.com/launchdarkly/go-jsonstream/v3/jwriter"
+	"github.com/shirou/gopsutil/v4/disk"
 
 	config "github.com/cloudzero/cloudzero-agent/app/config/gator"
 	"github.com/cloudzero/cloudzero-agent/app/types"
-	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -250,6 +251,13 @@ func (d *DiskStore) flushUnlocked() error {
 	if err != nil {
 		return fmt.Errorf("failed to rename active parquet file: %w", err)
 	}
+
+	log.Ctx(context.Background()).Info().
+		Time("startTime", time.UnixMilli(d.startTime)).
+		Time("stopTime", time.UnixMilli(stopTime)).
+		Str("filePath", timestampedFilePath).
+		Int("rowCount", d.rowCount).
+		Msg("flushed disk store")
 
 	// Reset writer and file pointers
 	d.writer = nil


### PR DESCRIPTION
## Why?

Currently the collector and shipper are completely silent during normal operation at the (default) info log level. It would be nice to just be able to see a bit of activity in the logs so we know things are working...

## What

Just adds a log entry on the collector side when we flush to disk, and bumps an existing log message from debug to info level on the shipper side.

## How Tested

Deploy, then `kubectl logs`
