### PR TITLE
CP-29878: don't test values against themselves in generic handler tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
   enable:
     # Bugs & Errors
     - copyloopvar # Detects places where loop variables are copied unnecessarily (in Go 1.22+)
+    - dupword # Check for duplicate words that might indicate copy-paste errors
     - dupl # Detects duplicate code
     - errcheck # Check for unexamined errors
     - gosec # Check for security issues
@@ -26,6 +27,7 @@ linters:
     - revive # Framework with many sub-linters
     - sqlclosecheck # Check that SQL rows/statements are closed
     - staticcheck # Subset of checks from the stand-along staticcheck tool
+    - testifylint # Check for common testify usage mistakes
     - tparallel # Finds incorrect usage of t.Parallel()
     - zerologlint # Check for correct usage of zerolog
 
@@ -134,6 +136,11 @@ linters-settings:
         # Any struct tag type can be used.
         # Support string case: `camel`, `pascal`, `kebab`, `snake`, `upperSnake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`, `header`.
         yaml: snake
+
+  testifylint:
+    # Enable all checkers (default)
+    enable-all: true
+    # The useless-assert checker will catch reflect.DeepEqual with identical arguments
 
 issues:
   uniq-by-line: false

--- a/app/domain/shipper/utils.go
+++ b/app/domain/shipper/utils.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package shipper provides domain logic for for the shipper.
+// Package shipper provides domain logic for the shipper.
 package shipper
 
 import (

--- a/app/domain/webhook/handler/generic_handler_test.go
+++ b/app/domain/webhook/handler/generic_handler_test.go
@@ -5,11 +5,11 @@ package handler_test
 
 import (
 	"context"
-	"reflect"
 	"regexp"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
@@ -96,14 +96,14 @@ func TestDataFormatters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.formatter(tt.accessor, tt.obj)
 
-			if !reflect.DeepEqual(tt.expected.MetricLabels, tt.expected.MetricLabels) {
-				t.Errorf("Maps are not equal:\nExpected: %v\nGot: %v", tt.expected.MetricLabels, tt.expected.MetricLabels)
+			if diff := cmp.Diff(tt.expected.MetricLabels, result.MetricLabels); diff != "" {
+				t.Errorf("MetricLabels mismatch (-want +got):\n%s", diff)
 			}
-			if !reflect.DeepEqual(tt.expected.Labels, tt.expected.Labels) {
-				t.Errorf("Maps are not equal:\nExpected: %v\nGot: %v", tt.expected.Labels, tt.expected.Labels)
+			if diff := cmp.Diff(tt.expected.Labels, result.Labels); diff != "" {
+				t.Errorf("Labels mismatch (-want +got):\n%s", diff)
 			}
-			if !reflect.DeepEqual(tt.expected.Annotations, tt.expected.Annotations) {
-				t.Errorf("Maps are not equal:\nExpected: %v\nGot: %v", tt.expected.Annotations, tt.expected.Annotations)
+			if diff := cmp.Diff(tt.expected.Annotations, result.Annotations); diff != "" {
+				t.Errorf("Annotations mismatch (-want +got):\n%s", diff)
 			}
 			assert.Equal(t, tt.expected.Type, result.Type)
 			assert.Equal(t, tt.expected.Name, result.Name)

--- a/app/domain/webhook/handler/generic_handler_test.go
+++ b/app/domain/webhook/handler/generic_handler_test.go
@@ -37,59 +37,302 @@ func TestDataFormatters(t *testing.T) {
 		{
 			name:      "WorkloadDataFormatter with labels and annotations enabled",
 			formatter: handler.WorkloadDataFormatter,
-			accessor:  makeMockAccessor(true, true, true, true, config.Pod, "app", "annotation-key"),
-			obj:       makePodObject(makeMeta("test-pod", "default", map[string]string{"app": "test"}, map[string]string{"annotation-key": "annotation-value"})),
-			expected:  makeExpectedTags(config.Pod, "test-pod", "default", "workload", map[string]string{"app": "test"}, map[string]string{"annotation-key": "annotation-value"}),
+			accessor: mockConfigAccessor{
+				labelsEnabled:             true,
+				annotationsEnabled:        true,
+				labelsEnabledForType:      true,
+				annotationsEnabledForType: true,
+				resourceType:              config.Pod,
+				settings: &config.Settings{
+					LabelMatches: []regexp.Regexp{
+						*regexp.MustCompile("app"),
+					},
+					AnnotationMatches: []regexp.Regexp{
+						*regexp.MustCompile("annotation-key"),
+					},
+				},
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+					Annotations: map[string]string{
+						"annotation-key": "annotation-value",
+					},
+				},
+			},
+			expected: types.ResourceTags{
+				Type:      config.Pod,
+				Name:      "test-pod",
+				Namespace: stringPtr("default"),
+				MetricLabels: &config.MetricLabels{
+					"workload":      "test-pod",
+					"namespace":     "default",
+					"resource_type": "pod",
+				},
+				Labels: &config.MetricLabelTags{
+					"app": "test",
+				},
+				Annotations: &config.MetricLabelTags{
+					"annotation-key": "annotation-value",
+				},
+			},
 		},
 		{
 			name:      "WorkloadDataFormatter with labels and annotations disabled",
 			formatter: handler.WorkloadDataFormatter,
-			accessor:  makeMockAccessor(false, false, false, false, config.Pod, "", ""),
-			obj:       makePodObject(makeMeta("test-pod", "default", nil, nil)),
-			expected:  makeExpectedTags(config.Pod, "test-pod", "default", "workload", nil, nil),
+			accessor: mockConfigAccessor{
+				labelsEnabled:             false,
+				annotationsEnabled:        false,
+				labelsEnabledForType:      false,
+				annotationsEnabledForType: false,
+				resourceType:              config.Pod,
+				settings:                  &config.Settings{},
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			expected: types.ResourceTags{
+				Type:      config.Pod,
+				Name:      "test-pod",
+				Namespace: stringPtr("default"),
+				MetricLabels: &config.MetricLabels{
+					"workload":      "test-pod",
+					"namespace":     "default",
+					"resource_type": "pod",
+				},
+				Labels:      &config.MetricLabelTags{},
+				Annotations: &config.MetricLabelTags{},
+			},
 		},
 		{
 			name:      "PodDataFormatter with labels and annotations enabled",
 			formatter: handler.PodDataFormatter,
-			accessor:  makeMockAccessor(true, true, true, true, config.Pod, "app", "annotation-key"),
-			obj:       makePodObject(makeMeta("test-pod", "default", map[string]string{"app": "test"}, map[string]string{"annotation-key": "annotation-value"})),
-			expected:  makeExpectedTags(config.Pod, "test-pod", "default", "pod", map[string]string{"app": "test"}, map[string]string{"annotation-key": "annotation-value"}),
+			accessor: mockConfigAccessor{
+				labelsEnabled:             true,
+				annotationsEnabled:        true,
+				labelsEnabledForType:      true,
+				annotationsEnabledForType: true,
+				resourceType:              config.Pod,
+				settings: &config.Settings{
+					LabelMatches: []regexp.Regexp{
+						*regexp.MustCompile("app"),
+					},
+					AnnotationMatches: []regexp.Regexp{
+						*regexp.MustCompile("annotation-key"),
+					},
+				},
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test",
+					},
+					Annotations: map[string]string{
+						"annotation-key": "annotation-value",
+					},
+				},
+			},
+			expected: types.ResourceTags{
+				Type:      config.Pod,
+				Name:      "test-pod",
+				Namespace: stringPtr("default"),
+				MetricLabels: &config.MetricLabels{
+					"pod":           "test-pod",
+					"namespace":     "default",
+					"resource_type": "pod",
+				},
+				Labels: &config.MetricLabelTags{
+					"app": "test",
+				},
+				Annotations: &config.MetricLabelTags{
+					"annotation-key": "annotation-value",
+				},
+			},
 		},
 		{
 			name:      "PodDataFormatter with labels and annotations disabled",
 			formatter: handler.PodDataFormatter,
-			accessor:  makeMockAccessor(false, false, false, false, config.Pod, "", ""),
-			obj:       makePodObject(makeMeta("test-pod", "default", nil, nil)),
-			expected:  makeExpectedTags(config.Pod, "test-pod", "default", "pod", nil, nil),
+			accessor: mockConfigAccessor{
+				labelsEnabled:             false,
+				annotationsEnabled:        false,
+				labelsEnabledForType:      false,
+				annotationsEnabledForType: false,
+				resourceType:              config.Pod,
+				settings:                  &config.Settings{},
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+			},
+			expected: types.ResourceTags{
+				Type:      config.Pod,
+				Name:      "test-pod",
+				Namespace: stringPtr("default"),
+				MetricLabels: &config.MetricLabels{
+					"pod":           "test-pod",
+					"namespace":     "default",
+					"resource_type": "pod",
+				},
+				Labels:      &config.MetricLabelTags{},
+				Annotations: &config.MetricLabelTags{},
+			},
 		},
-
 		{
 			name:      "NamespaceDataFormatter with labels and annotations enabled",
 			formatter: handler.NamespaceDataFormatter,
-			accessor:  makeMockAccessor(true, true, true, true, config.Namespace, "env", "annotation-key"),
-			obj:       makePodObject(makeMeta("test-namespace", "", map[string]string{"env": "prod"}, map[string]string{"annotation-key": "annotation-value"})),
-			expected:  makeExpectedTags(config.Namespace, "test-namespace", "", "namespace", map[string]string{"env": "prod"}, map[string]string{"annotation-key": "annotation-value"}),
+			accessor: mockConfigAccessor{
+				labelsEnabled:             true,
+				annotationsEnabled:        true,
+				labelsEnabledForType:      true,
+				annotationsEnabledForType: true,
+				resourceType:              config.Namespace,
+				settings: &config.Settings{
+					LabelMatches: []regexp.Regexp{
+						*regexp.MustCompile("env"),
+					},
+					AnnotationMatches: []regexp.Regexp{
+						*regexp.MustCompile("annotation-key"),
+					},
+				},
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace",
+					Labels: map[string]string{
+						"env": "prod",
+					},
+					Annotations: map[string]string{
+						"annotation-key": "annotation-value",
+					},
+				},
+			},
+			expected: types.ResourceTags{
+				Type:      config.Namespace,
+				Name:      "test-namespace",
+				Namespace: nil,
+				MetricLabels: &config.MetricLabels{
+					"namespace":     "test-namespace",
+					"resource_type": "namespace",
+				},
+				Labels: &config.MetricLabelTags{
+					"env": "prod",
+				},
+				Annotations: &config.MetricLabelTags{
+					"annotation-key": "annotation-value",
+				},
+			},
 		},
 		{
 			name:      "NamespaceDataFormatter with labels and annotations disabled",
 			formatter: handler.NamespaceDataFormatter,
-			accessor:  makeMockAccessor(false, false, false, false, config.Namespace, "", ""),
-			obj:       makePodObject(makeMeta("test-namespace", "", nil, nil)),
-			expected:  makeExpectedTags(config.Namespace, "test-namespace", "", "namespace", nil, nil),
+			accessor: mockConfigAccessor{
+				labelsEnabled:             false,
+				annotationsEnabled:        false,
+				labelsEnabledForType:      false,
+				annotationsEnabledForType: false,
+				resourceType:              config.Namespace,
+				settings:                  &config.Settings{},
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace",
+				},
+			},
+			expected: types.ResourceTags{
+				Type:      config.Namespace,
+				Name:      "test-namespace",
+				Namespace: nil,
+				MetricLabels: &config.MetricLabels{
+					"namespace":     "test-namespace",
+					"resource_type": "namespace",
+				},
+				Labels:      &config.MetricLabelTags{},
+				Annotations: &config.MetricLabelTags{},
+			},
 		},
 		{
 			name:      "NodeDataFormatter with labels and annotations enabled",
 			formatter: handler.NodeDataFormatter,
-			accessor:  makeMockAccessor(true, true, true, true, config.Node, "role", "annotation-key"),
-			obj:       makePodObject(makeMeta("test-node", "", map[string]string{"role": "worker"}, map[string]string{"annotation-key": "annotation-value"})),
-			expected:  makeExpectedTags(config.Node, "test-node", "", "node", map[string]string{"role": "worker"}, map[string]string{"annotation-key": "annotation-value"}),
+			accessor: mockConfigAccessor{
+				labelsEnabled:             true,
+				annotationsEnabled:        true,
+				labelsEnabledForType:      true,
+				annotationsEnabledForType: true,
+				resourceType:              config.Node,
+				settings: &config.Settings{
+					LabelMatches: []regexp.Regexp{
+						*regexp.MustCompile("role"),
+					},
+					AnnotationMatches: []regexp.Regexp{
+						*regexp.MustCompile("annotation-key"),
+					},
+				},
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Labels: map[string]string{
+						"role": "worker",
+					},
+					Annotations: map[string]string{
+						"annotation-key": "annotation-value",
+					},
+				},
+			},
+			expected: types.ResourceTags{
+				Type:      config.Node,
+				Name:      "test-node",
+				Namespace: nil,
+				MetricLabels: &config.MetricLabels{
+					"node":          "test-node",
+					"resource_type": "node",
+				},
+				Labels: &config.MetricLabelTags{
+					"role": "worker",
+				},
+				Annotations: &config.MetricLabelTags{
+					"annotation-key": "annotation-value",
+				},
+			},
 		},
 		{
 			name:      "NodeDataFormatter with labels and annotations disabled",
 			formatter: handler.NodeDataFormatter,
-			accessor:  makeMockAccessor(false, false, false, false, config.Node, "", ""),
-			obj:       makePodObject(makeMeta("test-node", "", nil, nil)),
-			expected:  makeExpectedTags(config.Node, "test-node", "", "node", nil, nil),
+			accessor: mockConfigAccessor{
+				labelsEnabled:             false,
+				annotationsEnabled:        false,
+				labelsEnabledForType:      false,
+				annotationsEnabledForType: false,
+				resourceType:              config.Node,
+				settings:                  &config.Settings{},
+			},
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+			},
+			expected: types.ResourceTags{
+				Type:      config.Node,
+				Name:      "test-node",
+				Namespace: nil,
+				MetricLabels: &config.MetricLabels{
+					"node":          "test-node",
+					"resource_type": "node",
+				},
+				Labels:      &config.MetricLabelTags{},
+				Annotations: &config.MetricLabelTags{},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -115,6 +358,9 @@ func TestDataFormatters(t *testing.T) {
 }
 
 func TestGenericHandler_Create(t *testing.T) {
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
 	tests := []struct {
 		name     string
 		accessor mockConfigAccessor
@@ -138,16 +384,20 @@ func TestGenericHandler_Create(t *testing.T) {
 					},
 				},
 			},
-			request: makePodObjectRequest(metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: "default",
-				Labels: map[string]string{
-					"app": "test",
-				},
-				Annotations: map[string]string{
-					"annotation-key": "annotation-value",
-				},
-			}),
+			request: &types.AdmissionReview{
+				NewObjectRaw: getRawObject(appsv1.SchemeGroupVersion, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+						},
+						Annotations: map[string]string{
+							"annotation-key": "annotation-value",
+						},
+					},
+				}),
+			},
 			expected: &types.AdmissionResponse{Allowed: true},
 		},
 		{
@@ -160,10 +410,14 @@ func TestGenericHandler_Create(t *testing.T) {
 				resourceType:              config.Pod,
 				settings:                  &config.Settings{},
 			},
-			request: makePodObjectRequest(metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: "default",
-			}),
+			request: &types.AdmissionReview{
+				NewObjectRaw: getRawObject(appsv1.SchemeGroupVersion, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+					},
+				}),
+			},
 			expected: &types.AdmissionResponse{Allowed: true},
 		},
 	}
@@ -173,7 +427,7 @@ func TestGenericHandler_Create(t *testing.T) {
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
 
-			clock := mocks.NewMockClock(time.Now())
+			clock := mockClock
 			store := mocks.NewMockResourceStore(mockCtl)
 
 			if tt.accessor.settings != nil && len(tt.accessor.settings.LabelMatches) > 0 {
@@ -218,16 +472,20 @@ func TestGenericHandler_Update(t *testing.T) {
 					},
 				},
 			},
-			request: makePodObjectRequest(metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: "default",
-				Labels: map[string]string{
-					"app": "test",
-				},
-				Annotations: map[string]string{
-					"annotation-key": "annotation-value",
-				},
-			}),
+			request: &types.AdmissionReview{
+				NewObjectRaw: getRawObject(appsv1.SchemeGroupVersion, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+						},
+						Annotations: map[string]string{
+							"annotation-key": "annotation-value",
+						},
+					},
+				}),
+			},
 			expected: &types.AdmissionResponse{Allowed: true},
 		},
 		{
@@ -247,24 +505,35 @@ func TestGenericHandler_Update(t *testing.T) {
 					},
 				},
 			},
-			request: makePodObjectRequest(metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: "default",
-				Labels: map[string]string{
-					"app": "test",
-				},
-				Annotations: map[string]string{
-					"annotation-key": "annotation-value",
-				},
-			}),
 			dbresult: &types.ResourceTags{
-				ID:            "1",
-				Type:          config.Pod,
-				Name:          "test-pod",
-				Labels:        &config.MetricLabelTags{"app": "test"},
-				Annotations:   &config.MetricLabelTags{"annotation-key": "annotation-value"},
-				RecordCreated: mockClock.GetCurrentTime(),
-				RecordUpdated: mockClock.GetCurrentTime(),
+				Type:      config.Pod,
+				Name:      "test-pod",
+				Namespace: stringPtr("default"),
+				MetricLabels: &config.MetricLabels{
+					"pod":           "test-pod",
+					"namespace":     "default",
+					"resource_type": "pod",
+				},
+				Labels: &config.MetricLabelTags{
+					"app": "old-value",
+				},
+				Annotations: &config.MetricLabelTags{
+					"annotation-key": "old-annotation-value",
+				},
+			},
+			request: &types.AdmissionReview{
+				NewObjectRaw: getRawObject(appsv1.SchemeGroupVersion, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+						},
+						Annotations: map[string]string{
+							"annotation-key": "annotation-value",
+						},
+					},
+				}),
 			},
 			expected: &types.AdmissionResponse{Allowed: true},
 		},
@@ -278,10 +547,14 @@ func TestGenericHandler_Update(t *testing.T) {
 				resourceType:              config.Pod,
 				settings:                  &config.Settings{},
 			},
-			request: makePodObjectRequest(metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: "default",
-			}),
+			request: &types.AdmissionReview{
+				NewObjectRaw: getRawObject(appsv1.SchemeGroupVersion, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+					},
+				}),
+			},
 			expected: &types.AdmissionResponse{Allowed: true},
 		},
 	}
@@ -291,10 +564,10 @@ func TestGenericHandler_Update(t *testing.T) {
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
 
-			clock := mocks.NewMockClock(time.Now())
+			clock := mockClock
 			store := mocks.NewMockResourceStore(mockCtl)
 
-			if len(tt.accessor.settings.LabelMatches) > 0 {
+			if tt.accessor.settings != nil && len(tt.accessor.settings.LabelMatches) > 0 {
 				store.EXPECT().FindFirstBy(gomock.Any(), gomock.Any()).Return(tt.dbresult, nil)
 				store.EXPECT().Tx(gomock.Any(), gomock.Any()).Return(nil)
 				if tt.dbresult == nil {
@@ -313,6 +586,9 @@ func TestGenericHandler_Update(t *testing.T) {
 }
 
 func TestGenericHandler_Delete(t *testing.T) {
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
 	tests := []struct {
 		name     string
 		accessor mockConfigAccessor
@@ -336,16 +612,20 @@ func TestGenericHandler_Delete(t *testing.T) {
 					},
 				},
 			},
-			request: makePodObjectRequest(metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: "default",
-				Labels: map[string]string{
-					"app": "test",
-				},
-				Annotations: map[string]string{
-					"annotation-key": "annotation-value",
-				},
-			}),
+			request: &types.AdmissionReview{
+				NewObjectRaw: getRawObject(appsv1.SchemeGroupVersion, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "test",
+						},
+						Annotations: map[string]string{
+							"annotation-key": "annotation-value",
+						},
+					},
+				}),
+			},
 			expected: &types.AdmissionResponse{Allowed: true},
 		},
 		{
@@ -358,10 +638,14 @@ func TestGenericHandler_Delete(t *testing.T) {
 				resourceType:              config.Pod,
 				settings:                  &config.Settings{},
 			},
-			request: makePodObjectRequest(metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: "default",
-			}),
+			request: &types.AdmissionReview{
+				NewObjectRaw: getRawObject(appsv1.SchemeGroupVersion, &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+					},
+				}),
+			},
 			expected: &types.AdmissionResponse{Allowed: true},
 		},
 	}
@@ -371,7 +655,7 @@ func TestGenericHandler_Delete(t *testing.T) {
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
 
-			clock := mocks.NewMockClock(time.Now())
+			clock := mockClock
 			store := mocks.NewMockResourceStore(mockCtl)
 
 			if tt.accessor.settings != nil && len(tt.accessor.settings.LabelMatches) > 0 {
@@ -421,80 +705,6 @@ func (m mockConfigAccessor) ResourceType() config.ResourceType {
 
 func (m mockConfigAccessor) Settings() *config.Settings {
 	return m.settings
-}
-
-func makeMockAccessor(labelsEnabled, annotationsEnabled, labelsEnabledForType, annotationsEnabledForType bool, resourceType config.ResourceType, labelMatch, annotationMatch string) mockConfigAccessor {
-	return mockConfigAccessor{
-		labelsEnabled:             labelsEnabled,
-		annotationsEnabled:        annotationsEnabled,
-		labelsEnabledForType:      labelsEnabledForType,
-		annotationsEnabledForType: annotationsEnabledForType,
-		resourceType:              resourceType,
-		settings: &config.Settings{
-			LabelMatches: []regexp.Regexp{
-				*regexp.MustCompile(labelMatch),
-			},
-			AnnotationMatches: []regexp.Regexp{
-				*regexp.MustCompile(annotationMatch),
-			},
-		},
-	}
-}
-
-func makeMeta(name, namespace string, labels, annotations map[string]string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:        name,
-		Namespace:   namespace,
-		Labels:      labels,
-		Annotations: annotations,
-	}
-}
-
-func makeExpectedTags(resourceType config.ResourceType, name, namespace, resourceKind string, labels, annotations map[string]string) types.ResourceTags {
-	return types.ResourceTags{
-		Type:         resourceType,
-		Name:         name,
-		Namespace:    stringPtr(namespace),
-		MetricLabels: &config.MetricLabels{"resource_kind": resourceKind},
-		Labels: func() *config.MetricLabelTags {
-			if labels == nil {
-				return nil
-			}
-			tags := config.MetricLabelTags(labels)
-			return &tags
-		}(),
-		Annotations: func() *config.MetricLabelTags {
-			if annotations == nil {
-				return nil
-			}
-			tags := config.MetricLabelTags(annotations)
-			return &tags
-		}(),
-	}
-}
-
-func makePodObject(o metav1.ObjectMeta) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        o.Name,
-			Namespace:   o.Namespace,
-			Labels:      o.Labels,
-			Annotations: o.Annotations,
-		},
-	}
-}
-
-func makePodObjectRequest(o metav1.ObjectMeta) *types.AdmissionReview {
-	return &types.AdmissionReview{
-		NewObjectRaw: getRawObject(appsv1.SchemeGroupVersion, &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        o.Name,
-				Namespace:   o.Namespace,
-				Labels:      o.Labels,
-				Annotations: o.Annotations,
-			},
-		}),
-	}
 }
 
 func encodeObject(t *testing.T, handler *hook.Handler, rawOjb []byte) metav1.Object {


### PR DESCRIPTION
## Why?

We were comparing expected values against expected values, so the test was a noop.

## What

Fixed the comparisons to compare expected vs result. This unmasked some issues in the test vectors, which I also fixed.

I tried adding a couple of linters to help spot this type of thing in the future, but alas nothing can detect if the arguments to reflect.DeepEqual or cmp.Diff are the same values... Might be a fun project to write a linter for that in the future.

## How Tested

`make test`
