### PR TITLE
CP-29473: reduce webhook timeout, allow configuration of value

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -690,6 +690,8 @@ insightsController:
     namespaceSelector: {}
     # Path for the validating admission webhook.
     path: /validate
+    # Timeout for the validating admission webhook.
+    timeoutSeconds: 1
     caInjection:
   configurationMountPath:
   ConfigMapNameOverride:

--- a/helm/templates/webhook-validating-config.yaml
+++ b/helm/templates/webhook-validating-config.yaml
@@ -37,6 +37,6 @@ webhooks:
       {{- end }}
     admissionReviewVersions: ["v1"]
     sideEffects: None
-    timeoutSeconds: 15
+    timeoutSeconds: {{ .Values.insightsController.webhooks.timeoutSeconds }}
 {{- end }}
 {{- end }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -21560,6 +21560,11 @@
               "default": "/validate",
               "description": "Path for the validating admission webhook.\n",
               "type": "string"
+            },
+            "timeoutSeconds": {
+              "default": 1,
+              "description": "Timeout for the validating admission webhook..\n",
+              "type": "integer"
             }
           },
           "type": "object"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -21563,7 +21563,7 @@
             },
             "timeoutSeconds": {
               "default": 1,
-              "description": "Timeout for the validating admission webhook..\n",
+              "description": "Timeout for the validating admission webhook.\n",
               "type": "integer"
             }
           },

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -21560,11 +21560,6 @@
               "default": "/validate",
               "description": "Path for the validating admission webhook.\n",
               "type": "string"
-            },
-            "timeoutSeconds": {
-              "default": 1,
-              "description": "Timeout for the validating admission webhook.\n",
-              "type": "integer"
             }
           },
           "type": "object"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -21560,6 +21560,11 @@
               "default": "/validate",
               "description": "Path for the validating admission webhook.\n",
               "type": "string"
+            },
+            "timeoutSeconds": {
+              "default": 1,
+              "description": "Timeout for the validating admission webhook.\n",
+              "type": "integer"
             }
           },
           "type": "object"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -21562,6 +21562,7 @@
               "type": "string"
             },
             "timeoutSeconds": {
+              "$ref": "#/$defs/io.k8s.api.admissionregistration.v1.ValidatingWebhook/properties/timeoutSeconds",
               "default": 1,
               "description": "Timeout for the validating admission webhook.\n",
               "type": "integer"

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1158,6 +1158,7 @@ properties:
               Timeout for the validating admission webhook.
             type: integer
             default: 1
+            $ref: "#/$defs/io.k8s.api.admissionregistration.v1.ValidatingWebhook/properties/timeoutSeconds"
           caInjection:
             type:
               - string

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1153,6 +1153,11 @@ properties:
               Path for the validating admission webhook.
             type: string
             default: "/validate"
+          timeoutSeconds:
+            description: |
+              Timeout for the validating admission webhook.
+            type: integer
+            default: 1
           caInjection:
             type:
               - string

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -690,6 +690,8 @@ insightsController:
     namespaceSelector: {}
     # Path for the validating admission webhook.
     path: /validate
+    # Timeout for the validating admission webhook.
+    timeoutSeconds: 1
     caInjection:
   configurationMountPath:
   ConfigMapNameOverride:

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -932,6 +932,7 @@ data:
         caInjection: null
         namespaceSelector: {}
         path: /validate
+        timeoutSeconds: 1
     jobConfigID: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
     kubeStateMetrics:
       affinity: {}
@@ -2746,4 +2747,4 @@ webhooks:
       caBundle: ''
     admissionReviewVersions: ["v1"]
     sideEffects: None
-    timeoutSeconds: 15
+    timeoutSeconds: 1

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -1001,6 +1001,7 @@ data:
         caInjection: null
         namespaceSelector: {}
         path: /validate
+        timeoutSeconds: 1
     jobConfigID: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
     kubeStateMetrics:
       affinity: {}
@@ -3017,4 +3018,4 @@ webhooks:
         port: 443
     admissionReviewVersions: ["v1"]
     sideEffects: None
-    timeoutSeconds: 15
+    timeoutSeconds: 1

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -948,6 +948,7 @@ data:
         caInjection: null
         namespaceSelector: {}
         path: /validate
+        timeoutSeconds: 1
     jobConfigID: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
     kubeStateMetrics:
       affinity: {}
@@ -2815,4 +2816,4 @@ webhooks:
         port: 443
     admissionReviewVersions: ["v1"]
     sideEffects: None
-    timeoutSeconds: 15
+    timeoutSeconds: 1


### PR DESCRIPTION
## Why?

reduces the impact of potential timeout issues with the webhook server

## What

allow the user configure the timeout, with a default of 1 second

## How Tested

in progress
