### PR TITLE
CP-30281: remove unused PVC mount code from the aggregator

### DIFF
--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -146,18 +146,6 @@ spec:
           secret:
             secretName: {{ include "cloudzero-agent.secretName" . }}
         {{- end }}
-        - name: cloudzero-agent-storage-volume
-        {{- if .Values.server.persistentVolume.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ if .Values.server.persistentVolume.existingClaim }}{{ .Values.server.persistentVolume.existingClaim }}{{- else }}{{ template "cloudzero-agent.server.fullname" . }}{{- end }}
-        {{- else }}
-          emptyDir:
-          {{- if .Values.server.emptyDir.sizeLimit }}
-            sizeLimit: {{ .Values.server.emptyDir.sizeLimit }}
-          {{- else }}
-            {}
-          {{- end }}
-        {{- end }}
         - name: aggregator-config-volume
           configMap:
             name: {{ include "cloudzero-agent.aggregator.name" . }}

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -2312,9 +2312,6 @@ spec:
         - name: cloudzero-api-key
           secret:
             secretName: cz-agent-api-key
-        - name: cloudzero-agent-storage-volume
-          emptyDir:
-            sizeLimit: 8Gi
         - name: aggregator-config-volume
           configMap:
             name: cz-agent-aggregator

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -2530,9 +2530,6 @@ spec:
         - name: cloudzero-api-key
           secret:
             secretName: cz-agent-api-key
-        - name: cloudzero-agent-storage-volume
-          emptyDir:
-            sizeLimit: 8Gi
         - name: aggregator-config-volume
           configMap:
             name: cz-agent-aggregator

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -2328,9 +2328,6 @@ spec:
         - name: cloudzero-api-key
           secret:
             secretName: cz-agent-api-key
-        - name: cloudzero-agent-storage-volume
-          emptyDir:
-            sizeLimit: 8Gi
         - name: aggregator-config-volume
           configMap:
             name: cz-agent-aggregator


### PR DESCRIPTION
## Why?

The PVC mount code is not used within the aggregator, so we should remove it incase customers set affinity rules for server and aggregator pods to be placed on the same nodes. If that happens, then both the agent and aggregator pod will request to mount the PVC on the same node, but this is not allowed with the `ReadWriteOnce` PVC request type which is standard for most storage backends.

Related issue: https://cloudzero.atlassian.net/browse/CP-30004