### PR TITLE
CP-29876: don't overwrite default values when generating PDBs

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -746,7 +746,7 @@ Generate a pod disruption budget
 */}}
 {{- define "cloudzero-agent.generatePodDisruptionBudget" -}}
 {{- $replicas := int (.replicas | default .component.replicas | default 99999) -}}
-{{- $pdb := merge .component.podDisruptionBudget .root.Values.defaults.podDisruptionBudget -}}
+{{- $pdb := merge (deepCopy .component.podDisruptionBudget) .root.Values.defaults.podDisruptionBudget -}}
 {{- if ($pdb.minAvailable | default $pdb.maxUnavailable) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -841,7 +841,7 @@ data:
       webhookServer:
         podDisruptionBudget:
           maxUnavailable: null
-          minAvailable: 1
+          minAvailable: null
         replicas: 3
     configmapReload:
       prometheus:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -788,7 +788,7 @@ data:
       webhookServer:
         podDisruptionBudget:
           maxUnavailable: null
-          minAvailable: 1
+          minAvailable: null
         replicas: 3
     configmapReload:
       prometheus:


### PR DESCRIPTION
## Why?

Previously, we were merging the into the default values for the components, which was causing the values to be set in the configuration instead of relying on the defaults, which was causing Helmless to always include them.

## What

Merge into a deepCopy instead.

## How Tested

The generated manifests show the difference.
