### PR TITLE
CP-29766: remove need for approvals for releases

### DIFF
--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   release-to-main:
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Why?

So we don't need approvals for releases anymore.

## What

Remove the release environment, which requires approval.

## How Tested

It's an action, so... YOLO. I'll make sure this works as intended before adding a similar one for the charts repo.