### PR TITLE
CP-30042: allow resource_type and workload labels in Gator

### DIFF
--- a/helm/docs/releases/1.2.2.md
+++ b/helm/docs/releases/1.2.2.md
@@ -8,6 +8,7 @@ This is a maintenance release that includes important bug fixes and dependency u
 - **ConfigMap References**: Updated ConfigMap name references in the loader job to use the correct naming convention, preventing resource lookup failures.
 - **JSON Schema Validation**: Added support for properties which were previously not present in `values.yaml`, but were used in the template.
 - **Invalid Template Fixes**: Fixed template generation for options were causing invalid Kubernetes resources to be generated.
+- **Allow resource_type Labels**: The Aggregator no longer filters out "resource_type" and "workload" labels.
 
 ### Enhancements
 

--- a/helm/templates/_defaults.tpl
+++ b/helm/templates/_defaults.tpl
@@ -171,8 +171,10 @@ metricFilters:
         - product_name
         - provider_id
         - resource
+        - resource_type
         - unit
         - uid
+        - workload
       prefix:
         - "_"
         - "label_"

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -405,9 +405,13 @@ data:
           match: exact
         - pattern: "resource"
           match: exact
+        - pattern: "resource_type"
+          match: exact
         - pattern: "unit"
           match: exact
         - pattern: "uid"
+          match: exact
+        - pattern: "workload"
           match: exact
         - pattern: "_"
           match: prefix

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -474,9 +474,13 @@ data:
           match: exact
         - pattern: "resource"
           match: exact
+        - pattern: "resource_type"
+          match: exact
         - pattern: "unit"
           match: exact
         - pattern: "uid"
+          match: exact
+        - pattern: "workload"
           match: exact
         - pattern: "_"
           match: prefix

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -421,9 +421,13 @@ data:
           match: exact
         - pattern: "resource"
           match: exact
+        - pattern: "resource_type"
+          match: exact
         - pattern: "unit"
           match: exact
         - pattern: "uid"
+          match: exact
+        - pattern: "workload"
           match: exact
         - pattern: "_"
           match: prefix


### PR DESCRIPTION
## Why?

Be the resource_type and workload labels, which are emitted by the webhook server.

## What

Add "resource_type" to the list of allowed labels.

## How Tested

YOLO.