### PR TITLE
CP-30109: add automatic Istio sidecar injection suppression for webhook server

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -668,6 +668,13 @@ insightsController:
     deploymentAnnotations: {}
     # Annotations to add to the webhook server pods.
     podAnnotations: {}
+    # Whether to suppress Istio-related annotations on webhook server pods. When
+    # false (default), the sidecar.istio.io/inject: "false" annotation is added
+    # to prevent Istio sidecar injection which can interfere with webhook TLS.
+    # Set to true to disable this behavior and allow Istio sidecar injection.
+    # For additional information, see:
+    # https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/docs/istio.md
+    suppressIstioAnnotations: false
   # Additional volume mounts to add to the insights controller pods.
   volumeMounts: []
   # Additional volumes to add to the insights controller pods.

--- a/helm/docs/istio.md
+++ b/helm/docs/istio.md
@@ -1,37 +1,37 @@
 # Installing `cloudzero-agent` in Istio-Enabled Clusters
 
-When installing the `cloudzero-agent` Helm chart in a Kubernetes cluster that uses Istio, additional steps may be required to ensure proper functionality. This is because Istio automatically configures sidecars to use **mutual TLS (mTLS)**, which can interfere with the agent’s existing TLS communication.
+When installing the `cloudzero-agent` Helm chart in a Kubernetes cluster that uses Istio, the chart automatically includes Istio-compatible configuration. The webhook server pods include the `sidecar.istio.io/inject: "false"` annotation by default to prevent Istio sidecar injection, which can interfere with webhook TLS communication.
 
-## Why These Steps Are Needed
+In most cases, no additional configuration is required. However, you may need additional steps depending on your specific Istio setup.
 
-The `cloudzero-agent` includes a **webhook server** component responsible for handling admission review requests from the Kubernetes API server. These requests use TLS, and when intercepted by an Istio sidecar, Istio may attempt to apply its mTLS policies. These policies are not always compatible with the webhook’s TLS configuration.
+## Default Behavior
 
-While this does not block pod deployments, it **prevents the `insightsController` from collecting critical pod labels**, which are necessary for accurate cost allocation.
+The webhook server pods automatically include the `sidecar.istio.io/inject: "false"` annotation. This prevents Istio sidecar injection and avoids TLS interference without any additional configuration.
 
-To ensure `cloudzero-agent` works correctly in Istio-enabled clusters, you can choose from the following options:
-
-- [**Disable sidecar injection for `cloudzero-agent` webhook-server pods only**](#option-1-disable-sidecar-injection-for-cloudzero-agent-webhook-server-pods-only) — Completely removes the Istio sidecar from the webhook server, avoiding any interference.
-- [**Disable envoy for webhook ports only**](#option-2-disable-envoy-for-webhook-ports-only) — Keeps the sidecar but excludes webhook traffic, preserving Istio functionality for all other traffic.
-- [**Disable mTLS for `cloudzero-agent` webhook-server pods**](#option-3-disable-mtls-for-cloudzero-agent) — Keeps the sidecar but disables mTLS enforcement specifically for webhook-server traffic.
-
----
-
-## **Option 1: Disable Sidecar Injection for `cloudzero-agent` webhook-server Pods Only**
-
-To disable the sidecar injection **only for a subset of the pods deployed by the cluster**, update the chart input values with the following annotation:
+**To override this default behavior** and allow Istio sidecar injection, set:
 
 ```yaml
 insightsController:
   server:
-    podAnnotations:
-      sidecar.istio.io/inject: "false"
+    suppressIstioAnnotations: true
 ```
 
-This annotation prevents the Istio sidecar from being injected into the `webhook-server` pods, while the rest of the cluster retains normal Istio functionality.
+When this setting is enabled, you will need to use one of the additional configuration options below to ensure proper functionality.
+
+## Additional Configuration Options
+
+The `cloudzero-agent` includes a **webhook server** component responsible for handling admission review requests from the Kubernetes API server. These requests use TLS, and when intercepted by an Istio sidecar, Istio may attempt to apply its mTLS policies. These policies are not always compatible with the webhook's TLS configuration.
+
+While this does not block pod deployments, it **prevents the `insightsController` from collecting critical pod labels**, which are necessary for accurate cost allocation.
+
+If you have overridden the default behavior (by setting `suppressIstioAnnotations: true`) and need alternative configuration, you can choose from the following options:
+
+- [**Disable envoy for webhook ports only**](#option-1-disable-envoy-for-webhook-ports-only) — Keeps the sidecar but excludes webhook traffic, preserving Istio functionality for all other traffic.
+- [**Disable mTLS for `cloudzero-agent` webhook-server pods**](#option-2-disable-mtls-for-cloudzero-agent) — Keeps the sidecar but disables mTLS enforcement specifically for webhook-server traffic.
 
 ---
 
-## **Option 2: Disable Envoy for Webhook Ports Only**
+## **Option 1: Disable Envoy for Webhook Ports Only**
 
 To prevent only requests to a single port on the webhook-server pods from being routed through envoy, apply the following annotation:
 
@@ -48,7 +48,7 @@ For more details, see [Istio Documentation](https://istio.io/latest/docs/referen
 
 ---
 
-## **Option 3: Disable mTLS for `cloudzero-agent`**
+## **Option 2: Disable mTLS for `cloudzero-agent`**
 
 To disable mTLS for the `cloudzero-agent` service, apply the following `PeerAuthentication` resource:
 

--- a/helm/templates/webhook-deploy.yaml
+++ b/helm/templates/webhook-deploy.yaml
@@ -19,9 +19,14 @@ spec:
         {{- with .Values.insightsController.server.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- $istioAnnotations := dict -}}
+      {{- if not .Values.insightsController.server.suppressIstioAnnotations -}}
+      {{- $istioAnnotations = dict "sidecar.istio.io/inject" "false" -}}
+      {{- end -}}
       {{- include "cloudzero-agent.generateAnnotations" (merge
           (deepCopy .Values.defaults.annotations)
           .Values.insightsController.server.podAnnotations
+          $istioAnnotations
           (dict "checksum/config" (include "cloudzero-agent.configurationChecksum" .))
         ) | nindent 6 }}
     spec:

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -21442,6 +21442,11 @@
               "default": "1m",
               "description": "Timeout for sending data to clients.\n"
             },
+            "suppressIstioAnnotations": {
+              "default": false,
+              "description": "Whether to suppress Istio-related annotations on webhook server pods.\nWhen false (default), the sidecar.istio.io/inject: \"false\" annotation is added\nto prevent Istio sidecar injection which can interfere with webhook TLS.\nSet to true to disable this behavior and allow Istio sidecar injection.\n",
+              "type": "boolean"
+            },
             "tolerations": {
               "$ref": "#/$defs/com.cloudzero.agent.tolerations",
               "description": "Tolerations configuration for the webhook server pods.\n"

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1098,6 +1098,14 @@ properties:
             description: |
               Annotations to add to the webhook server pods.
             $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+          suppressIstioAnnotations:
+            description: |
+              Whether to suppress Istio-related annotations on webhook server pods.
+              When false (default), the sidecar.istio.io/inject: "false" annotation is added
+              to prevent Istio sidecar injection which can interfere with webhook TLS.
+              Set to true to disable this behavior and allow Istio sidecar injection.
+            type: boolean
+            default: false
       volumeMounts:
         description: |
           Additional volume mounts to add to the insights controller pods.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -668,6 +668,13 @@ insightsController:
     deploymentAnnotations: {}
     # Annotations to add to the webhook server pods.
     podAnnotations: {}
+    # Whether to suppress Istio-related annotations on webhook server pods. When
+    # false (default), the sidecar.istio.io/inject: "false" annotation is added
+    # to prevent Istio sidecar injection which can interfere with webhook TLS.
+    # Set to true to disable this behavior and allow Istio sidecar injection.
+    # For additional information, see:
+    # https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/docs/istio.md
+    suppressIstioAnnotations: false
   # Additional volume mounts to add to the insights controller pods.
   volumeMounts: []
   # Additional volumes to add to the insights controller pods.

--- a/tests/helm/schema/insightsController.server.podAnnotations.with.suppressIstioAnnotations.pass.yaml
+++ b/tests/helm/schema/insightsController.server.podAnnotations.with.suppressIstioAnnotations.pass.yaml
@@ -1,0 +1,5 @@
+insightsController:
+  server:
+    podAnnotations:
+      sidecar.istio.io/inject: "false"
+    suppressIstioAnnotations: false

--- a/tests/helm/schema/insightsController.server.suppressIstioAnnotations.false.pass.yaml
+++ b/tests/helm/schema/insightsController.server.suppressIstioAnnotations.false.pass.yaml
@@ -1,0 +1,3 @@
+insightsController:
+  server:
+    suppressIstioAnnotations: false

--- a/tests/helm/schema/insightsController.server.suppressIstioAnnotations.invalid.fail.yaml
+++ b/tests/helm/schema/insightsController.server.suppressIstioAnnotations.invalid.fail.yaml
@@ -1,0 +1,3 @@
+insightsController:
+  server:
+    suppressIstioAnnotations: "not-a-boolean"

--- a/tests/helm/schema/insightsController.server.suppressIstioAnnotations.true.pass.yaml
+++ b/tests/helm/schema/insightsController.server.suppressIstioAnnotations.true.pass.yaml
@@ -1,0 +1,3 @@
+insightsController:
+  server:
+    suppressIstioAnnotations: true

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -910,6 +910,7 @@ data:
         replicaCount: null
         send_interval: 1m
         send_timeout: 1m
+        suppressIstioAnnotations: false
         tolerations: []
         write_timeout: 10s
       service:
@@ -2358,6 +2359,7 @@ spec:
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -979,6 +979,7 @@ data:
         replicaCount: null
         send_interval: 1m
         send_timeout: 1m
+        suppressIstioAnnotations: false
         tolerations: []
         write_timeout: 10s
       service:
@@ -2576,6 +2577,7 @@ spec:
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -926,6 +926,7 @@ data:
         replicaCount: null
         send_interval: 1m
         send_timeout: 1m
+        suppressIstioAnnotations: false
         tolerations: []
         write_timeout: 10s
       service:
@@ -2374,6 +2375,7 @@ spec:
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: cz-agent-cloudzero-agent-server
       


### PR DESCRIPTION
## Why?

Previously, users deploying cloudzero-agent in Istio-enabled clusters had to manually configure `sidecar.istio.io/inject: "false"` annotations to prevent Istio sidecar injection from interfering with webhook TLS communication. This created a poor out-of-the-box experience and required users to read documentation and troubleshoot connectivity issues.

## What

This change makes the webhook server work automatically in Istio environments by adding the `sidecar.istio.io/inject: "false"` annotation by default. The webhook server pods now automatically include this annotation without any user configuration required.

The implementation adds a new
`insightsController.server.suppressIstioAnnotations` boolean property (default: false) that controls whether the automatic annotation is added. When false (default), the template logic automatically merges the Istio annotation with any user-provided `podAnnotations`. When set to true, users can disable this behavior and handle Istio configuration manually using the alternative approaches documented in `docs/istio.md`.

The annotation should have no effect in non-Istio environments.

## How Tested

Schema tests for the new property, plus the manifest generation tests look good, and for good measure I deployed it.

Haven't tested that istio does what we want, though; only that the annotation exists.