### PR TITLE
CP-30254: explicitly list types we're interested in for admission controller

### DIFF
--- a/app/types/k8s_object.go
+++ b/app/types/k8s_object.go
@@ -21,6 +21,9 @@ const (
 	V1Beta2 = "v1beta2"
 	V1Beta1 = "v1beta1"
 
+	// Important: when adding a new resource type, please remember to also
+	// update the list in the webhook-validating-config.yaml template in the
+	// Helm chart.
 	KindDeployment            = "deployment"
 	KindStatefulSet           = "statefulset"
 	KindDaemonSet             = "daemonset"

--- a/helm/templates/webhook-validating-config.yaml
+++ b/helm/templates/webhook-validating-config.yaml
@@ -22,7 +22,26 @@ webhooks:
       - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["*"]
+        resources:
+          {{/* See app/types/k8s_object.go for the list of supported resources */}}
+          - deployment
+          - statefulset
+          - daemonset
+          - replicaset
+          - pod
+          - namespace
+          - node
+          - service
+          - storageclass
+          - persistentvolume
+          - persistentvolumeclaim
+          - job
+          - cronjob
+          - customresourcedefinition
+          - ingress
+          - ingressclass
+          - gateway
+          - gatewayclass
         scope: "*"
     clientConfig:
       service:

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -2738,7 +2738,26 @@ webhooks:
       - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["*"]
+        resources:
+          
+          - deployment
+          - statefulset
+          - daemonset
+          - replicaset
+          - pod
+          - namespace
+          - node
+          - service
+          - storageclass
+          - persistentvolume
+          - persistentvolumeclaim
+          - job
+          - cronjob
+          - customresourcedefinition
+          - ingress
+          - ingressclass
+          - gateway
+          - gatewayclass
         scope: "*"
     clientConfig:
       service:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -3010,7 +3010,26 @@ webhooks:
       - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["*"]
+        resources:
+          
+          - deployment
+          - statefulset
+          - daemonset
+          - replicaset
+          - pod
+          - namespace
+          - node
+          - service
+          - storageclass
+          - persistentvolume
+          - persistentvolumeclaim
+          - job
+          - cronjob
+          - customresourcedefinition
+          - ingress
+          - ingressclass
+          - gateway
+          - gatewayclass
         scope: "*"
     clientConfig:
       service:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -2808,7 +2808,26 @@ webhooks:
       - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: ["*"]
+        resources:
+          
+          - deployment
+          - statefulset
+          - daemonset
+          - replicaset
+          - pod
+          - namespace
+          - node
+          - service
+          - storageclass
+          - persistentvolume
+          - persistentvolumeclaim
+          - job
+          - cronjob
+          - customresourcedefinition
+          - ingress
+          - ingressclass
+          - gateway
+          - gatewayclass
         scope: "*"
     clientConfig:
       service:


### PR DESCRIPTION
## References and Reports
* https://github.com/Cloudzero/cloudzero-charts/issues/207

## Why?

Avoiding unnecessary load on the Webhook Server.

## What

Instead of requesting that Kubernetes sends us *all* resources, this requests only the resources we are interested in. This should significantly reduce traffic to the Webhook Server.

## How Tested

Deploy.