### PR TITLE
CP-30274: allow re-releasing

### DIFF
--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -45,7 +45,11 @@ jobs:
           sed -ri "s/^( *[a-z]*): +[^ ]+  (# <- Software release corresponding to this chart version.)$/\1: ${{ github.event.inputs.version }}  \2/" helm/values.yaml helm/templates/_helpers.tpl
           make helm-generate-tests format app/functions/helmless/default-values.yaml
           git add helm/values.yaml helm/templates/*.tpl tests/helm/template/*.yaml app/functions/helmless/default-values.yaml
-          git commit -m "Update image version in Helm chart to ${{ github.event.inputs.version }}"
+          if ! git diff --quiet --staged; then
+            git commit -m "Update image version in Helm chart to ${{ github.event.inputs.version }}"
+          else
+            echo "No changes to commit - files are already up to date for version ${{ github.event.inputs.version }}"
+          fi
 
       - name: Checkout main branch
         run: git checkout main


### PR DESCRIPTION
## Why?

Sometimes something goes wrong with a release, and we want to re-release after fixing. Unfortunately, the workflow to bump the version number in the chart will fail in this case.

## What

This just updates the workflow to account for when setting the version number to the new release is a no-op.

## How Tested

I didn't. Sorry, it's a corner case in an action that's hard to test... I did test the code in a terminal, though!