### PR TITLE
CP-30104: add scout configuration mismatch warnings

### DIFF
--- a/app/config/gator/settings.go
+++ b/app/config/gator/settings.go
@@ -146,10 +146,11 @@ func (s *Settings) Validate() error {
 	s.Region = strings.TrimSpace(s.Region)
 
 	// Auto-detect cloud account ID and region if needed
+	logger := log.Logger.With().Str("component", "gator-settings").Logger()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err := scout.DetectConfiguration(ctx, nil, &s.Region, &s.CloudAccountID, &s.ClusterName)
+	err := scout.DetectConfiguration(ctx, &logger, nil, &s.Region, &s.CloudAccountID, &s.ClusterName)
 	if err != nil {
 		return fmt.Errorf("failed to auto-detect cloud environment: %w", err)
 	}

--- a/app/config/validator/deployment.go
+++ b/app/config/validator/deployment.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout"
 )
@@ -26,10 +27,11 @@ func (s *Deployment) Validate() error {
 	s.Region = strings.TrimSpace(s.Region)
 
 	// Auto-detect cloud account ID and region if needed
+	logger := log.Logger.With().Str("component", "validator-deployment").Logger()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err := scout.DetectConfiguration(ctx, nil, &s.Region, &s.AccountID, &s.ClusterName)
+	err := scout.DetectConfiguration(ctx, &logger, nil, &s.Region, &s.AccountID, &s.ClusterName)
 	if err != nil {
 		return errors.Wrap(err, "failed to auto-detect cloud environment")
 	}

--- a/app/config/webhook/settings.go
+++ b/app/config/webhook/settings.go
@@ -83,10 +83,11 @@ func NewSettings(configFiles ...string) (*Settings, error) {
 	cfg.Region = strings.TrimSpace(cfg.Region)
 
 	// Auto-detect cloud account ID and region if needed
+	logger := log.Logger.With().Str("component", "webhook-settings").Logger()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err := scout.DetectConfiguration(ctx, nil, &cfg.Region, &cfg.CloudAccountID, &cfg.ClusterName)
+	err := scout.DetectConfiguration(ctx, &logger, nil, &cfg.Region, &cfg.CloudAccountID, &cfg.ClusterName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to auto-detect cloud environment: %w", err)
 	}

--- a/app/utils/scout/detect_configuration.go
+++ b/app/utils/scout/detect_configuration.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/rs/zerolog"
+
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
 )
 
@@ -18,42 +20,106 @@ import (
 // It is designed for use when loading configuration. If any fields are empty,
 // an auto scout (see the auto subpackage) will be used to attempt to detect the
 // correct values. If the fields are not empty, they will be treated as
-// overrides and left intact.
+// overrides and left intact, but a warning will be logged if they don't match
+// the detected values.
 //
-// If any of the fields are unable to be auto-detected, an error will be
-// returned.
-func DetectConfiguration(ctx context.Context, scout types.Scout, region *string, accountID *string, clusterName *string) error {
+// If any of the fields are unable to be auto-detected AND are required (empty),
+// an error will be returned. If all required fields are already provided,
+// detection failures will only result in warning logs.
+//
+// If all parameters are nil, no detection will be performed.
+// If logger is nil, no warning logs will be emitted.
+func DetectConfiguration(ctx context.Context, logger *zerolog.Logger, scout types.Scout, region *string, accountID *string, clusterName *string) error {
+	// If all parameters are nil, there's nothing to detect or compare
+	if region == nil && accountID == nil && clusterName == nil {
+		return nil
+	}
+
 	if scout == nil {
 		scout = NewScout()
 	}
 
-	if (region != nil && *region == "") || (accountID != nil && *accountID == "") || (clusterName != nil && *clusterName == "") {
-		ei, innerErr := scout.EnvironmentInfo(ctx)
-		if innerErr != nil {
-			return fmt.Errorf("failed to detect cloud provider: %w", innerErr)
-		} else if ei.CloudProvider == types.CloudProviderUnknown {
-			return errors.New("cloud provider could not be auto-detected, manual configuration may be required")
-		}
+	// Check if any values need to be detected (are empty)
+	needsDetection := (region != nil && *region == "") || (accountID != nil && *accountID == "") || (clusterName != nil && *clusterName == "")
 
-		if region != nil && *region == "" {
+	// Always try to run the scout to allow comparison and warning logs
+	ei, innerErr := scout.EnvironmentInfo(ctx)
+	if innerErr != nil {
+		// If detection fails but no values need to be filled, just log a warning
+		if !needsDetection {
+			if logger != nil {
+				logger.Warn().Str("detection_failure", innerErr.Error()).Msg("cloud provider detection failed, but all required values are already provided")
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to detect cloud provider: %w", innerErr)
+	}
+
+	if ei.CloudProvider == types.CloudProviderUnknown {
+		// If detection fails but no values need to be filled, just log a warning
+		if !needsDetection {
+			if logger != nil {
+				logger.Warn().Msg("cloud provider could not be auto-detected, but all required values are already provided")
+			}
+			return nil
+		}
+		return errors.New("cloud provider could not be auto-detected, manual configuration may be required")
+	}
+
+	// Handle region configuration
+	if region != nil {
+		if *region == "" {
+			// Empty field - set with detected value
 			if ei.Region == "" {
 				return errors.New("region could not be auto-detected, manual configuration may be required")
 			}
 			*region = ei.Region
+		} else if ei.Region != "" && *region != ei.Region {
+			// Non-empty field that doesn't match detected value - log warning
+			if logger != nil {
+				logger.Warn().
+					Str("provided", *region).
+					Str("detected", ei.Region).
+					Msg("provided region does not match detected region")
+			}
 		}
+	}
 
-		if accountID != nil && *accountID == "" {
+	// Handle account ID configuration
+	if accountID != nil {
+		if *accountID == "" {
+			// Empty field - set with detected value
 			if ei.AccountID == "" {
 				return errors.New("account ID could not be auto-detected, manual configuration may be required")
 			}
 			*accountID = ei.AccountID
+		} else if ei.AccountID != "" && *accountID != ei.AccountID {
+			// Non-empty field that doesn't match detected value - log warning
+			if logger != nil {
+				logger.Warn().
+					Str("provided", *accountID).
+					Str("detected", ei.AccountID).
+					Msg("provided account ID does not match detected account ID")
+			}
 		}
+	}
 
-		if clusterName != nil && *clusterName == "" {
+	// Handle cluster name configuration
+	if clusterName != nil {
+		if *clusterName == "" {
+			// Empty field - set with detected value
 			if ei.ClusterName == "" {
 				return errors.New("cluster name could not be auto-detected, manual configuration may be required")
 			}
 			*clusterName = ei.ClusterName
+		} else if ei.ClusterName != "" && *clusterName != ei.ClusterName {
+			// Non-empty field that doesn't match detected value - log warning
+			if logger != nil {
+				logger.Warn().
+					Str("provided", *clusterName).
+					Str("detected", ei.ClusterName).
+					Msg("provided cluster name does not match detected cluster name")
+			}
 		}
 	}
 


### PR DESCRIPTION
## Why?

The agent wasn't providing visibility when manually configured values differed from auto-detected cloud environment settings. This made it difficult to debug deployment issues where operators had specified incorrect regions, account IDs, or cluster names that didn't match the actual environment.

## What

This patch tweaks DetectConfiguration to always run scout detection and emit structured warning logs when provided values don't match what's detected. The function now compares all provided values against detected ones and logs specific warnings for each mismatch, making it much easier to spot configuration problems.

## How Tested

There are several new tests, but I also tried deploying to both EKS and GKE clusters in several different configurations to make sure everything was working as expected.
