### PR TITLE
CP-29885: allow setting server.serviceAccount.name in JSON schema

### DIFF
--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -21769,6 +21769,19 @@
           "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements",
           "description": "Resource requirements and limits for the server.\n\nFor details, see the Kubernetes documentation on resource management:\nhttps://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\n"
         },
+        "serviceAccount": {
+          "additionalProperties": false,
+          "deprecated": true,
+          "description": "This field is deprecated. Please use the top-level `serviceAccount` instead.\n\nConfiguration for the service account used by the server component.\nThis is only used as a fallback when `serviceAccount.create` is false.\n",
+          "properties": {
+            "name": {
+              "default": "default",
+              "description": "Name of the service account to use when `serviceAccount.create` is false.\nThis field is deprecated. Please use the top-level `serviceAccount.name` instead.\n",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "terminationGracePeriodSeconds": {
           "default": 300,
           "description": "Termination grace period in seconds.\n\nSee the Kubernetes documentation for details:\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination\n",

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1323,6 +1323,22 @@ properties:
               Number of successful checks required to mark as alive.
             type: integer
             default: 1
+      serviceAccount:
+        deprecated: true
+        description: |
+          This field is deprecated. Please use the top-level `serviceAccount` instead.
+
+          Configuration for the service account used by the server component.
+          This is only used as a fallback when `serviceAccount.create` is false.
+        type: object
+        additionalProperties: false
+        properties:
+          name:
+            type: string
+            default: "default"
+            description: |
+              Name of the service account to use when `serviceAccount.create` is false.
+              This field is deprecated. Please use the top-level `serviceAccount.name` instead.
 
   serverConfig:
     description: |

--- a/tests/helm/schema/server.serviceAccount.name.invalid.fail.yaml
+++ b/tests/helm/schema/server.serviceAccount.name.invalid.fail.yaml
@@ -1,0 +1,8 @@
+apiKey: test-key
+cloudAccountId: "123456789"
+clusterName: test-cluster
+region: us-west-2
+
+server:
+  serviceAccount:
+    name: 12345 # Invalid: should be string, not number

--- a/tests/helm/schema/server.serviceAccount.name.valid.pass.yaml
+++ b/tests/helm/schema/server.serviceAccount.name.valid.pass.yaml
@@ -1,0 +1,8 @@
+apiKey: test-key
+cloudAccountId: "123456789"
+clusterName: test-cluster
+region: us-west-2
+
+server:
+  serviceAccount:
+    name: my-custom-service-account


### PR DESCRIPTION
## Why?

This is an old, deprecated way to set the service account name, but it is still supposed to be viable (until 2.0) so we should allow it in the schema.

## What

Allow setting server.serviceAccount.name in the JSON schema

## How Tested

Tests are included in the PR.
