### PR TITLE
CP-29491: don't clobber defaults when merging component-specific config

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -518,7 +518,7 @@ Name for the issuer resource
 Map for initBackfillJob values; this allows us to preferably use initBackfillJob, but if users are still using the deprecated initScrapeJob, we will accept those as well
 */}}
 {{- define "cloudzero-agent.backFill" -}}
-{{- merge .Values.initBackfillJob (.Values.initScrapeJob | default (dict)) | toYaml }}
+{{- merge (deepCopy .Values.initBackfillJob) (.Values.initScrapeJob | default (dict)) | toYaml }}
 {{- end }}
 
 {{/*
@@ -715,7 +715,7 @@ Generate affinity sections
 {{- define "cloudzero-agent.generateAffinity" -}}
 {{ $affinity := .default }}
 {{- if .affinity -}}
-{{ $affinity = merge .affinity .default }}
+{{ $affinity = merge (deepCopy .affinity) .default }}
 {{- end -}}
 {{- if $affinity -}}
 affinity:

--- a/helm/templates/agent-cm.yaml
+++ b/helm/templates/agent-cm.yaml
@@ -5,7 +5,7 @@ metadata:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
   name: {{ include "cloudzero-agent.configMapName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
 data:
   prometheus.yml: |-
     {{- if and (not .Values.defaults.federation.enabled) .Values.prometheusConfig.configOverride }}

--- a/helm/templates/agent-daemonset-cm.yaml
+++ b/helm/templates/agent-daemonset-cm.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
   name: {{ .Release.Name }}-daemonset-cm
   namespace: {{ include "cloudzero-agent.namespace" . }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
 data:
   prometheus.yml.in: |-
     {{- if and (not .Values.defaults.federation.enabled) .Values.prometheusConfig.configOverride }}

--- a/helm/templates/agent-pvc.yaml
+++ b/helm/templates/agent-pvc.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- with .Values.server.persistentVolume.labels }}
        {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.server.persistentVolume.annotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.server.persistentVolume.annotations) | nindent 2 }}
   name: {{ template "cloudzero-agent.server.fullname" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 spec:

--- a/helm/templates/agent-serviceaccount.yaml
+++ b/helm/templates/agent-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.serviceAccount.annotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.serviceAccount.annotations) | nindent 2 }}
   name: {{ template "cloudzero-agent.serviceAccountName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 {{- if kindIs "bool" .Values.server.automountServiceAccountToken }}

--- a/helm/templates/aggregator-secret.yaml
+++ b/helm/templates/aggregator-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   labels:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.secretAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.secretAnnotations) | nindent 2 }}
   name: {{ include "cloudzero-agent.secretName" .}}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 data:

--- a/helm/templates/backfill-job.yaml
+++ b/helm/templates/backfill-job.yaml
@@ -6,7 +6,7 @@ kind: Job
 metadata:
   name: {{ include "cloudzero-agent.initBackfillJobName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.initBackfillJob.annotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.initBackfillJob.annotations) | nindent 2 }}
   labels:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
 spec:

--- a/helm/templates/init-cert-job.yaml
+++ b/helm/templates/init-cert-job.yaml
@@ -5,7 +5,7 @@ kind: Job
 metadata:
   name: {{ include "cloudzero-agent.initCertJobName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.initCertJob.annotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.initCertJob.annotations) | nindent 2 }}
   labels:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
 spec:

--- a/helm/templates/validator-cm.yaml
+++ b/helm/templates/validator-cm.yaml
@@ -5,7 +5,7 @@ metadata:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
   name: {{ include "cloudzero-agent.validatorConfigMapName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
 data:
   validator.yml: |-
     versions:

--- a/helm/templates/webhook-certificate.yaml
+++ b/helm/templates/webhook-certificate.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretName: {{ include "cloudzero-agent.tlsSecretName" .}}
   secretTemplate:
-    {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.secretAnnotations) | nindent 2 }}
+    {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.secretAnnotations) | nindent 2 }}
     labels:
       {{- include "cloudzero-agent.insightsController.labels" . | nindent 6 }}
   privateKey:

--- a/helm/templates/webhook-cm.yaml
+++ b/helm/templates/webhook-cm.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
   name: {{ include "cloudzero-agent.webhookConfigMapName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
 data:
   server-config.yaml: |-
 {{- include "cloudzero-agent.insightsController.configuration" . | nindent 4 -}}

--- a/helm/templates/webhook-deploy.yaml
+++ b/helm/templates/webhook-deploy.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge .Values.defaults.annotations .Values.insightsController.server.deploymentAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.insightsController.server.deploymentAnnotations) | nindent 2 }}
 spec:
   replicas: {{ .Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas }}
   selector:

--- a/helm/templates/webhook-validating-config.yaml
+++ b/helm/templates/webhook-validating-config.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- if $.Values.insightsController.tls.useCertManager -}}
   {{- $certManagerAnnotations = dict "cert-manager.io/inject-ca-from" ($.Values.insightsController.webhooks.caInjection | default (printf "%s/%s" $.Release.Namespace (include "cloudzero-agent.certificateName" $))) -}}
   {{- end -}}
-  {{- include "cloudzero-agent.generateAnnotations" (merge $.Values.defaults.annotations $certManagerAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy $.Values.defaults.annotations) $certManagerAnnotations) | nindent 2 }}
 webhooks:
   - name: {{ include "cloudzero-agent.validatingWebhookName" $ }}
     namespaceSelector: {{ toYaml $.Values.insightsController.webhooks.namespaceSelector | nindent 6 }}


### PR DESCRIPTION
## Why?

The `merge` function in Helm will write to the destination parameter (the first parameter), so if we just pass the defaults directly and merge into them, we will end up adding the values for the component we're merging to the defaults.

## What

Instead, we use the `deepCopy` function to create a copy of the defaults, then merge into that.

## How Tested

`make helm-generate-tests` to make sure I didn't break anything, and creating overrides to set the component-specific stuff and make sure it doesn't clobber the defaults for other components.