### PR TITLE
CP-29767: add release notes for 1.2.1

### DIFF
--- a/helm/docs/releases/1.2.1.md
+++ b/helm/docs/releases/1.2.1.md
@@ -1,0 +1,24 @@
+## [1.2.1](https://github.com/Cloudzero/cloudzero-agent/compare/v1.2.0...v1.2.1) (2025-06-17)
+
+This is primarily a bugfix release that resolves JSON Schema validation issues when the cloudzero-agent Helm chart is used as a subchart.
+
+### Bug Fixes
+
+- **Subchart Schema Validation**: Fixed JSON Schema validation error that occurred when the cloudzero-agent chart was used as a subchart. Helm automatically adds a top-level 'global' property for subcharts, which was not previously allowed by the schema, causing validation failures.
+
+### Additional Enhancements
+
+- **Helmless Job**: Added a Helm job that runs the helmless tool, providing an easy way to determine minimal configuration overrides by checking the job logs.
+- **Improved Logging**: Both the collector and shipper now emit regular info-level log messages, providing positive confirmation that the agent is working correctly.
+
+### Testing Improvements
+
+- **Subchart Testing**: Added comprehensive test coverage for subchart scenarios to prevent regression of schema validation issues.
+
+### Upgrade Steps
+
+To upgrade to version 1.2.1, run the following command:
+
+```sh
+helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.2.1
+```


### PR DESCRIPTION
## Why?

Because we want to make a release.

## What

Add release notes.

## How Tested

`cat helm/docs/release/1.2.1.md`