### PR TITLE
CP-30020: add kubeconform tests

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -39,6 +39,28 @@ jobs:
             --chart-repos=kube-state-metrics=$PROM_CHART_REPO \
             --helm-lint-extra-args "--set=existingSecretName=api-token,clusterName=$CLUSTER_NAME,cloudAccountId=$CLOUD_ACCOUNT_ID,region=$REGION"
 
+  # This job runs helm tests using the project's Makefile
+  helm-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: SETUP - Checkout
+        uses: actions/checkout@v4
+
+      - name: SETUP - Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: SETUP - Install tools
+        run: make install-tools
+
+      - name: TEST - Run helm tests
+        env:
+          CLOUDZERO_DEV_API_KEY: "fake-api-key"
+        run: make -j helm-test
+
   # This job tests the chart on a KinD cluster
   # and if we are in the develop or tag branch, it will
   # publish the image to the production registry

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ go.work.sum
 /.cloudzero-insights-controller.yaml
 override-values.yaml
 
+# helm charts dependency stamp
+/helm/charts/.stamp
+
 # tool and bin directories
 .tmp/
 bin/

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.5
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/wagoodman/go-partybus v0.0.0-20230516145632-8ccac152c651
+	github.com/yannh/kubeconform v0.7.0
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/driver/sqlite v1.6.0
@@ -222,6 +223,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/rubenv/sql-migrate v1.8.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/distribution/distribution/v3 v3.0.0 h1:q4R8wemdRQDClzoNNStftB2ZAfqOiN
 github.com/distribution/distribution/v3 v3.0.0/go.mod h1:tRNuFoZsUdyRVegq8xGNeds4KLjwLCRin/tTo6i1DhU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/docker v28.2.2+incompatible h1:CjwRSksz8Yo4+RmQ339Dp/D2tGO5JxwYeqtMOEe0LDw=
 github.com/docker/docker v28.2.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
@@ -515,6 +517,8 @@ github.com/rubenv/sql-migrate v1.8.0 h1:dXnYiJk9k3wetp7GfQbKJcPHjVJL6YK19tKj8t2N
 github.com/rubenv/sql-migrate v1.8.0/go.mod h1:F2bGFBwCU+pnmbtNYDeKvSuvL6lBVtXDXUUv5t+u1qw=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.33 h1:KhF0WejiUTDbL5X55nXowP7zNopwpowa6qaMAWyIE+0=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.33/go.mod h1:792k1RTU+5JeMXm35/e2Wgp71qPH/DmDoZrRc+EFZDk=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
@@ -575,6 +579,8 @@ github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGC
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
+github.com/yannh/kubeconform v0.7.0 h1:ZFfniR8VChrWQxaxTUGnNrxw8RIDkjVBrjdhXSamwjw=
+github.com/yannh/kubeconform v0.7.0/go.mod h1:oHO1wjM16sTRW6s41HJUox+tD69qOTE5ZVQ9HeqX+xM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=

--- a/helm/templates/webhook-service.yaml
+++ b/helm/templates/webhook-service.yaml
@@ -4,9 +4,7 @@ metadata:
   name: {{ include "cloudzero-agent.serviceName" . }}
   labels:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
-  annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  {{- include "cloudzero-agent.generateAnnotations" (merge (dict "nginx.ingress.kubernetes.io/ssl-redirect" "false") .Values.defaults.annotations) | nindent 2 }}
   namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP

--- a/tests/helm/schema/defaults.dns.valid.pass.yaml
+++ b/tests/helm/schema/defaults.dns.valid.pass.yaml
@@ -8,7 +8,7 @@ defaults:
       searches:
         - "svc.cluster.local"
         - "cluster.local"
-      option:
+      options:
         - name: "ndots"
           value: "5"
         - name: "timeout"

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -83,9 +83,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -99,9 +99,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -114,9 +114,9 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -133,9 +133,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -337,7 +337,9 @@ metadata:
   name: cz-agent-aggregator
   namespace: cz-agent
   labels:
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -679,7 +681,9 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1294,9 +1298,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1377,9 +1381,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1606,9 +1610,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1693,9 +1697,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1761,9 +1765,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1784,9 +1788,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1836,9 +1840,9 @@ metadata:
   name: cz-agent-aggregator
   labels:
     app.kubernetes.io/component: aggregator
-    app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1860,13 +1864,12 @@ metadata:
   name: cz-agent-cloudzero-agent-webhook-server-svc
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
   namespace: cz-agent
@@ -1974,9 +1977,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1995,9 +1998,9 @@ spec:
         
       labels:
         app.kubernetes.io/component: server
-        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2008,7 +2011,6 @@ spec:
         - name: env-validator-copy
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: K8S_NAMESPACE
               value: cz-agent
@@ -2033,7 +2035,6 @@ spec:
         - name: env-validator-run
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: K8S_NAMESPACE
               value: cz-agent
@@ -2060,7 +2061,6 @@ spec:
         - name: cloudzero-agent-server-configmap-reload
           image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
           imagePullPolicy: "IfNotPresent"
-          
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload
@@ -2072,7 +2072,6 @@ spec:
           
           image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
-          
           lifecycle:
             postStart:
               exec:
@@ -2208,7 +2207,6 @@ spec:
         - name: cz-agent-aggregator-collector
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           ports:
             - name: port-collector
               containerPort: 8080
@@ -2251,7 +2249,6 @@ spec:
         - name: cz-agent-aggregator-shipper
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           ports:
             - name: port-shipper
               containerPort: 8081
@@ -2331,9 +2328,9 @@ metadata:
   namespace: cz-agent
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2349,9 +2346,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/component: webhook-server
-        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2383,7 +2380,6 @@ spec:
         - name: webhook-server
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /app/cloudzero-webhook
           args:
@@ -2443,9 +2439,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2469,7 +2465,6 @@ spec:
         - name: init-scrape
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /app/cloudzero-webhook
           args:
@@ -2506,9 +2501,9 @@ metadata:
     checksum/values: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2531,7 +2526,6 @@ spec:
         - name: run-validator
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: K8S_NAMESPACE
               value: cz-agent
@@ -2612,7 +2606,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: helmless
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2623,7 +2619,9 @@ spec:
       namespace: cz-agent
       labels:
         app.kubernetes.io/component: helmless
+        app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2636,7 +2634,6 @@ spec:
         - name: helmless
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /app/cloudzero-helmless
           args:
@@ -2660,7 +2657,9 @@ metadata:
   name: cz-agent-cloudzero-agent-webhook-server-certificate
   namespace: cz-agent
   labels:
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2670,9 +2669,9 @@ spec:
   secretTemplate:
     labels:
       app.kubernetes.io/component: webhook-server
-      app.kubernetes.io/name: cloudzero-agent
       app.kubernetes.io/instance: cz-agent
       app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/name: cloudzero-agent
       app.kubernetes.io/part-of: cloudzero-agent
       app.kubernetes.io/version: v2.55.1
       helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2697,7 +2696,9 @@ metadata:
   name: cz-agent-cloudzero-agent-webhook-server-issuer
   namespace: cz-agent
   labels:
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2713,9 +2714,9 @@ metadata:
   namespace: cz-agent
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -83,9 +83,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -99,9 +99,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -114,9 +114,9 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -133,9 +133,9 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -149,9 +149,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -298,9 +298,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -406,7 +406,9 @@ metadata:
   name: cz-agent-aggregator
   namespace: cz-agent
   labels:
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -748,7 +750,9 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1363,9 +1367,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1446,9 +1450,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1675,9 +1679,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1762,9 +1766,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1830,9 +1834,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1853,9 +1857,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1905,9 +1909,9 @@ metadata:
   name: cz-agent-aggregator
   labels:
     app.kubernetes.io/component: aggregator
-    app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1929,13 +1933,12 @@ metadata:
   name: cz-agent-cloudzero-agent-webhook-server-svc
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
   namespace: cz-agent
@@ -1957,9 +1960,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1977,9 +1980,9 @@ spec:
         
       labels:
         app.kubernetes.io/component: server
-        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1994,7 +1997,6 @@ spec:
         - name: config-subst
           image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /bin/sh
             - -c
@@ -2013,7 +2015,6 @@ spec:
         - name: cloudzero-agent-server-configmap-reload
           image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
           imagePullPolicy: "IfNotPresent"
-          
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload
@@ -2025,7 +2026,6 @@ spec:
           
           image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: NODE_NAME
               valueFrom:
@@ -2195,9 +2195,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2216,9 +2216,9 @@ spec:
         
       labels:
         app.kubernetes.io/component: server
-        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2229,7 +2229,6 @@ spec:
         - name: env-validator-copy
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: K8S_NAMESPACE
               value: cz-agent
@@ -2254,7 +2253,6 @@ spec:
         - name: env-validator-run
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: K8S_NAMESPACE
               value: cz-agent
@@ -2281,7 +2279,6 @@ spec:
         - name: cloudzero-agent-server-configmap-reload
           image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
           imagePullPolicy: "IfNotPresent"
-          
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload
@@ -2293,7 +2290,6 @@ spec:
           
           image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
-          
           lifecycle:
             postStart:
               exec:
@@ -2429,7 +2425,6 @@ spec:
         - name: cz-agent-aggregator-collector
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           ports:
             - name: port-collector
               containerPort: 8080
@@ -2472,7 +2467,6 @@ spec:
         - name: cz-agent-aggregator-shipper
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           ports:
             - name: port-shipper
               containerPort: 8081
@@ -2552,9 +2546,9 @@ metadata:
   namespace: cz-agent
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2570,9 +2564,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/component: webhook-server
-        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2604,7 +2598,6 @@ spec:
         - name: webhook-server
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /app/cloudzero-webhook
           args:
@@ -2664,9 +2657,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2690,7 +2683,6 @@ spec:
         - name: init-scrape
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /app/cloudzero-webhook
           args:
@@ -2727,9 +2719,9 @@ metadata:
     checksum/values: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2752,7 +2744,6 @@ spec:
         - name: run-validator
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: K8S_NAMESPACE
               value: cz-agent
@@ -2833,7 +2824,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: helmless
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2844,7 +2837,9 @@ spec:
       namespace: cz-agent
       labels:
         app.kubernetes.io/component: helmless
+        app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2857,7 +2852,6 @@ spec:
         - name: helmless
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /app/cloudzero-helmless
           args:
@@ -2883,9 +2877,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2911,7 +2905,6 @@ spec:
         - name: init-cert
           image: "docker.io/bitnami/kubectl:1.33.1"
           imagePullPolicy: "IfNotPresent"
-          
           command: ["/bin/bash", "-c"]
           workingDir: /var/tmp
           args:
@@ -2994,9 +2987,9 @@ metadata:
   namespace: cz-agent
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -83,9 +83,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -99,9 +99,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -114,9 +114,9 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -133,9 +133,9 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -149,9 +149,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -353,7 +353,9 @@ metadata:
   name: cz-agent-aggregator
   namespace: cz-agent
   labels:
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -695,7 +697,9 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1310,9 +1314,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1393,9 +1397,9 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1622,9 +1626,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1709,9 +1713,9 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1777,9 +1781,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1800,9 +1804,9 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1852,9 +1856,9 @@ metadata:
   name: cz-agent-aggregator
   labels:
     app.kubernetes.io/component: aggregator
-    app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1876,13 +1880,12 @@ metadata:
   name: cz-agent-cloudzero-agent-webhook-server-svc
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-  
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
   namespace: cz-agent
@@ -1990,9 +1993,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2011,9 +2014,9 @@ spec:
         
       labels:
         app.kubernetes.io/component: server
-        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2024,7 +2027,6 @@ spec:
         - name: env-validator-copy
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: K8S_NAMESPACE
               value: cz-agent
@@ -2049,7 +2051,6 @@ spec:
         - name: env-validator-run
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: K8S_NAMESPACE
               value: cz-agent
@@ -2076,7 +2077,6 @@ spec:
         - name: cloudzero-agent-server-configmap-reload
           image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
           imagePullPolicy: "IfNotPresent"
-          
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload
@@ -2088,7 +2088,6 @@ spec:
           
           image: "quay.io/prometheus/prometheus:v2.55.1"
           imagePullPolicy: "IfNotPresent"
-          
           lifecycle:
             postStart:
               exec:
@@ -2224,7 +2223,6 @@ spec:
         - name: cz-agent-aggregator-collector
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           ports:
             - name: port-collector
               containerPort: 8080
@@ -2267,7 +2265,6 @@ spec:
         - name: cz-agent-aggregator-shipper
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           ports:
             - name: port-shipper
               containerPort: 8081
@@ -2347,9 +2344,9 @@ metadata:
   namespace: cz-agent
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2365,9 +2362,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/component: webhook-server
-        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2399,7 +2396,6 @@ spec:
         - name: webhook-server
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /app/cloudzero-webhook
           args:
@@ -2459,9 +2455,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2485,7 +2481,6 @@ spec:
         - name: init-scrape
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /app/cloudzero-webhook
           args:
@@ -2522,9 +2517,9 @@ metadata:
     checksum/values: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2547,7 +2542,6 @@ spec:
         - name: run-validator
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           env:
             - name: K8S_NAMESPACE
               value: cz-agent
@@ -2628,7 +2622,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: helmless
+    app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2639,7 +2635,9 @@ spec:
       namespace: cz-agent
       labels:
         app.kubernetes.io/component: helmless
+        app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v2.55.1
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2652,7 +2650,6 @@ spec:
         - name: helmless
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.1"
           imagePullPolicy: "IfNotPresent"
-          
           command:
             - /app/cloudzero-helmless
           args:
@@ -2678,9 +2675,9 @@ metadata:
   
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2706,7 +2703,6 @@ spec:
         - name: init-cert
           image: "docker.io/bitnami/kubectl:1.33.1"
           imagePullPolicy: "IfNotPresent"
-          
           command: ["/bin/bash", "-c"]
           workingDir: /var/tmp
           args:
@@ -2789,9 +2785,9 @@ metadata:
   namespace: cz-agent
   labels:
     app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v2.55.1
     helm.sh/chart: cloudzero-agent-1.1.0-dev

--- a/tools.go
+++ b/tools.go
@@ -7,6 +7,7 @@ package tools
 
 import (
 	_ "github.com/itchyny/gojq/cmd/gojq"
+	_ "github.com/yannh/kubeconform/cmd/kubeconform"
 	_ "go.uber.org/mock/mockgen"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 	_ "helm.sh/helm/v3/cmd/helm"


### PR DESCRIPTION
## Why?

Previously, there was a bug in the template which was causing the generated output to not be valid according to the Kubernetes schema. I want to be able to catch bugs like this automatically.

## What

For every schema test where the result is valid (i.e., files named *.pass.yaml), run the output through kubeconform with strict validation enabled.

The schema tests are a great opportunity because they exercise a lot of different properties, particularly ones which don't get used very often. This gives us much greater coverage. In fact, I was able to spot several issues using these new tests, so this PR also includes fixes for those.

I also added a GitHub Action job to run `helm -j helm-test`. Oh, and that `-j` is interesting; I refactored the Makefile a bit to create multiple targets, so -j will actually cause these tests to be executed in parallel.

## How Tested

`make helm-install-deps install-tools && make -j helm-test`

Note that I'm currently targeting the CP-29985 branch. I'll update this PR to target develop once that is merged.
