### PR TITLE
CP-30251: Fix validator environment

### DIFF
--- a/app/domain/diagnostic/k8s/namespace/check_test.go
+++ b/app/domain/diagnostic/k8s/namespace/check_test.go
@@ -19,7 +19,7 @@ func TestUnit_Diagnostic_K8s_Namespace_CheckOK(t *testing.T) {
 
 	// set the namespace for the test
 	expectedNs := "test-ns"
-	os.Setenv("NAMESPACE", expectedNs)
+	os.Setenv("K8S_NAMESPACE", expectedNs)
 
 	provider := namespace.NewProvider(context.Background(), cfg)
 

--- a/app/domain/diagnostic/k8s/provider/check.go
+++ b/app/domain/diagnostic/k8s/provider/check.go
@@ -6,15 +6,14 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"path/filepath"
 
 	config "github.com/cloudzero/cloudzero-agent/app/config/validator"
 	"github.com/cloudzero/cloudzero-agent/app/domain/diagnostic"
 	"github.com/cloudzero/cloudzero-agent/app/domain/diagnostic/common"
+	"github.com/cloudzero/cloudzero-agent/app/domain/k8s"
 	logging "github.com/cloudzero/cloudzero-agent/app/logging/validator"
 	"github.com/cloudzero/cloudzero-agent/app/types/status"
 	"github.com/sirupsen/logrus"
@@ -58,14 +57,14 @@ func (c *checker) Check(ctx context.Context, client *http.Client, accessor statu
 }
 
 func (c *checker) getProviderID(ctx context.Context) (string, error) {
-	// ensure the correct env variables were injected
-	ns, exists := os.LookupEnv("NAMESPACE")
-	if !exists {
-		return "", errors.New("the env variable `NAMESPACE` must exist")
+	// get the required values
+	ns, err := k8s.GetNamespace()
+	if err != nil {
+		return "", err
 	}
-	name, exists := os.LookupEnv("POD_NAME")
-	if !exists {
-		return "", errors.New("the env variable `POD_NAME` must exist")
+	name, err := k8s.GetPodName()
+	if err != nil {
+		return "", err
 	}
 
 	// create the k8s client

--- a/app/domain/diagnostic/k8s/provider/check_test.go
+++ b/app/domain/diagnostic/k8s/provider/check_test.go
@@ -22,8 +22,8 @@ func TestUnit_Diagnostic_K8s_Provider_CheckOK(t *testing.T) {
 	// set this to the namespace and the pod name you have currently running within a
 	// local kubernetes cluster.
 	// TODO: we should run some tests inside of a k8s cluster
-	os.Setenv("NAMESPACE", "flux-system")
-	os.Setenv("POD_NAME", "flux-59dbfd5444-dlr5c")
+	os.Setenv("K8S_NAMESPACE", "flux-system")
+	os.Setenv("K8S_POD_NAME", "flux-59dbfd5444-dlr5c")
 
 	p := provider.NewProvider(t.Context(), cfg)
 	accessor := status.NewAccessor(&status.ClusterStatus{})


### PR DESCRIPTION
## Why?

> The branch name is incorrect

There namespace aware values were not using the right namespace in the validator. We were looking for `NAMESPACE` when we should be looking for `K8S_NAMESPACE`. The confload job does it correctly, but we never updated the validator to use the shared values.

```
│ 2025-07-02T17:08:29Z │ 1.2.2         │ 1.26            │ {'k8s_namespace': {'message': 'the env variable `NAMESPACE` must exist',         │ POD_STARTED  │
│                      │               │                 │ 'passing': False}, 'k8s_provider': {'message': 'the env variable `NAMESPACE`     │              │
│                      │               │                 │ must exist', 'passing': False}, 'k8s_version': {'message': None, 'passing':      │              │
│                      │               │                 │ True}, 'kube_state_metrics_reachable': {'message': 'Failed to fetch metrics      │              │
│                      │               │                 │ after 12 retries', 'passing': False}, 'scrape_cfg': {'message': None, 'passing': │              │
│                      │               │                 │ True}, 'prometheus_version': {'message': None, 'passing': True},                 │              │
│                      │               │                 │ 'webhook_server_reachable': {'message': 'received non-2xx response from          │              │
│                      │               │                 │ https://cloudzero-server-webhook-svc.cloudzero.svc.cluster.local/validate after  │              │
│                      │               │                 │ 6 retries: webhook request failed: Post                                          │              │
│                      │               │                 │ "https://cloudzero-server-webhook-svc.cloudzero.svc.cluster.local/validate":     │              │
│                      │               │                 │ context deadline exceeded', 'passing': False}}
```