### PR TITLE
CP-30077: add Azure scout

### DIFF
--- a/app/config/validator/deployment.go
+++ b/app/config/validator/deployment.go
@@ -12,12 +12,20 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout"
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
 )
 
 type Deployment struct {
-	AccountID   string `yaml:"account_id" env:"ACCOUNT_ID" required:"true" env-description:"AWS Account ID"`
-	ClusterName string `yaml:"cluster_name" env:"CLUSTER_NAME" required:"true" env-description:"Cluster Name"`
-	Region      string `yaml:"region" env:"REGION" required:"true" env-description:"AWS Region"`
+	AccountID   string      `yaml:"account_id" env:"ACCOUNT_ID" required:"true" env-description:"AWS Account ID"`
+	ClusterName string      `yaml:"cluster_name" env:"CLUSTER_NAME" required:"true" env-description:"Cluster Name"`
+	Region      string      `yaml:"region" env:"REGION" required:"true" env-description:"AWS Region"`
+	scout       types.Scout `yaml:"-" env:"-" env-description:"Scout"`
+}
+
+// SetScout provides a way to specify a scout. By default, an auto scout will be
+// used.
+func (s *Deployment) SetScout(scout types.Scout) {
+	s.scout = scout
 }
 
 func (s *Deployment) Validate() error {
@@ -31,7 +39,7 @@ func (s *Deployment) Validate() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err := scout.DetectConfiguration(ctx, &logger, nil, &s.Region, &s.AccountID, &s.ClusterName)
+	err := scout.DetectConfiguration(ctx, &logger, s.scout, &s.Region, &s.AccountID, &s.ClusterName)
 	if err != nil {
 		return errors.Wrap(err, "failed to auto-detect cloud environment")
 	}

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -1,10 +1,38 @@
 # -- CloudZero host to send metrics to.
 host: api.cloudzero.com
-# -- Account ID of the account the cluster is running in. This must be a string - even if it is a number in your system.
+
+# Account ID of the account the cluster is running in.
+#
+# This value can be automatically detected by the CloudZero Agent on AWS (EKS),
+# Google Cloud (GKE), and Azure (AKS), but if specified explicitly the specified
+# value will be used instead of the detected value. If you wish to use the
+# detected value, leave this property set to null.
+#
+# Note also that this must be a string value, even where the account ID may be
+# numeric (e.g., an AWS account ID). i.e., `"123456789012"` not `123456789012`.
+# If you are passing this as a parameter to the Helm CLI, you should generally
+# use --set-string (e.g., "cloudAccountId=123456789012").
 cloudAccountId: null
-# -- Name of the clusters.
+
+# Name of the Kubernetes cluster.
+#
+# This value can be automatically detected reliably by the CloudZero Agent on
+# GKE. On Azure, due to Azure API limitations the cluster name can be detected
+# only if it does not contain any underscores, otherwise it may be detected
+# incorrectly. On AWS, the cluster name cannot be detected at all and you'll
+# need to pass it explicitly.
+#
+# If specified explicitly the specified value will be used instead of the
+# detected value. If you wish to use the detected value, leave this property set
+# to null.
 clusterName: ""
-# -- Region the cluster is running in.
+
+# Region the cluster is running in.
+#
+# This value can be automatically detected by the CloudZero Agent on AWS (EKS),
+# Google Cloud (GKE), and Azure (AKS), but if specified explicitly the specified
+# value will be used instead of the detected value. If you wish to use the
+# detected value, leave this property set to null.
 region: null
 
 # -- CloudZero API key. Required if existingSecretName is null.

--- a/app/functions/scout/scout.go
+++ b/app/functions/scout/scout.go
@@ -35,6 +35,7 @@ Use 'scout detect' to only identify the cloud provider.
 
 Supported cloud providers:
 - Amazon Web Services (AWS)
+- Microsoft Azure
 - Google Cloud`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runScout()
@@ -46,7 +47,7 @@ var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Retrieve cloud environment information",
 	Long: `Retrieve detailed information about the current cloud environment including:
-- Cloud provider (aws, google)
+- Cloud provider (aws, azure, google)
 - Region/location
 - Account ID/Subscription ID/Project ID`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/app/utils/scout/azure/azure.go
+++ b/app/utils/scout/azure/azure.go
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package azure provides Azure cloud environment detection and metadata retrieval
+// capabilities using the Azure Instance Metadata Service (IMDS).
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
+)
+
+const (
+	// azureMetadataURL is the URL for the Azure Instance Metadata Service (IMDS)
+	// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
+	azureMetadataURL = "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
+
+	// metadataHeader is the required header for Azure IMDS requests
+	metadataHeader = "Metadata"
+
+	// maxDNSLabelLength is the maximum length for a DNS label (RFC 1035)
+	// This applies to Kubernetes cluster names which must be valid DNS labels
+	maxDNSLabelLength = 63
+
+	requestTimeout = 5 * time.Second
+)
+
+type Scout struct {
+	client *http.Client
+}
+
+// instanceMetadata represents the structure of Azure IMDS response
+type instanceMetadata struct {
+	Compute struct {
+		Location          string `json:"location"`
+		SubscriptionID    string `json:"subscriptionId"`
+		ResourceGroupName string `json:"resourceGroupName"`
+	} `json:"compute"`
+}
+
+// NewScout creates a new Azure metadata scout
+func NewScout() *Scout {
+	return &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+		},
+	}
+}
+
+// Detect determines if the current environment is running on Azure by testing the metadata service.
+func (s *Scout) Detect(ctx context.Context) (types.CloudProvider, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", azureMetadataURL, nil)
+	if err != nil {
+		return types.CloudProviderUnknown, err
+	}
+
+	// Azure metadata service requires this header
+	req.Header.Set(metadataHeader, "true")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		// Network errors mean we can't detect, but not an error condition
+		return types.CloudProviderUnknown, nil
+	}
+	defer resp.Body.Close()
+
+	// Consider 2xx status codes as successful detection
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return types.CloudProviderAzure, nil
+	}
+
+	return types.CloudProviderUnknown, nil
+}
+
+// EnvironmentInfo retrieves Azure environment information from Instance Metadata Service
+func (s *Scout) EnvironmentInfo(ctx context.Context) (*types.EnvironmentInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", azureMetadataURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Azure metadata service requires this header
+	req.Header.Set(metadataHeader, "true")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Azure metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get Azure metadata, status: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Azure metadata response: %w", err)
+	}
+
+	var metadata instanceMetadata
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to parse Azure metadata JSON: %w", err)
+	}
+
+	if metadata.Compute.SubscriptionID == "" {
+		return nil, errors.New("subscriptionId not found in Azure metadata")
+	}
+
+	if metadata.Compute.Location == "" {
+		return nil, errors.New("location not found in Azure metadata")
+	}
+
+	// Extract cluster name using heuristic approach (best effort)
+	clusterName := s.extractClusterName(metadata.Compute.ResourceGroupName)
+
+	return &types.EnvironmentInfo{
+		CloudProvider: types.CloudProviderAzure,
+		Region:        strings.TrimSpace(metadata.Compute.Location),
+		AccountID:     strings.TrimSpace(metadata.Compute.SubscriptionID),
+		ClusterName:   clusterName,
+	}, nil
+}
+
+// extractClusterName attempts to extract the AKS cluster name from the managed
+// resource group name.
+//
+// Note that Azure IMDS only provides the managed resource group information
+// (MC_*), not the original resource group where the AKS cluster was created.
+// This creates a fundamental ambiguity in parsing cluster names when both
+// resource group and cluster names contain underscores.
+//
+// Azure AKS creates a managed resource group with the pattern:
+// MC_{resourceGroupName}_{clusterName}_{region}
+//
+// This implementation assumes cluster names do not contain underscores, but
+// resource group names might. Under this assumption, we can parse
+// deterministically:
+//
+// - The region is the last underscore-separated component
+// - The cluster name is the second-to-last component
+// - The resource group name is everything between "MC_" and "_{clusterName}_{region}"
+//
+// However, note that the cluster name *can* contain underscores. In this
+// situation, you will unfortunately need to specify the cluster name manually.
+func (s *Scout) extractClusterName(resourceGroupName string) string {
+	// Must start with "MC_"
+	if !strings.HasPrefix(resourceGroupName, "MC_") {
+		return ""
+	}
+
+	// Remove "MC_" prefix and split by underscores
+	withoutPrefix := strings.TrimPrefix(resourceGroupName, "MC_")
+	parts := strings.Split(withoutPrefix, "_")
+
+	// Need at least 3 parts: {resourceGroup}_{clusterName}_{region}
+	// Resource group could be multiple parts joined by underscores
+	if len(parts) < 3 {
+		return ""
+	}
+
+	// Under the assumption that cluster names don't contain underscores:
+	// - parts[len(parts)-1] is the region
+	// - parts[len(parts)-2] is the cluster name
+	clusterName := parts[len(parts)-2]
+
+	// Validate cluster name (basic DNS label validation)
+	if len(clusterName) == 0 || len(clusterName) > maxDNSLabelLength {
+		return ""
+	}
+
+	return clusterName
+}

--- a/app/utils/scout/azure/azure_test.go
+++ b/app/utils/scout/azure/azure_test.go
@@ -1,0 +1,463 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package azure
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	validAzureMetadataResponse = `{
+		"compute": {
+			"location": "eastus",
+			"subscriptionId": "f192f712-2862-4c95-9d8b-fc95c72dc795",
+			"resourceGroupName": "MC_azure-cirrus-evan_azure-cirrus-evan_eastus"
+		}
+	}`
+
+	minimalAzureMetadataResponse = `{
+		"compute": {
+			"location": "westus2",
+			"subscriptionId": "12345678-1234-1234-1234-123456789012",
+			"resourceGroupName": "MC_my-rg_my-cluster_westus2"
+		}
+	}`
+
+	complexAzureMetadataResponse = `{
+		"compute": {
+			"location": "northeurope",
+			"subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+			"resourceGroupName": "MC_my_complex_rg_my_test_cluster_v2_northeurope"
+		}
+	}`
+)
+
+func TestNewScout(t *testing.T) {
+	scout := NewScout()
+	assert.NotNil(t, scout)
+	assert.NotNil(t, scout.client)
+	assert.Equal(t, requestTimeout, scout.client.Timeout)
+}
+
+func TestScout_Detect_Success(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		expected   types.CloudProvider
+	}{
+		{
+			name:       "successful detection with 200",
+			statusCode: 200,
+			expected:   types.CloudProviderAzure,
+		},
+		{
+			name:       "successful detection with 201",
+			statusCode: 201,
+			expected:   types.CloudProviderAzure,
+		},
+		{
+			name:       "successful detection with 202",
+			statusCode: 202,
+			expected:   types.CloudProviderAzure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "true", r.Header.Get("Metadata"))
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(validAzureMetadataResponse))
+			}))
+			defer server.Close()
+
+			scout := createScoutWithCustomURL(server.URL)
+			ctx := context.Background()
+
+			result, err := scout.Detect(ctx)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestScout_Detect_NotAzure(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		expected   types.CloudProvider
+	}{
+		{
+			name:       "detection fails with 404",
+			statusCode: 404,
+			expected:   types.CloudProviderUnknown,
+		},
+		{
+			name:       "detection fails with 500",
+			statusCode: 500,
+			expected:   types.CloudProviderUnknown,
+		},
+		{
+			name:       "detection fails with 403",
+			statusCode: 403,
+			expected:   types.CloudProviderUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			scout := createScoutWithCustomURL(server.URL)
+			ctx := context.Background()
+
+			result, err := scout.Detect(ctx)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestScout_Detect_NetworkError(t *testing.T) {
+	scout := NewScout()
+	scout.client.Timeout = 10 * time.Millisecond // Very short timeout
+
+	ctx := context.Background()
+	result, err := scout.Detect(ctx)
+
+	// Network errors should not return an error, just unknown provider
+	assert.NoError(t, err)
+	assert.Equal(t, types.CloudProviderUnknown, result)
+}
+
+func TestScout_Detect_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate slow response
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(validAzureMetadataResponse))
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURL(server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result, err := scout.Detect(ctx)
+
+	// Network errors return no error, but context timeout should return unknown
+	assert.NoError(t, err)
+	assert.Equal(t, types.CloudProviderUnknown, result)
+}
+
+func TestScout_EnvironmentInfo_Success(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseBody string
+		expectedInfo *types.EnvironmentInfo
+	}{
+		{
+			name:         "successful environment info retrieval",
+			responseBody: validAzureMetadataResponse,
+			expectedInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderAzure,
+				Region:        "eastus",
+				AccountID:     "f192f712-2862-4c95-9d8b-fc95c72dc795",
+				ClusterName:   "azure-cirrus-evan",
+			},
+		},
+		{
+			name:         "environment info with simple resource group pattern",
+			responseBody: minimalAzureMetadataResponse,
+			expectedInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderAzure,
+				Region:        "westus2",
+				AccountID:     "12345678-1234-1234-1234-123456789012",
+				ClusterName:   "my-cluster",
+			},
+		},
+		{
+			name:         "environment info with complex resource group pattern",
+			responseBody: complexAzureMetadataResponse,
+			expectedInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderAzure,
+				Region:        "northeurope",
+				AccountID:     "abcdef12-3456-7890-abcd-ef1234567890",
+				ClusterName:   "v2",
+			},
+		},
+		{
+			name:         "handles whitespace in response fields",
+			responseBody: `{"compute": {"location": "  eastus  ", "subscriptionId": "  12345  ", "resourceGroupName": "MC_rg_cluster_eastus"}}`,
+			expectedInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderAzure,
+				Region:        "eastus",
+				AccountID:     "12345",
+				ClusterName:   "cluster",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "true", r.Header.Get("Metadata"))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			scout := createScoutWithCustomURL(server.URL)
+			ctx := context.Background()
+
+			result, err := scout.EnvironmentInfo(ctx)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedInfo, result)
+		})
+	}
+}
+
+func TestScout_EnvironmentInfo_Errors(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		responseBody  string
+		errorContains string
+	}{
+		{
+			name:          "error on non-200 status",
+			statusCode:    500,
+			responseBody:  "",
+			errorContains: "failed to get Azure metadata, status: 500",
+		},
+		{
+			name:          "error on invalid JSON",
+			statusCode:    200,
+			responseBody:  `{invalid json`,
+			errorContains: "failed to parse Azure metadata JSON",
+		},
+		{
+			name:          "error on missing subscription ID",
+			statusCode:    200,
+			responseBody:  `{"compute": {"location": "eastus", "resourceGroupName": "MC_rg_cluster_eastus"}}`,
+			errorContains: "subscriptionId not found in Azure metadata",
+		},
+		{
+			name:          "error on missing location",
+			statusCode:    200,
+			responseBody:  `{"compute": {"subscriptionId": "12345", "resourceGroupName": "MC_rg_cluster_eastus"}}`,
+			errorContains: "location not found in Azure metadata",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if tt.responseBody != "" {
+					_, _ = w.Write([]byte(tt.responseBody))
+				}
+			}))
+			defer server.Close()
+
+			scout := createScoutWithCustomURL(server.URL)
+			ctx := context.Background()
+
+			result, err := scout.EnvironmentInfo(ctx)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errorContains)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestScout_EnvironmentInfo_NetworkError(t *testing.T) {
+	scout := NewScout()
+	scout.client.Timeout = 10 * time.Millisecond // Very short timeout
+
+	ctx := context.Background()
+	result, err := scout.EnvironmentInfo(ctx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get Azure metadata")
+	assert.Nil(t, result)
+}
+
+func TestScout_EnvironmentInfo_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate slow response
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(validAzureMetadataResponse))
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURL(server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result, err := scout.EnvironmentInfo(ctx)
+
+	// Should get context timeout error
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.Nil(t, result)
+}
+
+func TestScout_EnvironmentInfo_ReadError(t *testing.T) {
+	// Create a server that closes the connection after sending headers
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Write headers but then close connection before body
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		if conn, ok := w.(http.Hijacker); ok {
+			if c, _, err := conn.Hijack(); err == nil {
+				_ = c.Close()
+			}
+		}
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURL(server.URL)
+	ctx := context.Background()
+
+	result, err := scout.EnvironmentInfo(ctx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read Azure metadata response")
+	assert.Nil(t, result)
+}
+
+func TestScout_extractClusterName(t *testing.T) {
+	s := &Scout{}
+	tests := []struct {
+		name                 string
+		managedResourceGroup string
+		expected             string
+	}{
+		{
+			name:                 "standard pattern",
+			managedResourceGroup: "MC_my-rg_my-cluster_eastus",
+			expected:             "my-cluster",
+		},
+		{
+			name:                 "resource group with underscores",
+			managedResourceGroup: "MC_my_test_rg_cluster-name_westus2",
+			expected:             "cluster-name",
+		},
+		{
+			name:                 "complex resource group name",
+			managedResourceGroup: "MC_prod_web_services_rg_aks-cluster_centralus",
+			expected:             "aks-cluster",
+		},
+		{
+			name:                 "single character components",
+			managedResourceGroup: "MC_a_b_c",
+			expected:             "b",
+		},
+		{
+			name:                 "actual example from berlioz cluster",
+			managedResourceGroup: "MC_azure-cirrus-evan_azure-cirrus-evan_eastus",
+			expected:             "azure-cirrus-evan",
+		},
+		{
+			name:                 "invalid format - missing MC prefix",
+			managedResourceGroup: "azure-cirrus-evan_azure-cirrus-evan_eastus",
+			expected:             "",
+		},
+		{
+			name:                 "invalid format - too few parts",
+			managedResourceGroup: "MC_rg_cluster",
+			expected:             "",
+		},
+		{
+			name:                 "invalid format - only MC",
+			managedResourceGroup: "MC_",
+			expected:             "",
+		},
+		{
+			name:                 "empty string",
+			managedResourceGroup: "",
+			expected:             "",
+		},
+		{
+			name:                 "cluster name too long",
+			managedResourceGroup: "MC_rg_" + strings.Repeat("a", 64) + "_eastus",
+			expected:             "",
+		},
+		{
+			name:                 "cluster name at length limit",
+			managedResourceGroup: "MC_rg_" + strings.Repeat("a", 63) + "_eastus",
+			expected:             strings.Repeat("a", 63),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.extractClusterName(tt.managedResourceGroup)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper functions
+
+// createScoutWithCustomURL creates a scout for testing with a custom URL
+func createScoutWithCustomURL(baseURL string) *Scout {
+	return &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+			Transport: &customTransport{
+				baseURL: baseURL,
+			},
+		},
+	}
+}
+
+// customTransport redirects Azure metadata requests to a test server
+type customTransport struct {
+	baseURL string
+}
+
+func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace the Azure metadata URL with our test server URL
+	newURL := strings.Replace(req.URL.String(), "http://169.254.169.254", t.baseURL, 1)
+
+	newReq := req.Clone(req.Context())
+	var err error
+	newReq.URL, err = newReq.URL.Parse(newURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.DefaultTransport.RoundTrip(newReq)
+}
+
+func TestConstants(t *testing.T) {
+	// Test that constants are properly defined
+	assert.Equal(t, "http://169.254.169.254/metadata/instance?api-version=2021-02-01", azureMetadataURL)
+	assert.Equal(t, "Metadata", metadataHeader)
+	assert.Equal(t, 63, maxDNSLabelLength)
+	assert.Equal(t, 5*time.Second, requestTimeout)
+}

--- a/app/utils/scout/azure/azure_test.go
+++ b/app/utils/scout/azure/azure_test.go
@@ -133,8 +133,15 @@ func TestScout_Detect_NotAzure(t *testing.T) {
 }
 
 func TestScout_Detect_NetworkError(t *testing.T) {
-	scout := NewScout()
-	scout.client.Timeout = 10 * time.Millisecond // Very short timeout
+	// Use custom transport that simulates network failure
+	scout := &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+			Transport: &customTransport{
+				baseURL: "http://192.0.2.1", // RFC 5737 TEST-NET-1 - guaranteed unreachable
+			},
+		},
+	}
 
 	ctx := context.Background()
 	result, err := scout.Detect(ctx)
@@ -290,8 +297,15 @@ func TestScout_EnvironmentInfo_Errors(t *testing.T) {
 }
 
 func TestScout_EnvironmentInfo_NetworkError(t *testing.T) {
-	scout := NewScout()
-	scout.client.Timeout = 10 * time.Millisecond // Very short timeout
+	// Use custom transport that simulates network failure
+	scout := &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+			Transport: &customTransport{
+				baseURL: "http://192.0.2.1", // RFC 5737 TEST-NET-1 - guaranteed unreachable
+			},
+		},
+	}
 
 	ctx := context.Background()
 	result, err := scout.EnvironmentInfo(ctx)

--- a/app/utils/scout/scout.go
+++ b/app/utils/scout/scout.go
@@ -8,6 +8,7 @@ package scout
 import (
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/auto"
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/aws"
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/azure"
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/google"
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
 )
@@ -16,6 +17,7 @@ import (
 func NewScout() types.Scout {
 	return auto.NewScout(
 		aws.NewScout(),
+		azure.NewScout(),
 		google.NewScout(),
 	)
 }

--- a/app/utils/scout/types/types.go
+++ b/app/utils/scout/types/types.go
@@ -17,6 +17,8 @@ const (
 	CloudProviderAWS CloudProvider = "aws"
 	// CloudProviderGoogle represents Google Cloud Platform
 	CloudProviderGoogle CloudProvider = "google"
+	// CloudProviderAzure represents Microsoft Azure
+	CloudProviderAzure CloudProvider = "azure"
 	// CloudProviderUnknown represents an undetected or unsupported cloud provider
 	CloudProviderUnknown CloudProvider = "unknown"
 	// CloudProviderMock represents a mock provider for testing

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,10 +1,38 @@
 # -- CloudZero host to send metrics to.
 host: api.cloudzero.com
-# -- Account ID of the account the cluster is running in. This must be a string - even if it is a number in your system.
+
+# Account ID of the account the cluster is running in.
+#
+# This value can be automatically detected by the CloudZero Agent on AWS (EKS),
+# Google Cloud (GKE), and Azure (AKS), but if specified explicitly the specified
+# value will be used instead of the detected value. If you wish to use the
+# detected value, leave this property set to null.
+#
+# Note also that this must be a string value, even where the account ID may be
+# numeric (e.g., an AWS account ID). i.e., `"123456789012"` not `123456789012`.
+# If you are passing this as a parameter to the Helm CLI, you should generally
+# use --set-string (e.g., "cloudAccountId=123456789012").
 cloudAccountId: null
-# -- Name of the clusters.
+
+# Name of the Kubernetes cluster.
+#
+# This value can be automatically detected reliably by the CloudZero Agent on
+# GKE. On Azure, due to Azure API limitations the cluster name can be detected
+# only if it does not contain any underscores, otherwise it may be detected
+# incorrectly. On AWS, the cluster name cannot be detected at all and you'll
+# need to pass it explicitly.
+#
+# If specified explicitly the specified value will be used instead of the
+# detected value. If you wish to use the detected value, leave this property set
+# to null.
 clusterName: ""
-# -- Region the cluster is running in.
+
+# Region the cluster is running in.
+#
+# This value can be automatically detected by the CloudZero Agent on AWS (EKS),
+# Google Cloud (GKE), and Azure (AKS), but if specified explicitly the specified
+# value will be used instead of the detected value. If you wish to use the
+# detected value, leave this property set to null.
 region: null
 
 # -- CloudZero API key. Required if existingSecretName is null.


### PR DESCRIPTION
## Why?

To automatically detect values in AKS

## What

Added an Azure scout.

The cluster name detection is a bit dodgy; the problem is that Azure IMDS provides a single string for both the resource group name and the cluster name: `MC_{resourceGroupName}_{clusterName}_{region}`.

Unfortunately, both resourceGroupName and clusterName can contain underscores, so without knowledge of either parsing is ambiguous. For example, for "MC_foo_bar_baz_qux_useast1", the clusterName could conceivably be bar_baz_qux, baz_qux, or qux.

While Kubernetes clusters *can* include underscores, it is considered best practice to avoid them (generally using dashes instead). Therefore, this scout will assume that the cluster name does *not* contain any underscores. If a cluster name contains underscores, you will need to manually specify the cluster name.

## How Tested

There are a bunch of tests included in this PR, but I've also tested by deploying to an AKS cluster.