### PR TITLE
CP-29759: add helmless job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# These are platform-specific, and can override using system-wide
+# versions of the tools.
+/.tools/bin
+/.tools/node_modules

--- a/app/functions/helmless/README.md
+++ b/app/functions/helmless/README.md
@@ -14,15 +14,36 @@ helmless [flags]
 ### Flags
 
 - `-c, --configured string` - Path to the configured values YAML file (default "configured-values.yaml")
-- `-d, --defaults string` - Path to the default values YAML file (default "default-values.yaml")
+- `-d, --defaults string` - Path to the default values YAML file (uses embedded defaults if not provided)
 - `-o, --output string` - Path to write the output YAML file (default "-" for stdout)
 
-### Example Workflow
+### Example Workflows
+
+#### Simplified Workflow (Using Embedded Defaults)
+
+The tool now includes embedded default values from the Helm chart, so you can use it without manually extracting defaults:
 
 1. Extract the current values from a deployed Helm release:
 
    ```sh
-   kubectl -n cza get cm/cz-agent-config-values -o jsonpath='{.data.values\.yaml}' > configured-values.yaml
+   kubectl -n cza get cm/cz-agent-helmless-cm -o jsonpath='{.data.values\.yaml}' > configured-values.yaml
+   ```
+
+2. Compare the values and generate a minimal overrides file:
+   ```sh
+   cloudzero-helmless \
+       --configured configured-values.yaml \
+       --output overrides.yaml
+   ```
+
+#### Traditional Workflow (Explicit Defaults)
+
+If you need to use a different version of defaults or want explicit control:
+
+1. Extract the current values from a deployed Helm release:
+
+   ```sh
+   kubectl -n cza get cm/cz-agent-helmless-cm -o jsonpath='{.data.values\.yaml}' > configured-values.yaml
    ```
 
 2. Get the default values from the Helm chart:
@@ -41,6 +62,18 @@ helmless [flags]
 
 The resulting `overrides.yaml` will contain only the values that differ from the
 defaults, making it easy to understand what has been customized.
+
+## Getting Logs
+
+When the helmless job runs as part of a Helm deployment, you can view its logs without needing to know the chart name by using the job's component label:
+
+```sh
+kubectl logs -l app.kubernetes.io/component=helmless -n <namespace> --tail=100
+```
+
+## Build System Integration
+
+The embedded defaults are automatically generated during the build process by running `helm show values ./helm` and embedding the result into the binary. This ensures that the embedded defaults always match the current version of the Helm chart.
 
 ## Limitations
 

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -1,0 +1,858 @@
+# -- CloudZero host to send metrics to.
+host: api.cloudzero.com
+# -- Account ID of the account the cluster is running in. This must be a string - even if it is a number in your system.
+cloudAccountId: null
+# -- Name of the clusters.
+clusterName: null
+# -- Region the cluster is running in.
+region: null
+
+# -- CloudZero API key. Required if existingSecretName is null.
+apiKey: null
+# -- If set, the agent will use the API key in this Secret to authenticate with CloudZero.
+existingSecretName: null
+
+# Agent largely contains top-level settings which are often shared by multiple
+# components within this chart, or used as defaults in case values are not
+# explicitly set per-component.
+defaults:
+  # Federated mode deploys the agent as a DaemonSet, with each node in the
+  # cluster running its own metrics collector.
+  federation:
+    # Whether to enable federated mode.
+    enabled: false
+
+  # The default image settings which will be fallen back on for all components.
+  #
+  # Note that all image values (including repository, tag, etc.) are valid here,
+  # though for the most part they are overridden by the component-specific
+  # settings anyways.
+  image:
+    pullPolicy: IfNotPresent
+    pullSecrets:
+  # If set, these DNS settings will be attached to resources which support it.
+  dns:
+    # DNS policy to use on all pods.
+    #
+    # Valid values include:
+    #
+    # - "Default"
+    # - "ClusterFirst"
+    # - "ClusterFirstWithHostNet"
+    # - "None"
+    #
+    # Somewhat counterintuitively, "Default" is not actually the default,
+    # "ClusterFirst" is.
+    #
+    # For details, see the Kubernetes documentation:
+    # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+    #
+    # Note that if you set this, you'll likely also want to set kubeStateMetrics.dnsPolicy
+    # to the same value.
+    policy:
+    # DNS configuration to use on all pods.
+    #
+    # There are currently three properties which can be specified: nameservers,
+    # searches, and options.
+    #
+    # For details, see the Kubernetes documentation:
+    # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+    #
+    # Note that if you set this, you'll likely also want to set kubeStateMetrics.dnsConfig
+    # to the same value.
+    config: {}
+  # Labels to be added to all resources.
+  #
+  # Labels are organized as key/value pairs. For example, if you wanted to set a
+  # my.org/team label to the value "superstars":
+  #
+  #   labels:
+  #     my.org/team: superstars
+  #
+  # Note that this chart will unconditionally add the following labels:
+  #
+  #  - app.kubernetes.io/version
+  #  - helm.sh/chart
+  #  - app.kubernetes.io/managed-by
+  #  - app.kubernetes.io/part-of
+  #
+  # Additionally, certain components will add additional labels. Any labels
+  # specified here will be *in addition* to the labels added automatically, not
+  # instead of them.
+  #
+  # For more information, see the Kubernetes documentation:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  #
+  # You may also be interested in this list of well-known labels:
+  # https://kubernetes.io/docs/reference/labels-annotations-taints/
+  #
+  # Note that if you set this, you'll likely also want to set
+  # kubeStateMetrics.customLabels.
+  labels: {}
+  # Annotations to be added to all resources.
+  #
+  # Similar to labels, annotations are organized as key/value pairs, and
+  # annotations specified here will be merged into any annotations added
+  # automatically by the chart.
+  #
+  # For more information, see the Kubernetes documentation:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  #
+  # Note that if you set this, you'll likely also want to set
+  # kubeStateMetrics.annotations.
+  annotations: {}
+  # Affinity settings to be added to all resources.
+  #
+  # Affinity settings are used to control the scheduling of pods. For more
+  # information, see the Kubernetes documentation:
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  #
+  # Note that if you set this, you'll likely also want to set
+  # kubeStateMetrics.affinity.
+  affinity: {}
+  # Tolerations to be added to all resources.
+  #
+  # Tolerations are used to control the scheduling of pods. For more
+  # information, see the Kubernetes documentation:
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  #
+  # Note that if you set this, you'll likely also want to set
+  # kubeStateMetrics.tolerations.
+  tolerations: []
+  # Node Selector to be added to all resources.
+  #
+  # Node Selector is used to control the scheduling of pods. For more
+  # information, see the Kubernetes documentation:
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+  #
+  # Note that if you set this, you'll likely also want to set
+  # kubeStateMetrics.nodeSelector.
+  nodeSelector: {}
+  # Pod Disruption Budget to be added to all resources.
+  #
+  # For information about PDBs, see the Kubernetes documentation:
+  # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  #
+  # Note that if you set this, you'll likely also want to set
+  # kubeStateMetrics.podDisruptionBudget.
+  podDisruptionBudget:
+    minAvailable: 1
+    maxUnavailable:
+  # If set, this priority class name will be used for all deployments and jobs.
+  #
+  # Note that, if used, you will need to create the PriorityClass resource
+  # yourself; this chart is only capable of referencing an existing priority
+  # class, not creating one from whole cloth.
+  #
+  # For more information, see the Kubernetes documentation:
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  #
+  # Note that if you set this, you'll likely also want to set
+  # kubeStateMetrics.priorityClassName.
+  priorityClassName:
+
+# Component-specific configuration settings.
+components:
+  # The agent here refers to the CloudZero Agent, which is the component that
+  # collects metrics from the cluster and sends them to the aggregator.
+  agent:
+    # This is the image which contains most of the code that makes this chart
+    # work. Since 1.1, CloudZero uses a single container image, with multiple
+    # executables, to provide CloudZero functionality.
+    image:
+      repository: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent
+      tag: 1.2.0 # <- Software release corresponding to this chart version.
+    podDisruptionBudget:
+      minAvailable:
+      maxUnavailable:
+
+  # kubectl contains details about where to find the kubectl image.  This chart
+  # uses the kubectl image as part of the job to initialize certificates.
+  kubectl:
+    image:
+      repository: docker.io/bitnami/kubectl
+      tag: "1.33.1"
+
+  # prometheus contains details about where to find the Prometheus image.
+  # Prometheus is critical to the functionality of this chart, and is used to
+  # scrape metrics.
+  prometheus:
+    image:
+      repository: quay.io/prometheus/prometheus
+      tag: # This will fall back on .Chart.AppVersion if not set.
+
+  # prometheusReloader contains details about where to find the Prometheus
+  # reloader image.
+  #
+  # prometheus-config-reloader will watch the Prometheus configuration for
+  # changes and restart the Prometheus pod as necessary.
+  prometheusReloader:
+    image:
+      repository: quay.io/prometheus-operator/prometheus-config-reloader
+      tag: "v0.83.0"
+
+  # Settings for the aggregator component. This is the piece which accepts
+  # metrics from the agent, webhook, etc., and sends them to the CloudZero API
+  # after some processing.
+  aggregator:
+    replicas: 3
+    podDisruptionBudget:
+      minAvailable:
+      maxUnavailable:
+    tolerations: []
+    annotations: {}
+
+  # Settings for the webhook server.
+  webhookServer:
+    replicas: 3
+    podDisruptionBudget:
+      minAvailable:
+      maxUnavailable:
+
+# Due to limitations of Helm, we are unfortunately not able to automatically configure the
+# kube-state-metrics subchart using the configuration above, and instead need to configure
+# it here, often duplicating things.
+#
+# For full documentation on configuring this subchart, see:
+# https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics
+# Specifically, the values.yaml file in that repository:
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-state-metrics/values.yaml
+kubeStateMetrics:
+  enabled: true
+  affinity: {}
+  tolerations: []
+  customLabels: {}
+  dnsPolicy: ClusterFirst
+  dnsConfig: {}
+  annotations: {}
+  podAnnotations: {}
+  nodeSelector: {}
+  podDisruptionBudget:
+    minAvailable: 1
+  image:
+    registry: registry.k8s.io
+    repository: kube-state-metrics/kube-state-metrics
+    tag: "v2.15.0"
+    sha:
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  nameOverride: "cloudzero-state-metrics"
+  # Disable CloudZero KSM as a Scrape Target since the service endpoint is
+  # explicitly defined by the Validators config file.
+  prometheusScrape: false
+  # Set a default port other than 8080 to avoid collisions with any existing KSM
+  # services.
+  service:
+    port: 8080
+
+#######################################################################################
+#######################################################################################
+####                                                                               ####
+####  Values below this point are not considered API stable. Use at your own risk. ####
+####  If you do require them for some reason, please let us know so we can work on ####
+####  covering your use case in the stable section.                                ####
+####                                                                               ####
+#######################################################################################
+#######################################################################################
+
+prometheusConfig:
+  configMapNameOverride: ""
+  configMapAnnotations: {}
+  configOverride: ""
+  globalScrapeInterval: 60s
+  outOfOrderTimeWindow: 5m
+  scrapeJobs:
+    # -- Enables the kube-state-metrics scrape job.
+    kubeStateMetrics:
+      enabled: true
+      # Scrape interval for kubeStateMetrics job
+      scrapeInterval: 60s
+    # -- Enables the cadvisor scrape job.
+    cadvisor:
+      enabled: true
+      # Scrape interval for nodesCadvisor job
+      scrapeInterval: 60s
+    # -- Enables the prometheus scrape job.
+    prometheus:
+      enabled: true
+      # Scrape interval for prometheus job
+      scrapeInterval: 120s
+    aggregator:
+      enabled: true
+      # Scrape interval for aggregator job
+      scrapeInterval: 120s
+    # -- Any items added to this list will be added to the Prometheus scrape configuration.
+    additionalScrapeJobs: []
+
+# General server settings that apply to both the prometheus agent server and the webhook server
+serverConfig:
+  # -- The agent will use this file path on the container filesystem to get the CZ API key.
+  containerSecretFilePath: /etc/config/secrets/
+  # -- The agent will look for a file with this name to get the CZ API key.
+  containerSecretFileName: value
+
+# -- The following settings are for the init-backfill-job, which is used to backfill data from the cluster to CloudZero.
+initBackfillJob:
+  annotations: {}
+  tolerations: []
+  # -- By default, all image settings use those set in insightsController.server. Optionally use the below to override. This should not be common.
+  # imagePullSecrets: []
+  image:
+    repository:
+    tag:
+    digest:
+    pullPolicy:
+  enabled: true
+
+# -- This is a deprecated field that is replaced by initBackfillJob. However, the fields are identical, and initScrapeJob can still be used to configure the backFill/scrape Job.
+# initScrapeJob:
+# -- By default, all image settings use those set in insightsController.server. Optionally use the below to override. This should not be common.
+# imagePullSecrets: []
+# image:
+#   repository:
+#   tag:
+#   pullPolicy:
+
+initCertJob:
+  enabled: true
+  # -- Defaults to the same setting as the insightsController.server if set, otherwise left empty.
+  # imagePullSecrets: []
+  annotations: {}
+  tolerations: []
+  image:
+    repository:
+    pullPolicy:
+    digest:
+    tag:
+  rbac:
+    create: true
+    serviceAccountName: ""
+    clusterRoleName: ""
+    clusterRoleBindingName: ""
+
+  # -- Overriding static scrape target address for an existing KSM.
+  # -- Set to service <service-name>.<namespace>.svc.cluster.local:port if built-in is disabled (enable=false above)
+  # targetOverride: kube-state-metrics.monitors.svc.cluster.local:8080
+  # -- If targetOverride is set and kubeStateMetrics.enabled is true, it is likely that fullnameOverride below must be set as well.
+  # -- This should not be a common configuration
+  # fullnameOverride: "kube-state-metrics"
+
+# -- Annotations to be added to the Secret, if the chart is configured to create one
+secretAnnotations: {}
+imagePullSecrets: []
+
+# environment validator image allows for CI to use a different image in testing
+validator:
+  serviceEndpoints:
+    kubeStateMetrics:
+  # -- Flag to skip validator failure if unable to connect to the CloudZero API.
+  name: env-validator
+  image:
+    repository:
+    tag:
+    digest:
+    pullPolicy:
+    pullSecrets:
+
+server:
+  name: server
+  # Container image configuration for the server.
+  #
+  # Deprecated. Please use components.agent.image instead.
+  image:
+    repository:
+    tag:
+    digest:
+    pullPolicy:
+  # Node selector configuration for the server pods.
+  #
+  # See the Kubernetes documentation for details:
+  # https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+  nodeSelector: {}
+  # Resource requirements and limits for the server.
+  #
+  # For details, see the Kubernetes documentation on resource management:
+  # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 250m
+    limits:
+      memory: 1024Mi
+  # Annotations to add to the server Deployment.
+  deploymentAnnotations: {}
+  # Annotations to add to the server pods.
+  podAnnotations: {}
+  # Whether the server is running in agent mode.
+  agentMode: true
+  # Command-line arguments to pass to the server.
+  args:
+    - --config.file=/etc/config/prometheus/configmaps/prometheus.yml
+    - --web.enable-lifecycle
+    - --web.console.libraries=/etc/prometheus/console_libraries
+    - --web.console.templates=/etc/prometheus/consoles
+  logging:
+    level:
+  # Configuration for persistent storage.
+  persistentVolume:
+    existingClaim: ""
+    enabled: false
+    mountPath: /data
+    subPath: ""
+    storageClass: ""
+    size: 8Gi
+    accessModes:
+      - ReadWriteOnce
+    # Annotations to add to the PersistentVolumeClaim.
+    annotations: {}
+  # --Limit the size to 8Gi to lower impact on the cluster, and to provide a reasonable backup for the WAL
+  emptyDir:
+    sizeLimit: 8Gi
+  # Affinity rules
+  #
+  # See the Kubernetes documentation for details:
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+  # Tolerations configuration for the aggregator pods.
+  #
+  # See the Kubernetes documentation for details:
+  # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+  # Topology spread constraints for pod scheduling
+  topologySpreadConstraints: []
+  # Termination grace period in seconds
+  terminationGracePeriodSeconds: 300
+  # Readiness probe configuration
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    timeoutSeconds: 4
+    failureThreshold: 3
+    successThreshold: 1
+  # Liveness probe configuration
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
+
+# Configuration for the webhook server (née Insights Controller), which collects
+# and processes Kubernetes resource metadata for cost attribution and analysis.
+insightsController:
+  # Whether to enable the insights controller.
+  #
+  # It is strongly recommended that this feature be enabled as it provides
+  # important functionality.
+  enabled: true
+  # Configuration for collecting labels from Kubernetes resources.
+  labels:
+    # Whether to enable collection of specific labels for cost attribution
+    # dimensions.
+    #
+    # It is strongly recommended that this feature be enabled as it provides
+    # important functionality.
+    enabled: true
+    # List of Go-style regular expressions used to filter desired labels.
+    #
+    # Caution: The CloudZero system has a limit of 300 labels and annotations,
+    # so it is advisable to provide a specific list of required labels rather
+    # than a wildcard.
+    patterns:
+      - "app.kubernetes.io/component"
+    # Specify which resources to collect labels from.
+    resources:
+      # Whether to collect labels from CronJobs.
+      cronjobs: false
+      # Whether to collect labels from DaemonSets.
+      daemonsets: false
+      # Whether to collect labels from Deployments.
+      deployments: false
+      # Whether to collect labels from Jobs.
+      jobs: false
+      # Whether to collect labels from Namespaces.
+      namespaces: true
+      # Whether to collect labels from Nodes.
+      nodes: false
+      # Whether to collect labels from Pods.
+      pods: true
+      # Whether to collect labels from StatefulSets.
+      statefulsets: false
+  # Configuration for collecting annotations from Kubernetes resources.
+  annotations:
+    # Whether to enable collection of annotations for cost attribution dimensions.
+    enabled: false
+    # List of Go-style regular expressions used to filter desired annotations.
+    # Caution: The CloudZero system has a limit of 300 labels and annotations,
+    # so it is advisable to provide a specific list of required annotations rather than a wildcard.
+    patterns:
+      - ".*" # Use regex patterns to specify which annotations to collect. ".*" collects all annotations.
+    # Specify which resources to collect annotations from.
+    resources:
+      # Whether to collect annotations from CronJobs.
+      cronjobs: false
+      # Whether to collect annotations from DaemonSets.
+      daemonsets: false
+      # Whether to collect annotations from Deployments.
+      deployments: false
+      # Whether to collect annotations from Jobs.
+      jobs: false
+      # Whether to collect annotations from Namespaces.
+      namespaces: true
+      # Whether to collect annotations from Nodes.
+      nodes: false
+      # Whether to collect annotations from Pods.
+      pods: true
+      # Whether to collect annotations from StatefulSets.
+      statefulsets: false
+  # Configuration for TLS certificates used by the insights controller.
+  tls:
+    # Whether to enable TLS certificate management.
+    enabled: true
+    # TLS certificate in PEM format. If empty, a certificate will be generated.
+    crt: ""
+    # TLS private key in PEM format. If empty, a key will be generated.
+    key: ""
+    # Configuration for the TLS certificate Secret.
+    secret:
+      # Whether to create a Secret to store the TLS certificate and key.
+      create: true
+      # Name of the Secret to create. If empty, a name will be generated.
+      name: ""
+    # Path where the TLS certificate and key will be mounted in the container.
+    mountPath: /etc/certs
+    # CA bundle for validating admission webhook requests. If empty, the default
+    # self-signed certificate will be used.
+    caBundle: ""
+    # Whether to use cert-manager for certificate management. If disabled, a
+    # self-signed certificate will be used.
+    useCertManager: false
+  # Configuration for the webhook server component.
+  server:
+    # Name of the webhook server component.
+    name: webhook-server
+    # Number of replicas to run for the webhook server.
+    replicaCount:
+    # Container image configuration for the webhook server.
+    #
+    # Deprecated. Please use components.webhookServer.image instead.
+    image:
+      repository:
+      tag:
+      pullPolicy:
+    # Port that the webhook server listens on.
+    port: 8443
+    # Timeout for reading HTTP requests.
+    #
+    # This is formatted as a Go duration string; see
+    # https://pkg.go.dev/time#ParseDuration for details.
+    read_timeout: 10s
+    # Timeout for writing HTTP responses.
+    #
+    # This is formatted as a Go duration string; see
+    # https://pkg.go.dev/time#ParseDuration for details.
+    write_timeout: 10s
+    # Timeout for sending data to clients.
+    #
+    # This is formatted as a Go duration string; see
+    # https://pkg.go.dev/time#ParseDuration for details.
+    send_timeout: 1m
+    # Interval between sending data to clients.
+    #
+    # This is formatted as a Go duration string; see
+    # https://pkg.go.dev/time#ParseDuration for details.
+    send_interval: 1m
+    # Timeout for idle connections.
+    #
+    # This is formatted as a Go duration string; see
+    # https://pkg.go.dev/time#ParseDuration for details.
+    idle_timeout: 120s
+    # Configuration for logging in the webhook server.
+    logging:
+      # Logging level for the webhook server.
+      level: info
+    # Configuration for the health check endpoint.
+    healthCheck:
+      # Whether to enable the health check endpoint.
+      enabled: true
+      # Path for the health check endpoint.
+      path: /healthz
+      # Port for the health check endpoint.
+      port: 8443
+      # Initial delay before starting health checks.
+      initialDelaySeconds: 15
+      # Interval between health checks.
+      periodSeconds: 20
+      # Timeout for health check requests.
+      timeoutSeconds: 3
+      # Number of successful checks required to mark as healthy.
+      successThreshold: 1
+      # Number of failed checks before marking as unhealthy.
+      failureThreshold: 5
+    # Node selector configuration for the webhook server pods.
+    #
+    # See the Kubernetes documentation for details:
+    # https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+    nodeSelector: {}
+    # Tolerations configuration for the webhook server pods.
+    #
+    # See the Kubernetes documentation for details:
+    # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+    # Affinity rules for the webhook server pods.
+    #
+    # See the Kubernetes documentation for details:
+    # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    affinity: {}
+    # Annotations to add to the webhook server Deployment.
+    deploymentAnnotations: {}
+    # Annotations to add to the webhook server pods.
+    podAnnotations: {}
+  # Additional volume mounts to add to the insights controller pods.
+  volumeMounts: []
+  # Additional volumes to add to the insights controller pods.
+  volumes: []
+  # Resource requirements and limits for the insights controller.
+  resources: {}
+  # Annotations to add to the insights controller pods.
+  podAnnotations: {}
+  # Labels to add to the insights controller pods.
+  podLabels: {}
+  # Configuration for the insights controller Service.
+  service:
+    # Port that the insights controller Service listens on.
+    port: 443
+  # Configuration for the validating admission webhook.
+  webhooks:
+    # Annotations to add to the validating admission webhook.
+    annotations: {}
+    # Namespace selector for the validating admission webhook.
+    namespaceSelector: {}
+    # Path for the validating admission webhook.
+    path: /validate
+    caInjection:
+  configurationMountPath:
+  ConfigMapNameOverride:
+
+# Configuration for the service account in the chart.
+serviceAccount:
+  # Whether to create the service account.
+  create: true
+  # Name of the service account to create.
+  #
+  # If not set, one will be generated automatically.
+  name: ""
+  # Annotations to add to the service account.
+  #
+  # For more information, see the Kubernetes documentation:
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  annotations: {}
+
+# Configuration for the RBAC resources in the chart (e.g., ClusterRole,
+# ClusterRoleBinding, Role, RoleBinding, etc.).
+rbac:
+  # Whether to create the RBAC resources.
+  create: true
+
+# These labels are added to all resources in the chart.
+#
+# Deprecated. Please use defaults.labels instead.
+commonMetaLabels: {}
+
+# Configuration for the ConfigMap reloader component, which watches for changes in
+# ConfigMaps and triggers a reload of the affected components.
+configmapReload:
+  # Configuration specific to the Prometheus ConfigMap reloader.
+  prometheus:
+    # Whether to enable the Prometheus ConfigMap reloader.
+    enabled: true
+    # Container image configuration for the Prometheus ConfigMap reloader.
+    image:
+      repository:
+      tag:
+      digest:
+      pullPolicy:
+    # Resource requirements and limits for the Prometheus ConfigMap reloader.
+    #
+    # For details, see the Kubernetes documentation on resource management:
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources: {}
+
+# The aggregator provides an intermediary between the CloudZero Agent and the
+# CloudZero API. It is composed of two applications, the collector and the
+# shipper.
+#
+# The collector application provides an endpoint for the CloudZero Agent to
+# write metrics to. It filters out any unwanted metrics as it receives them,
+# aggregates the wanted metrics, and stores them in a compressed format on disk
+# until they are ready to be uploaded to the CloudZero servers. Once the
+# collector has aggregated sufficient metrics (or a given amount of time has
+# elapsed) the data is sent to the shipper.
+#
+# The shipper will process the completed metrics files and push them to the
+# remote server. It will also handle any requests from the server to re-send any
+# missing or incomplete data, ensuring that there is no data loss in the event
+# of any loss of communication with the CloudZero API, even when a
+# misconfiguration (such as an incorrect API key) prevents it.
+aggregator:
+  # Configuration for logging behavior of the aggregator components.
+  logging:
+    # Logging level that will be posted to stdout.
+    # Valid values are: 'debug', 'info', 'warn', 'error'
+    level: info
+    # Whether to persist logs to disk.
+    capture: true
+  # Top-level directory containing CloudZero data. There will be subdirectories
+  # for configuration (the mounted ConfigMap) and the API key (typically a
+  # mounted Secret), and data to be uploaded to CloudZero, specifically metrics.
+  # This value is really only visible internally in the container, so you
+  # shouldn't generally need to change it.
+  #
+  # Set `aggregator.database.purgeRules` to control the cleanup behavior of this
+  # directory.
+  mountRoot: /cloudzero
+  # Whether to enable the profiling endpoint (/debug/pprof/). This should
+  # generally be disabled in production.
+  profiling: false
+  # Wether to enable rolling a debug container inside the aggregator pod.
+  # This should be disabled in production.
+  debugContainer: false
+  # Frequency to close HTTP connections from clients, to help distribute the
+  # load across the various collector replicas. 0=never, otherwise 1/N
+  # probability.
+  reconnectFrequency: 16
+  # Container image configuration for the aggregator components.
+  #
+  # Deprecated. Please use components.aggregator.image instead.
+  image:
+    repository:
+    tag:
+    digest:
+    pullPolicy:
+  cloudzero:
+    # Interval between attempts to ship metrics to the remote endpoint.
+    #
+    # This is formatted as a Go duration string; see
+    # https://pkg.go.dev/time#ParseDuration for details.
+    sendInterval: 10m
+    # Max time the aggregator will spend attempting to ship metrics to the remote endpoint.
+    #
+    # This is formatted as a Go duration string; see
+    # https://pkg.go.dev/time#ParseDuration for details.
+    sendTimeout: 120s
+    # Interval at which the aggregator will rotate its internal data structures.
+    #
+    # This is formatted as a Go duration string; see
+    # https://pkg.go.dev/time#ParseDuration for details.
+    rotateInterval: 30m
+    # The number of http retry attempts to use before failing.
+    # This is not a recommended option to change.
+    httpMaxRetries: 10
+    # The max wait time between http request retry attempts.
+    # This is not a recommended option to change.
+    httpMaxWait: 30s
+  # Configuration for the aggregator's database and storage behavior.
+  database:
+    # Max number of records per file. Use this to adjust file sizes uploaded to
+    # the server. The default value should generally be left unchanged.
+    maxRecords: 1500000
+    # Max interval to flush a cost metrics file. This is mostly useful for
+    # smaller clusters with little activity.
+    costMaxInterval: 10m
+    # Max interval to flush an observability metrics file. This is mostly useful
+    # for smaller clusters with little activity.
+    observabilityMaxInterval: 30m
+    # Compression level to use when compressing metrics files on-disk.
+    #
+    # Valid value range from 0-11, with higher values yielding improved
+    # compression ratios at the expense of speed and memory usage.
+    #
+    # Read more about brotli compression here:
+    # https://github.com/google/brotli/blob/master/c/tools/brotli.md#options
+    compressionLevel: 8
+    # The rules that the application will follow in respect to cleaning up old
+    # files that have been uploaded to the CloudZero platform.
+    #
+    # Generally, the defaults will be okay for the majority of use cases. But,
+    # the options are here for more advanced users to optimize disk usage. For
+    # example, the default case is to keep uploaded files around for 90 days, as
+    # this falls in line with most customer's data tolerance policies. But, if
+    # deployed on a more active and/or larger cluster, this value can be lowered
+    # to keep disk usage lower with the tradeoff of less data-retention.
+    # Regardless of what you define here if there is disk pressure detected,
+    # files will be deleted (oldest first) to free space.
+    purgeRules:
+      # How long to keep uploaded files. This option can be useful to optimize
+      # the storage required by the collector/shipper architecture on your
+      # nodes.
+      #
+      # Note that, regardless of this option, if disk pressure is detected,
+      # files will be deleted (oldest first) to free space.
+      #
+      # `168h` is 7 days, and is a reasonable default for most clusters.
+      #
+      # `0s` is also a valid option and can signify that you do not want to keep
+      # uploaded files at all. Though do note that this could possibly result in
+      # data loss if there are transient upload failures during the lifecycle of
+      # the application.
+      metricsOlderThan: 168h
+      # If set to true (default), then files older than `metricsOlderThan` will
+      # not be deleted unless there is detected storage pressure. For example,
+      # if there are files older than `metricsOlderThan` but only 30% of storage
+      # space is used, the files will not be deleted.
+      lazy: true
+      # This controls the percentage of files the application will remove when
+      # there is critical storage pressure. This is defined by >95% of storage
+      # usage.
+      percent: 20
+    # Configuration for the emptyDir volume used by the aggregator.
+    emptyDir:
+      # Whether to enable the emptyDir volume for the aggregator.
+      enabled: true
+      # Size limit for the emptyDir volume. If not set, no limit is applied.
+      sizeLimit: ""
+  # Configuration for the collector component of the aggregator.
+  collector:
+    # Port that the collector listens on for incoming metrics.
+    port: 8080
+    # Resource requirements and limits for the collector component.
+    #
+    # For details, see the Kubernetes documentation on resource management:
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+  # Configuration for the shipper component of the aggregator.
+  shipper:
+    # Port that the shipper listens on for internal communication.
+    port: 8081
+    # Resource requirements and limits for the shipper component.
+    #
+    # For details, see the Kubernetes documentation on resource management:
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+  # Node selector configuration for the aggregator pods.
+  #
+  # See the Kubernetes documentation for details:
+  # https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/
+  nodeSelector: {}
+  # Tolerations configuration for the aggregator pods.
+  #
+  # See the Kubernetes documentation for details:
+  # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+  # Affinity rules for the aggregator pods.
+  #
+  # See the Kubernetes documentation for details:
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,10 +17,17 @@ RUN grep nobody /etc/passwd > /etc/passwd_nobody
 # Copy the Go module files and download dependencies
 COPY go.mod go.sum ./
 RUN go mod download \
-    && apk add build-base make zig
+    && apk add \
+        binutils-gold \
+        build-base \
+        make \
+        npm \
+        zig
 
 # Copy the source code
 COPY . .
+
+RUN make install-tools
 
 # Build the Go binary
 RUN make build OUTPUT_BIN_DIR=/go/bin \
@@ -72,6 +79,7 @@ COPY --from=builder /go/bin/cloudzero-collector /app/cloudzero-collector
 COPY --from=builder /go/bin/cloudzero-webhook /app/cloudzero-webhook
 COPY --from=builder /go/bin/cloudzero-shipper /app/cloudzero-shipper
 COPY --from=builder /go/bin/cloudzero-cluster-config /app/cloudzero-cluster-config
+COPY --from=builder /go/bin/cloudzero-helmless /app/cloudzero-helmless
 
 # Allow the default ENTRYPOINT from busybox to be the default,
 # however run the app as the default command

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -565,6 +565,13 @@ Name for the certificate init job resource. Should be a new name each installati
 {{- end }}
 
 {{/*
+Name for the helmless job resource. Should be a new name each installation/upgrade.
+*/}}
+{{- define "cloudzero-agent.helmlessJobName" -}}
+{{- include "cloudzero-agent.jobName" (dict "Release" .Release.Name "Name" "helmless" "Version" .Chart.Version "Values" .Values) -}}
+{{- end }}
+
+{{/*
 Annotations for the webhooks
 */}}
 {{- define "cloudzero-agent.webhooks.annotations" -}}

--- a/helm/templates/helmless-cm.yaml
+++ b/helm/templates/helmless-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-config-values
+  name: {{ .Release.Name }}-helmless-cm
   namespace: {{ .Release.Namespace }}
   {{- include "cloudzero-agent.generateLabels" (dict "globals" . "labels" .Values.commonMetaLabels) | nindent 2 }}
   {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}

--- a/helm/templates/helmless-job.yaml
+++ b/helm/templates/helmless-job.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cloudzero-agent.helmlessJobName" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict "globals" . "component" "helmless") | nindent 2 }}
+spec:
+  template:
+    metadata:
+      name: {{ include "cloudzero-agent.helmlessJobName" . }}
+      namespace: {{ .Release.Namespace }}
+      {{- include "cloudzero-agent.generateLabels" (dict "globals" . "component" "helmless") | nindent 6 }}
+      {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 6 }}
+    spec:
+      restartPolicy: OnFailure
+      {{- include "cloudzero-agent.generateDNSInfo" (dict "defaults" .Values.defaults.dns) | nindent 6 }}
+      {{- include "cloudzero-agent.generatePriorityClassName" .Values.defaults.priorityClassName | nindent 6 }}
+      containers:
+        - name: helmless
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image) | nindent 10 }}
+          command:
+            - /app/cloudzero-helmless
+          args:
+            - --configured
+            - /etc/config/values/values.yaml
+            - --output
+            - "-"
+          volumeMounts:
+            - name: helmless-cm
+              mountPath: /etc/config/values
+              readOnly: true
+      volumes:
+        - name: helmless-cm
+          configMap:
+            name: {{ .Release.Name }}-helmless-cm
+      {{- include "cloudzero-agent.generateNodeSelector" (dict "default" .Values.defaults.nodeSelector) | nindent 6 }}
+      {{- include "cloudzero-agent.generateAffinity" (dict "default" .Values.defaults.affinity) | nindent 6 }}
+      {{- include "cloudzero-agent.generateTolerations" .Values.defaults.tolerations | nindent 6 }}

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -741,11 +741,11 @@ data:
       http_max_retries: 10
       http_max_wait: 30s
 ---
-# Source: cloudzero-agent/templates/config-map.yaml
+# Source: cloudzero-agent/templates/helmless-cm.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cz-agent-config-values
+  name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
     app.kubernetes.io/managed-by: Helm
@@ -2781,6 +2781,56 @@ spec:
             secretName: cz-agent-api-key
         - name: aggregator-persistent-storage
           emptyDir: {}
+---
+# Source: cloudzero-agent/templates/helmless-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cz-agent-helmless-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
+  namespace: cz-agent
+  
+  labels:
+    app.kubernetes.io/component: helmless
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: cloudzero-agent
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: cloudzero-agent-1.1.0-dev
+spec:
+  template:
+    metadata:
+      name: cz-agent-helmless-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
+      namespace: cz-agent
+      labels:
+        app.kubernetes.io/component: helmless
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
+      
+    spec:
+      restartPolicy: OnFailure
+      
+      
+      containers:
+        - name: helmless
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.0"
+          imagePullPolicy: "IfNotPresent"
+          
+          command:
+            - /app/cloudzero-helmless
+          args:
+            - --configured
+            - /etc/config/values/values.yaml
+            - --output
+            - "-"
+          volumeMounts:
+            - name: helmless-cm
+              mountPath: /etc/config/values
+              readOnly: true
+      volumes:
+        - name: helmless-cm
+          configMap:
+            name: cz-agent-helmless-cm
 ---
 # Source: cloudzero-agent/templates/init-cert-job.yaml
 apiVersion: batch/v1

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -688,11 +688,11 @@ data:
       http_max_retries: 10
       http_max_wait: 30s
 ---
-# Source: cloudzero-agent/templates/config-map.yaml
+# Source: cloudzero-agent/templates/helmless-cm.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cz-agent-config-values
+  name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
     app.kubernetes.io/managed-by: Helm
@@ -2576,6 +2576,56 @@ spec:
             secretName: cz-agent-api-key
         - name: aggregator-persistent-storage
           emptyDir: {}
+---
+# Source: cloudzero-agent/templates/helmless-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cz-agent-helmless-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
+  namespace: cz-agent
+  
+  labels:
+    app.kubernetes.io/component: helmless
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: cloudzero-agent
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: cloudzero-agent-1.1.0-dev
+spec:
+  template:
+    metadata:
+      name: cz-agent-helmless-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
+      namespace: cz-agent
+      labels:
+        app.kubernetes.io/component: helmless
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
+      
+    spec:
+      restartPolicy: OnFailure
+      
+      
+      containers:
+        - name: helmless
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.0"
+          imagePullPolicy: "IfNotPresent"
+          
+          command:
+            - /app/cloudzero-helmless
+          args:
+            - --configured
+            - /etc/config/values/values.yaml
+            - --output
+            - "-"
+          volumeMounts:
+            - name: helmless-cm
+              mountPath: /etc/config/values
+              readOnly: true
+      volumes:
+        - name: helmless-cm
+          configMap:
+            name: cz-agent-helmless-cm
 ---
 # Source: cloudzero-agent/templates/init-cert-job.yaml
 apiVersion: batch/v1


### PR DESCRIPTION
## Why?

This provides an easy way to get the minimal config overrides.

## What

Create a job which runs helmless against the values in the configmap. I also renamed the config-values configmap to helmless-cm, since it is only used by helmless-job and that matches our naming convention a bit better.

## How Tested

Deploy, then `kubectl -n whatever logs --tail 9999 -l app.kubernetes.io/component=helmless`
