### PR TITLE
CP-29810: remove log capture code

### DIFF
--- a/app/functions/shipper/main.go
+++ b/app/functions/shipper/main.go
@@ -49,19 +49,7 @@ func main() {
 		logging.WithSink(logging.NewFieldFilterWriter(os.Stdout, []string{"spanId", "parentSpanId"})),
 	)
 
-	// if log capture is set, then create a new sink
-	if settings.Logging.Capture {
-		logStore, ierr := disk.NewDiskStore(
-			settings.Database,
-			disk.WithContentIdentifier(disk.LogsContentIdentifider),
-			disk.WithMaxInterval(settings.Database.ObservabilityMaxInterval), // use same interval as observability
-		)
-		if ierr != nil {
-			log.Fatal().Err(ierr).Msg("failed to create the log disk store")
-		}
-
-		loggingOpts = append(loggingOpts, logging.WithSink(logging.StoreWriter(ctx, logStore, settings.ClusterName, settings.CloudAccountID)))
-	}
+	// TODO -- add log capture code
 
 	logger, err := logging.NewLogger(loggingOpts...)
 	if err != nil {

--- a/tests/smoke/client_test.go
+++ b/tests/smoke/client_test.go
@@ -60,7 +60,7 @@ func TestSmoke_ClientApplication_Runs(t *testing.T) {
 		// wait for the shipper to send all files
 		err = utils.ContainerWaitForLog(t.ctx, &utils.WaitForLogInput{
 			Container: shipper,
-			Log:       "Successfully uploaded new files",
+			Log:       "Successfully ran the shipper cycle",
 			N:         3,
 		})
 		require.NoError(t, err, "failed to find log message waiting for the shipper")


### PR DESCRIPTION
## Why?

The log capture code can cause deadlocks if a log message is sent inside the disk code.

## What

Remove the log capture code for the shipper

## How Tested

Smoke test works for multiple cycles, when logging inside disk.go with the log capture code we get a deadlock
