### PR TITLE
CP-30015: add release notes for 1.2.2

### DIFF
--- a/helm/docs/releases/1.2.2.md
+++ b/helm/docs/releases/1.2.2.md
@@ -1,0 +1,24 @@
+## [1.2.2](https://github.com/Cloudzero/cloudzero-agent/compare/v1.2.1...v1.2.2) (2025-06-24)
+
+This is a maintenance release that includes important bug fixes and dependency updates to improve reliability and stability.
+
+### Bug Fixes
+
+- **Configuration Management**: Fixed an issue where component-specific configuration merging was incorrectly modifying default values, potentially causing unexpected behavior.
+- **ConfigMap References**: Updated ConfigMap name references in the loader job to use the correct naming convention, preventing resource lookup failures.
+- **JSON Schema Validation**: Added support for properties which were previously not present in `values.yaml`, but were used in the template.
+- **Invalid Template Fixes**: Fixed template generation for options were causing invalid Kubernetes resources to be generated.
+
+### Enhancements
+
+- **Helmless Tool**: Improved the helmless implementation by splitting it out from the CLI with enhanced testing coverage and removal of unnecessary functionality.
+- **Testing Infrastructure**: Added checks to verify that all Kubernetes resources are created successfully during deployment validation.
+- **Testing Template Generation**: Added kubeconform tests to validate generated templates.
+
+### Upgrade Steps
+
+To upgrade to version 1.2.2, run the following command:
+
+```sh
+helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.2.2
+```


### PR DESCRIPTION
## Why?

So we can release 1.2.2.

## What

Add release notes for 1.2.2.

## How Tested

`test -f helm/docs/releases/1.2.2.md`