### PR TITLE
CP-30076: add Google Cloud scout

### DIFF
--- a/app/functions/scout/scout.go
+++ b/app/functions/scout/scout.go
@@ -34,7 +34,8 @@ By default, running 'scout' will retrieve full environment information.
 Use 'scout detect' to only identify the cloud provider.
 
 Supported cloud providers:
-- Amazon Web Services (AWS)`,
+- Amazon Web Services (AWS)
+- Google Cloud`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runScout()
 	},
@@ -45,7 +46,7 @@ var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Retrieve cloud environment information",
 	Long: `Retrieve detailed information about the current cloud environment including:
-- Cloud provider
+- Cloud provider (aws, google)
 - Region/location
 - Account ID/Subscription ID/Project ID`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/app/utils/scout/google/google.go
+++ b/app/utils/scout/google/google.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package google provides functionality for detecting and gathering environment
+// information from Google Cloud metadat services.
+package google
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
+)
+
+const (
+	// GCP metadata service endpoints
+	metadataBaseURL = "http://metadata.google.internal/computeMetadata/v1"
+	projectEndpoint = metadataBaseURL + "/project/project-id"
+	zoneEndpoint    = metadataBaseURL + "/instance/zone"
+
+	requestTimeout = 5 * time.Second
+)
+
+type Scout struct {
+	client *http.Client
+}
+
+// NewScout creates a new GCP metadata scout
+func NewScout() *Scout {
+	return &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+		},
+	}
+}
+
+// EnvironmentInfo retrieves GCP environment information from metadata service
+func (s *Scout) EnvironmentInfo(ctx context.Context) (*types.EnvironmentInfo, error) {
+	// Get project ID (equivalent to account ID)
+	projectID, err := s.getMetadata(ctx, projectEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project ID: %w", err)
+	}
+
+	// Get zone (to extract region)
+	zone, err := s.getMetadata(ctx, zoneEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get zone: %w", err)
+	}
+
+	// Extract region from zone (e.g., "projects/123456789/zones/us-central1-a" -> "us-central1")
+	region := s.extractRegionFromZone(zone)
+
+	return &types.EnvironmentInfo{
+		CloudProvider: types.CloudProviderGoogle,
+		Region:        strings.TrimSpace(region),
+		AccountID:     strings.TrimSpace(projectID),
+	}, nil
+}
+
+// getMetadata retrieves metadata from the specified GCP metadata endpoint
+func (s *Scout) getMetadata(ctx context.Context, endpoint string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// GCP metadata service requires this header
+	req.Header.Set("Metadata-Flavor", "Google")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get metadata, status: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// extractRegionFromZone extracts the region from a GCP zone string
+// Zone format: "projects/{project}/zones/{zone}" or just "{zone}"
+// Zone examples: "us-central1-a", "europe-west1-b"
+// Region examples: "us-central1", "europe-west1"
+func (s *Scout) extractRegionFromZone(zone string) string {
+	// Handle full zone path format
+	if strings.Contains(zone, "/zones/") {
+		parts := strings.Split(zone, "/zones/")
+		if len(parts) == 2 {
+			zone = parts[1]
+		}
+	}
+
+	// Extract region from zone by removing the last part after the last hyphen
+	// e.g., "us-central1-a" -> "us-central1"
+	zoneParts := strings.Split(zone, "-")
+	if len(zoneParts) > 1 {
+		// Join all parts except the last one
+		region := strings.Join(zoneParts[:len(zoneParts)-1], "-")
+		return region
+	}
+
+	// If we can't parse it properly, return the zone as-is
+	return zone
+}
+
+// Detect determines if the current environment is running on GCP by testing the metadata service.
+func (s *Scout) Detect(ctx context.Context) (types.CloudProvider, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", metadataBaseURL+"/", nil)
+	if err != nil {
+		return types.CloudProviderUnknown, err
+	}
+
+	// GCP metadata service requires this header
+	req.Header.Set("Metadata-Flavor", "Google")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		// Network errors mean we can't detect, but not an error condition
+		return types.CloudProviderUnknown, nil
+	}
+	defer resp.Body.Close()
+
+	// Consider 2xx status codes as successful detection
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return types.CloudProviderGoogle, nil
+	}
+
+	return types.CloudProviderUnknown, nil
+}

--- a/app/utils/scout/google/google_test.go
+++ b/app/utils/scout/google/google_test.go
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package google
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
+)
+
+func TestNewScout(t *testing.T) {
+	scout := NewScout()
+	if scout == nil {
+		t.Fatal("Expected non-nil scout")
+	}
+
+	if scout.client == nil {
+		t.Fatal("Expected non-nil HTTP client")
+	}
+
+	if scout.client.Timeout != requestTimeout {
+		t.Errorf("Expected timeout %v, got %v", requestTimeout, scout.client.Timeout)
+	}
+}
+
+func TestDetect_Success(t *testing.T) {
+	// Create test server that mimics GCP metadata service behavior
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check for required Metadata-Flavor header
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		// GCP returns 200 OK for valid metadata service requests
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	// Test detection with custom server
+	testDetectWithMockServer(t, server.URL, types.CloudProviderGoogle)
+}
+
+func TestDetect_NotGCP(t *testing.T) {
+	// Test various non-GCP responses
+	testCases := []struct {
+		name           string
+		statusCode     int
+		expectedResult types.CloudProvider
+	}{
+		{"Unauthorized", http.StatusUnauthorized, types.CloudProviderUnknown},
+		{"Not Found", http.StatusNotFound, types.CloudProviderUnknown},
+		{"Internal Server Error", http.StatusInternalServerError, types.CloudProviderUnknown},
+		{"Forbidden", http.StatusForbidden, types.CloudProviderUnknown},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer server.Close()
+
+			testDetectWithMockServer(t, server.URL, tc.expectedResult)
+		})
+	}
+}
+
+func TestDetect_NetworkError(t *testing.T) {
+	scout := NewScout()
+	ctx := context.Background()
+
+	// Test with invalid URL to simulate network error
+	originalClient := scout.client
+	scout.client = &http.Client{
+		Timeout: 10 * time.Millisecond, // Very short timeout
+	}
+
+	// This should return Unknown (not error) for network issues
+	detected, err := scout.Detect(ctx)
+	if err != nil {
+		t.Errorf("Expected no error for network failure, got: %v", err)
+	}
+
+	if detected != types.CloudProviderUnknown {
+		t.Errorf("Expected %s, got %s", types.CloudProviderUnknown, detected)
+	}
+
+	scout.client = originalClient
+}
+
+func TestEnvironmentInfo_Success(t *testing.T) {
+	// Create test server that mimics GCP metadata service
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check for required Metadata-Flavor header
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/computeMetadata/v1/project/project-id":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("test-project-123"))
+
+		case "/computeMetadata/v1/instance/zone":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("projects/123456789/zones/us-central1-a"))
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURLs(server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	info, err := scout.EnvironmentInfo(ctx)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if info.CloudProvider != types.CloudProviderGoogle {
+		t.Errorf("Expected cloud provider %s, got %s", types.CloudProviderGoogle, info.CloudProvider)
+	}
+
+	if info.Region != "us-central1" {
+		t.Errorf("Expected region 'us-central1', got '%s'", info.Region)
+	}
+
+	if info.AccountID != "test-project-123" {
+		t.Errorf("Expected account ID 'test-project-123', got '%s'", info.AccountID)
+	}
+}
+
+func TestEnvironmentInfo_ProjectIDFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		if r.URL.Path == "/computeMetadata/v1/project/project-id" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURLs(server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := scout.EnvironmentInfo(ctx)
+	if err == nil {
+		t.Error("Expected error for project ID failure")
+	}
+
+	if !strings.Contains(err.Error(), "failed to get project ID") {
+		t.Errorf("Expected project ID error, got: %v", err)
+	}
+}
+
+func TestEnvironmentInfo_ZoneFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/computeMetadata/v1/project/project-id":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("test-project-123"))
+
+		case "/computeMetadata/v1/instance/zone":
+			w.WriteHeader(http.StatusInternalServerError)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURLs(server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := scout.EnvironmentInfo(ctx)
+	if err == nil {
+		t.Error("Expected error for zone failure")
+	}
+
+	if !strings.Contains(err.Error(), "failed to get zone") {
+		t.Errorf("Expected zone error, got: %v", err)
+	}
+}
+
+func TestEnvironmentInfo_MissingMetadataHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reject requests without the required header
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create scout with a client that doesn't set the header
+	scout := &Scout{
+		client: &http.Client{Timeout: requestTimeout},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Make a request without the header (this tests our implementation sets it correctly)
+	req, err := http.NewRequestWithContext(ctx, "GET", server.URL+"/computeMetadata/v1/project/project-id", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	resp, err := scout.client.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Should get 403 without the header
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("Expected status %d, got %d", http.StatusForbidden, resp.StatusCode)
+	}
+}
+
+func TestEnvironmentInfo_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Delay to allow context cancellation
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURLs(server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := scout.EnvironmentInfo(ctx)
+	if err == nil {
+		t.Error("Expected error for context cancellation")
+	}
+}
+
+func TestEnvironmentInfo_WhitespaceHandling(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/computeMetadata/v1/project/project-id":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("  test-project-123  ")) // Whitespace
+
+		case "/computeMetadata/v1/instance/zone":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("  projects/123456789/zones/us-central1-a  ")) // Whitespace
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURLs(server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	info, err := scout.EnvironmentInfo(ctx)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Verify whitespace is trimmed
+	if info.Region != "us-central1" {
+		t.Errorf("Expected region 'us-central1', got '%s'", info.Region)
+	}
+
+	if info.AccountID != "test-project-123" {
+		t.Errorf("Expected account ID 'test-project-123', got '%s'", info.AccountID)
+	}
+}
+
+func TestExtractRegionFromZone(t *testing.T) {
+	scout := NewScout()
+
+	tests := []struct {
+		name     string
+		zone     string
+		expected string
+	}{
+		{
+			name:     "full zone path format",
+			zone:     "projects/123456789/zones/us-central1-a",
+			expected: "us-central1",
+		},
+		{
+			name:     "simple zone format",
+			zone:     "us-central1-a",
+			expected: "us-central1",
+		},
+		{
+			name:     "europe zone",
+			zone:     "europe-west1-b",
+			expected: "europe-west1",
+		},
+		{
+			name:     "asia zone",
+			zone:     "asia-southeast1-c",
+			expected: "asia-southeast1",
+		},
+		{
+			name:     "multi-hyphen region",
+			zone:     "us-west-2-a",
+			expected: "us-west-2",
+		},
+		{
+			name:     "invalid format returns as-is",
+			zone:     "invalid-zone-format",
+			expected: "invalid-zone",
+		},
+		{
+			name:     "single part returns as-is",
+			zone:     "invalid",
+			expected: "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := scout.extractRegionFromZone(tt.zone)
+			if result != tt.expected {
+				t.Errorf("extractRegionFromZone(%q) = %q, want %q", tt.zone, result, tt.expected)
+			}
+		})
+	}
+}
+
+func testDetectWithMockServer(t *testing.T, serverURL string, expectedResult types.CloudProvider) {
+	t.Helper()
+
+	scout := createScoutWithCustomURLs(serverURL)
+
+	ctx := context.Background()
+	detected, err := scout.Detect(ctx)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if detected != expectedResult {
+		t.Errorf("Expected %s, got %s", expectedResult, detected)
+	}
+}
+
+// createScoutWithCustomURLs creates a scout for testing with custom URLs
+func createScoutWithCustomURLs(baseURL string) *Scout {
+	return &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+			Transport: &customTransport{
+				baseURL: baseURL,
+			},
+		},
+	}
+}
+
+// customTransport is a helper for testing that redirects requests to a test server
+type customTransport struct {
+	baseURL string
+}
+
+func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Rewrite the URL to point to our test server
+	newURL := strings.Replace(req.URL.String(), metadataBaseURL, t.baseURL+"/computeMetadata/v1", 1)
+
+	// Handle the detect endpoint specially
+	if strings.HasSuffix(req.URL.Path, "/") {
+		newURL = t.baseURL + "/"
+	}
+
+	newReq := req.Clone(req.Context())
+	newReq.URL, _ = req.URL.Parse(newURL)
+
+	return http.DefaultTransport.RoundTrip(newReq)
+}
+
+func TestConstants(t *testing.T) {
+	if metadataBaseURL == "" {
+		t.Error("metadataBaseURL should not be empty")
+	}
+
+	if projectEndpoint == "" {
+		t.Error("projectEndpoint should not be empty")
+	}
+
+	if zoneEndpoint == "" {
+		t.Error("zoneEndpoint should not be empty")
+	}
+
+	if requestTimeout == 0 {
+		t.Error("requestTimeout should not be zero")
+	}
+
+	// Verify endpoints are correctly constructed
+	expectedProjectEndpoint := metadataBaseURL + "/project/project-id"
+	if projectEndpoint != expectedProjectEndpoint {
+		t.Errorf("Expected projectEndpoint %q, got %q", expectedProjectEndpoint, projectEndpoint)
+	}
+
+	expectedZoneEndpoint := metadataBaseURL + "/instance/zone"
+	if zoneEndpoint != expectedZoneEndpoint {
+		t.Errorf("Expected zoneEndpoint %q, got %q", expectedZoneEndpoint, zoneEndpoint)
+	}
+}

--- a/app/utils/scout/scout.go
+++ b/app/utils/scout/scout.go
@@ -8,6 +8,7 @@ package scout
 import (
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/auto"
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/aws"
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/google"
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
 )
 
@@ -15,5 +16,6 @@ import (
 func NewScout() types.Scout {
 	return auto.NewScout(
 		aws.NewScout(),
+		google.NewScout(),
 	)
 }

--- a/app/utils/scout/types/types.go
+++ b/app/utils/scout/types/types.go
@@ -15,6 +15,8 @@ type CloudProvider string
 const (
 	// CloudProviderAWS represents Amazon Web Services
 	CloudProviderAWS CloudProvider = "aws"
+	// CloudProviderGoogle represents Google Cloud Platform
+	CloudProviderGoogle CloudProvider = "google"
 	// CloudProviderUnknown represents an undetected or unsupported cloud provider
 	CloudProviderUnknown CloudProvider = "unknown"
 	// CloudProviderMock represents a mock provider for testing


### PR DESCRIPTION
## Why?

Automatic detection of region and clusterAccountId on GKE

## What

Added a new Scout, integrate it into the existing code.

## How Tested

There are tests, but you really need to deploy to GKE to fully test... which I have done.