### PR TITLE
CP-30738: change dependabot day from Friday to Wednesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "friday"
+      day: "wednesday"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -16,7 +16,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "friday"
+      day: "wednesday"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -27,7 +27,7 @@ updates:
     directory: "/docker/"
     schedule:
       interval: "weekly"
-      day: "friday"
+      day: "wednesday"
     commit-message:
       prefix: "CP-29639: "
 
@@ -35,7 +35,7 @@ updates:
     directory: "/.tools/"
     schedule:
       interval: "weekly"
-      day: "friday"
+      day: "wednesday"
     commit-message:
       prefix: "CP-29639: "
 
@@ -43,6 +43,6 @@ updates:
     directory: "/helm/"
     schedule:
       interval: "weekly"
-      day: "friday"
+      day: "wednesday"
     commit-message:
       prefix: "CP-29639: "


### PR DESCRIPTION
## Why?

The thinking is that patches generally come out on Tuesdays, we update our dependencies on Wednesdays, and do a release (if desired) on Thursday.

## What

Change dependabot day from Friday to Wednesday

## How Tested

😇 