### PR TITLE
CP-30604: implement HPA autoscaling with custom metrics API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,7 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# AI files to temporarily ignore, until we're ready to commit them
+CLAUDE.md
+/.cursor

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": ".cursor/rules/*.mdc",
+      "options": {
+        "parser": "markdown"
+      }
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,8 @@ ifneq ($(REGENERATE),never)
 app/functions/helmless/default-values.yaml: helm/values.yaml $(wildcard helm/*.yaml helm/templates/*.yaml helm/templates/*.tpl helm/*.yaml)
 	$(HELM) show values ./helm | $(PRETTIER) --stdin-filepath $@ > $@
 
+generate: app/functions/helmless/default-values.yaml
+
 bin/cloudzero-helmless: app/functions/helmless/default-values.yaml
 
 # Add the embedded defaults file to dependencies

--- a/app/config/gator/settings.go
+++ b/app/config/gator/settings.go
@@ -43,11 +43,12 @@ type Settings struct {
 	Region         string `yaml:"region" env:"CSP_REGION" env-description:"cloud service provider region"`
 	ClusterName    string `yaml:"cluster_name" env:"CLUSTER_NAME" env-description:"name of the cluster to monitor"`
 
-	Server    Server    `yaml:"server"`
-	Logging   Logging   `yaml:"logging"`
-	Database  Database  `yaml:"database"`
-	Cloudzero Cloudzero `yaml:"cloudzero"`
-	Metrics   Metrics   `yaml:"metrics"`
+	Server      Server      `yaml:"server"`
+	Logging     Logging     `yaml:"logging"`
+	Database    Database    `yaml:"database"`
+	Cloudzero   Cloudzero   `yaml:"cloudzero"`
+	Metrics     Metrics     `yaml:"metrics"`
+	Certificate Certificate `yaml:"certificate"`
 
 	mu sync.Mutex
 }
@@ -59,6 +60,11 @@ type Metrics struct {
 	ObservabilityLabels []filter.FilterEntry `yaml:"observability_labels"`
 }
 
+type Certificate struct {
+	Cert string `yaml:"cert" env:"CERT_PATH" env-description:"path to TLS certificate file"`
+	Key  string `yaml:"key" env:"KEY_PATH" env-description:"path to TLS key file"`
+}
+
 type Logging struct {
 	Level   string `yaml:"level" default:"info" env:"LOG_LEVEL" env-description:"logging level such as debug, info, error"`
 	Capture bool   `yaml:"capture" default:"true" env:"LOG_CAPTURE" env-description:"whether to persist logs to disk or not"`
@@ -66,9 +72,9 @@ type Logging struct {
 
 type Database struct {
 	StoragePath              string        `yaml:"storage_path" default:"/cloudzero/data" env:"DATABASE_STORAGE_PATH" env-description:"location where to write database"`
-	MaxRecords               int           `yaml:"max_records" default:"1000000" env:"MAX_RECORDS_PER_FILE" env-description:"maximum records per file"`
+	MaxRecords               int           `yaml:"max_records" default:"1500000" env:"MAX_RECORDS_PER_FILE" env-description:"maximum records per file"`
 	CompressionLevel         int           `yaml:"compression_level" default:"8" env:"DATABASE_COMPRESS_LEVEL" env-description:"compression level for database files"`
-	CostMaxInterval          time.Duration `yaml:"cost_max_interval" default:"10m" env:"COST_MAX_INTERVAL" env-description:"maximum interval to wait before flushing cost metrics"`
+	CostMaxInterval          time.Duration `yaml:"cost_max_interval" default:"30m" env:"COST_MAX_INTERVAL" env-description:"maximum interval to wait before flushing cost metrics"`
 	ObservabilityMaxInterval time.Duration `yaml:"observability_max_interval" default:"10m" env:"OBSERVABILITY_MAX_INTERVAL" env-description:"maximum interval to wait before flushing observability metrics"`
 
 	PurgeRules       PurgeRules `yaml:"purge_rules"`
@@ -82,8 +88,9 @@ type PurgeRules struct {
 }
 
 type Server struct {
-	Mode               string `yaml:"mode" default:"http" env:"SERVER_MODE" env-description:"server mode such as http, https"`
+	Mode               string `yaml:"mode" default:"http" env:"SERVER_MODE" env-description:"server mode such as http, https, dual"`
 	Port               uint   `yaml:"port" default:"8080" env:"SERVER_PORT" env-description:"server port"`
+	TLSPort            uint   `yaml:"tls_port" default:"8443" env:"SERVER_TLS_PORT" env-description:"server TLS port"`
 	Profiling          bool   `yaml:"profiling" default:"false" env:"SERVER_PROFILING" env-description:"enable profiling"`
 	ReconnectFrequency int    `yaml:"reconnect_frequency" default:"16" env:"SERVER_RECONNECT_FREQUENCY" env-description:"how frequently to close HTTP connections from clients, to distribute the load. 0=never, otherwise 1/N probability."`
 }

--- a/app/domain/metric_collector_test.go
+++ b/app/domain/metric_collector_test.go
@@ -40,6 +40,8 @@ func TestPutMetrics(t *testing.T) {
 		storage := mocks.NewMockStore(ctrl)
 		storage.EXPECT().Put(ctx, gomock.Any()).Return(nil)
 		storage.EXPECT().Flush().Return(nil)
+		storage.EXPECT().Pending().Return(0).AnyTimes()                // For the shipping progress metric
+		storage.EXPECT().ElapsedTime().Return(int64(10000)).AnyTimes() // For the time-based shipping progress metric
 		d, err := domain.NewMetricCollector(&cfg, mockClock, storage, nil)
 		require.NoError(t, err)
 		defer d.Close()
@@ -55,6 +57,8 @@ func TestPutMetrics(t *testing.T) {
 		storage := mocks.NewMockStore(ctrl)
 		storage.EXPECT().Put(ctx, gomock.Any()).Return(nil)
 		storage.EXPECT().Flush().Return(nil)
+		storage.EXPECT().Pending().Return(0).AnyTimes()                // For the shipping progress metric
+		storage.EXPECT().ElapsedTime().Return(int64(10000)).AnyTimes() // For the time-based shipping progress metric
 		d, err := domain.NewMetricCollector(&cfg, mockClock, storage, nil)
 		require.NoError(t, err)
 		defer d.Close()
@@ -72,5 +76,152 @@ func TestPutMetrics(t *testing.T) {
 		stats, err := d.PutMetrics(ctx, "application/x-protobuf;proto=io.prometheus.write.v2.Request", "snappy", payload)
 		assert.NoError(t, err)
 		assert.NotNil(t, stats)
+	})
+}
+
+func TestCostMetricsShippingProgressMetric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name                     string
+		maxRecords               int
+		pendingRecords           int
+		elapsedTimeMs            int64
+		expectedProgress         float64
+		expectMetricUpdateCalled bool
+	}{
+		{
+			name:                     "zero pending records",
+			maxRecords:               1000,
+			pendingRecords:           0,
+			elapsedTimeMs:            10000, // 10 seconds
+			expectedProgress:         0.0,
+			expectMetricUpdateCalled: true,
+		},
+		{
+			name:                     "10 seconds elapsed with expected rate",
+			maxRecords:               1000,
+			pendingRecords:           6, // Expected: (10000/1800000) * 1000 = 5.56, actual: 6, so 6/5.56 ≈ 1.08
+			elapsedTimeMs:            10000,
+			expectedProgress:         1.08,
+			expectMetricUpdateCalled: true,
+		},
+		{
+			name:                     "30 seconds elapsed with expected rate",
+			maxRecords:               1000,
+			pendingRecords:           17, // Expected: (30000/1800000) * 1000 = 16.67, actual: 17, so 17/16.67 ≈ 1.02
+			elapsedTimeMs:            30000,
+			expectedProgress:         1.02,
+			expectMetricUpdateCalled: true,
+		},
+		{
+			name:                     "5 minutes elapsed with expected rate",
+			maxRecords:               1000,
+			pendingRecords:           167, // Expected: (300000/1800000) * 1000 = 166.67, actual: 167, so 167/166.67 ≈ 1.0
+			elapsedTimeMs:            300000,
+			expectedProgress:         1.0,
+			expectMetricUpdateCalled: true,
+		},
+		{
+			name:                     "15 minutes elapsed with expected rate",
+			maxRecords:               1500000,
+			pendingRecords:           750000, // Expected: (900000/1800000) * 1500000 = 750000, actual: 750000, so 750000/750000 = 1.0
+			elapsedTimeMs:            900000,
+			expectedProgress:         1.0,
+			expectMetricUpdateCalled: true,
+		},
+		{
+			name:                     "30 minutes elapsed (full interval)",
+			maxRecords:               1000,
+			pendingRecords:           1000, // Expected: (1800000/1800000) * 1000 = 1000, actual: 1000, so 1000/1000 = 1.0
+			elapsedTimeMs:            1800000,
+			expectedProgress:         1.0,
+			expectMetricUpdateCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Settings{
+				CloudAccountID: "123456789012",
+				Region:         "us-west-2",
+				ClusterName:    "testcluster",
+				Database: config.Database{
+					MaxRecords:      tt.maxRecords,
+					CostMaxInterval: 30 * time.Minute, // 30 minutes = 1800000 milliseconds
+				},
+			}
+
+			// Create a mock store that implements all needed methods
+			mockStore := mocks.NewMockStore(ctrl)
+
+			if tt.expectMetricUpdateCalled {
+				mockStore.EXPECT().Pending().Return(tt.pendingRecords).AnyTimes()
+				mockStore.EXPECT().ElapsedTime().Return(tt.elapsedTimeMs).AnyTimes()
+			}
+
+			mockStore.EXPECT().Put(ctx, gomock.Any()).Return(nil).AnyTimes()
+			mockStore.EXPECT().Flush().Return(nil).AnyTimes()
+
+			d, err := domain.NewMetricCollector(&cfg, mockClock, mockStore, nil)
+			require.NoError(t, err)
+			defer d.Close()
+
+			// Create test metric data
+			payload, _, _, err := testdata.BuildWriteRequest(testdata.WriteRequestFixture.Timeseries, nil, nil, nil, nil, "snappy")
+			require.NoError(t, err)
+
+			// Process metrics to trigger the progress metric update
+			stats, err := d.PutMetrics(ctx, "application/x-protobuf", "snappy", payload)
+			assert.NoError(t, err)
+			assert.Nil(t, stats)
+		})
+	}
+}
+
+func TestUpdateShippingProgressMetric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	ctx := context.Background()
+
+	t.Run("flush triggers metric update", func(t *testing.T) {
+		cfg := config.Settings{
+			CloudAccountID: "123456789012",
+			Region:         "us-west-2",
+			ClusterName:    "testcluster",
+			Database: config.Database{
+				MaxRecords:      1000,
+				CostMaxInterval: 30 * time.Minute,
+			},
+		}
+
+		// Create mock stores for both cost and observability
+		mockCostStore := mocks.NewMockStore(ctrl)
+		mockObservabilityStore := mocks.NewMockStore(ctrl)
+
+		// Expect Pending() and ElapsedTime() to be called when Flush() is called
+		mockCostStore.EXPECT().Pending().Return(0).AnyTimes()
+		mockCostStore.EXPECT().ElapsedTime().Return(int64(10000)).AnyTimes()
+
+		mockCostStore.EXPECT().Flush().Return(nil)
+		mockObservabilityStore.EXPECT().Flush().Return(nil)
+
+		d, err := domain.NewMetricCollector(&cfg, mockClock, mockCostStore, mockObservabilityStore)
+		require.NoError(t, err)
+		defer d.Close()
+
+		// Call flush to trigger metric update
+		err = d.Flush(ctx)
+		assert.NoError(t, err)
 	})
 }

--- a/app/functions/collector/main.go
+++ b/app/functions/collector/main.go
@@ -5,16 +5,21 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
+	"time"
 
 	"github.com/go-obvious/server"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/cloudzero/cloudzero-agent/app/build"
 	config "github.com/cloudzero/cloudzero-agent/app/config/gator"
@@ -26,6 +31,83 @@ import (
 	"github.com/cloudzero/cloudzero-agent/app/types"
 	"github.com/cloudzero/cloudzero-agent/app/utils"
 )
+
+const (
+	// apiBasePath is the base path for the custom metrics API
+	apiBasePath = "/apis/custom.metrics.k8s.io/v1beta1"
+)
+
+// startCollectorServer starts an HTTP server with core APIs (collector, metrics, profiling)
+func startCollectorServer(ctx context.Context, logger *zerolog.Logger, settings *config.Settings, domain *domain.MetricCollector, k8sClient kubernetes.Interface, includeCustomMetrics bool) {
+	// HTTP server always serves core APIs
+	apis := []server.API{
+		handlers.NewRemoteWriteAPI("/collector", domain),
+		handlers.NewPromMetricsAPI("/metrics"),
+	}
+
+	// Add custom metrics API only if not served by separate HTTPS server
+	if includeCustomMetrics {
+		apis = append(apis, handlers.NewCustomMetricsAPI(apiBasePath, domain, k8sClient))
+	}
+
+	if settings.Server.Profiling {
+		apis = append(apis, handlers.NewProfilingAPI("/debug/pprof/"))
+	}
+
+	// HTTP server uses all middleware including prometheus metrics
+	srv := server.New(build.Version()).
+		WithAddress(fmt.Sprintf(":%d", settings.Server.Port)).
+		WithMiddleware(middleware.LoggingMiddlewareWrapper, middleware.PromHTTPMiddleware).
+		WithAPIs(apis...)
+
+	logger.Info().Uint("port", settings.Server.Port).Msg("Starting HTTP server")
+	srv.WithListener(server.HTTPListener()).Run(ctx)
+}
+
+// startAutscalerServer starts an HTTPS server that serves only the custom metrics API
+func startAutscalerServer(ctx context.Context, logger *zerolog.Logger, settings *config.Settings, domain *domain.MetricCollector, k8sClient kubernetes.Interface) {
+	// HTTPS server serves only custom metrics API with discovery endpoints
+	apis := []server.API{
+		handlers.NewCustomMetricsWithDiscoveryAPI(apiBasePath, domain, k8sClient),
+	}
+
+	// Use only logging middleware (no prometheus to avoid duplication with HTTP server)
+	srv := server.New(build.Version()).
+		WithAddress(fmt.Sprintf(":%d", settings.Server.TLSPort)).
+		WithMiddleware(middleware.LoggingMiddlewareWrapper).
+		WithAPIs(apis...)
+
+	// TLS certificate paths for dual mode
+	certPath := settings.Certificate.Cert
+	keyPath := settings.Certificate.Key
+
+	// Validate TLS certificates exist
+	if certPath == "" || keyPath == "" {
+		logger.Fatal().Msg("TLS certificate paths not configured, cannot start HTTPS server")
+	}
+
+	if _, err := os.Stat(certPath); err != nil {
+		logger.Fatal().Err(err).Msg("TLS certificate file not found, cannot start HTTPS server")
+	}
+
+	if _, err := os.Stat(keyPath); err != nil {
+		logger.Fatal().Err(err).Msg("TLS key file not found, cannot start HTTPS server")
+	}
+
+	logger.Info().Uint("port", settings.Server.TLSPort).Msg("Starting HTTPS server (custom metrics API only)")
+	tlsProvider := func() *tls.Config {
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("Failed to load TLS certificate")
+		}
+		return &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		}
+	}
+
+	srv.WithListener(server.TLSListener(30*time.Second, 30*time.Second, 120*time.Second, tlsProvider)).Run(ctx)
+}
 
 func main() {
 	var configFile string
@@ -96,12 +178,6 @@ func main() {
 		}
 	}()
 
-	// Handle shutdown events gracefully
-	go func() {
-		HandleShutdownEvents(ctx, costMetricStore, observabilityMetricStore)
-		os.Exit(0)
-	}()
-
 	// create the metric collector service interface
 	domain, err := domain.NewMetricCollector(settings, clock, costMetricStore, observabilityMetricStore)
 	if err != nil {
@@ -109,28 +185,58 @@ func main() {
 	}
 	defer domain.Close()
 
-	mw := []server.Middleware{
-		middleware.LoggingMiddlewareWrapper,
-		middleware.PromHTTPMiddleware,
+	// Create Kubernetes client for custom metrics API (only when running in cluster)
+	var k8sClient kubernetes.Interface
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		// Silently skip Kubernetes client setup when not running in cluster
+		// Custom metrics API will work with fallback behavior (only looking at
+		// the current pod).
+		k8sClient = nil
+	} else {
+		k8sClient, err = kubernetes.NewForConfig(config)
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to create Kubernetes client, custom metrics API will have limited functionality")
+			k8sClient = nil
+		}
 	}
 
-	apis := []server.API{
-		handlers.NewRemoteWriteAPI("/collector", domain),
-		handlers.NewPromMetricsAPI("/metrics"),
-	}
+	// Create a cancellable context for server shutdown
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	if settings.Server.Profiling {
-		apis = append(apis, handlers.NewProfilingAPI("/debug/pprof/"))
-	}
+	// Handle shutdown events gracefully
+	go func() {
+		HandleShutdownEvents(ctx, costMetricStore, observabilityMetricStore)
+		logger.Info().Msg("Shutdown signal received, cancelling context")
+		cancel()
+	}()
 
 	// Expose the service
 	logger.Info().Msg("Starting service")
-	server.New(build.Version()).
-		WithAddress(fmt.Sprintf(":%d", settings.Server.Port)).
-		WithMiddleware(mw...).
-		WithAPIs(apis...).
-		WithListener(server.HTTPListener()).
-		Run(ctx)
+
+	wg := sync.WaitGroup{}
+
+	if settings.Server.Mode == "https" || settings.Server.Mode == "dual" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			startAutscalerServer(ctx, logger, settings, domain, k8sClient)
+		}()
+	}
+
+	if settings.Server.Mode == "http" || settings.Server.Mode == "dual" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Include custom metrics API only in HTTP-only mode (not in dual mode)
+			includeCustomMetrics := settings.Server.Mode == "http"
+			startCollectorServer(ctx, logger, settings, domain, k8sClient, includeCustomMetrics)
+		}()
+	}
+
+	wg.Wait()
+
 	logger.Info().Msg("Service stopping")
 }
 

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -225,6 +225,9 @@ components:
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
   # after some processing.
   aggregator:
+    # The number of replicas to run. Note that, if autoscale is enabled, this
+    # will be the starting number of replicas, which may or may not be the
+    # number of replicas in the cluster due to the HPA.
     replicas: 3
     podDisruptionBudget:
       # enabled:
@@ -232,6 +235,8 @@ components:
       # maxUnavailable:
     tolerations: []
     annotations: {}
+    # Enable autoscaling for the aggregator deployment
+    autoscale: false
 
   # Settings for the webhook server.
   webhookServer:
@@ -935,6 +940,16 @@ aggregator:
       limits:
         memory: "1024Mi"
         cpu: "2000m"
+    # TLS configuration for the collector (automatically enabled when autoscaling is enabled)
+    tls:
+      # Path where the TLS certificate and key will be mounted in the container
+      mountPath: /etc/certs
+      # Configuration for the TLS certificate Secret
+      secret:
+        # Whether to create a Secret to store the TLS certificate and key
+        create: true
+        # Name of the Secret to create. If empty, a name will be generated
+        name: ""
   # Configuration for the shipper component of the aggregator.
   shipper:
     # Port that the shipper listens on for internal communication.
@@ -965,6 +980,51 @@ aggregator:
   # See the Kubernetes documentation for details:
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # Detailed scaling configuration for the aggregator deployment
+  scaling:
+    # Minimum number of replicas for the aggregator
+    minReplicas: 1
+    # Maximum number of replicas for the aggregator
+    maxReplicas: 10
+    # Target value for czo_cost_metrics_shipping_progress metric
+    # "900m" = scale when metrics reach 90% of MaxRecords capacity
+    # Values >1.0 indicate saturation and trigger more aggressive scaling
+    targetValue: "900m"
+    # Annotations to apply to the HPA resource
+    annotations: {}
+    # Scaling behavior configuration
+    behavior:
+      scaleUp:
+        # Time to wait before allowing another scale up
+        stabilizationWindowSeconds: 300
+        # Scale up policies
+        policies:
+          # Allow up to 100% increase
+          - type: Percent
+            value: 100
+            periodSeconds: 60
+          # Allow up to 2 pod increase
+          - type: Pods
+            value: 2
+            periodSeconds: 60
+        # Use the maximum of the policies
+        selectPolicy: Max
+      scaleDown:
+        # Time to wait before allowing another scale down
+        stabilizationWindowSeconds: 300
+        # Scale down policies
+        policies:
+          # Allow up to 50% decrease
+          - type: Percent
+            value: 50
+            periodSeconds: 60
+          # Allow up to 1 pod decrease
+          - type: Pods
+            value: 1
+            periodSeconds: 60
+        # Use the minimum of the policies
+        selectPolicy: Min
+
 
 # -- Deprecated. Override the name of the chart. Used in resource naming.
 nameOverride:

--- a/app/handlers/apis.go
+++ b/app/handlers/apis.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-obvious/server"
+	"github.com/go-obvious/server/api"
+	"github.com/go-obvious/server/request"
+	"github.com/rs/zerolog/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// APIsHandler provides the /apis endpoint for API discovery
+type APIsHandler struct {
+	api.Service
+}
+
+// NewAPIsHandler creates a new APIs handler that mounts to the specified path
+func NewAPIsHandler(path string) *APIsHandler {
+	h := &APIsHandler{
+		Service: api.Service{
+			APIName: "apis",
+			Mounts:  map[string]*chi.Mux{},
+		},
+	}
+	h.Service.Mounts[path] = h.Routes()
+	return h
+}
+
+func (h *APIsHandler) Register(app server.Server) error {
+	if err := h.Service.Register(app); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *APIsHandler) Routes() *chi.Mux {
+	r := chi.NewRouter()
+	r.Get("/", h.listAPIGroups)
+	return r
+}
+
+// listAPIGroups returns the API groups available for discovery
+func (h *APIsHandler) listAPIGroups(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log.Ctx(ctx).Info().Str("path", r.URL.Path).Msg("APIsHandler: listAPIGroups called")
+
+	// Return the API group list that includes custom.metrics.k8s.io
+	// According to Kubernetes API docs, this should list all API groups supported by the cluster
+	apiGroupList := metav1.APIGroupList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIGroupList",
+			APIVersion: "v1",
+		},
+		Groups: []metav1.APIGroup{
+			{
+				Name: "custom.metrics.k8s.io",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{
+						GroupVersion: "custom.metrics.k8s.io/v1beta1",
+						Version:      "v1beta1",
+					},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{
+					GroupVersion: "custom.metrics.k8s.io/v1beta1",
+					Version:      "v1beta1",
+				},
+				// Include server address as required by some clients
+				ServerAddressByClientCIDRs: []metav1.ServerAddressByClientCIDR{
+					{
+						ClientCIDR:    "0.0.0.0/0",
+						ServerAddress: "",
+					},
+				},
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(apiGroupList); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode API group list")
+		request.Reply(r, w, "failed to encode API group list", http.StatusInternalServerError)
+		return
+	}
+}

--- a/app/handlers/custom_metrics.go
+++ b/app/handlers/custom_metrics.go
@@ -1,0 +1,447 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-obvious/server"
+	"github.com/go-obvious/server/api"
+	"github.com/go-obvious/server/request"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/metrics/pkg/apis/custom_metrics/v1beta1"
+
+	"github.com/cloudzero/cloudzero-agent/app/domain"
+)
+
+const (
+	// metricName is the name of the custom metric for HPA scaling
+	metricName = "czo_cost_metrics_shipping_progress"
+	// errorMsgFailedToGetMetricValue is the error message when failing to get metric value
+	errorMsgFailedToGetMetricValue = "failed to get metric value"
+	// apiVersion is the API version for custom metrics
+	apiVersion = "custom.metrics.k8s.io/v1beta1"
+	// contentTypeJSON is the content type for JSON responses
+	contentTypeJSON = "application/json"
+	// contentTypeHeader is the HTTP header for content type
+	contentTypeHeader = "Content-Type"
+	// kubernetesAPIVersion is the Kubernetes API version
+	kubernetesAPIVersion = "v1"
+	// rootPath is the root path for API endpoints
+	rootPath = "/"
+)
+
+// CustomMetricsAPI implements the Kubernetes custom metrics API
+type CustomMetricsAPI struct {
+	api.Service
+	collector *domain.MetricCollector
+	k8sClient kubernetes.Interface
+}
+
+// NewCustomMetricsAPI creates a new custom metrics API handler
+func NewCustomMetricsAPI(base string, collector *domain.MetricCollector, k8sClient kubernetes.Interface) *CustomMetricsAPI {
+	a := &CustomMetricsAPI{
+		collector: collector,
+		k8sClient: k8sClient,
+		Service: api.Service{
+			APIName: "custom-metrics",
+			Mounts:  map[string]*chi.Mux{},
+		},
+	}
+
+	// Mount custom metrics API at its base path
+	a.Service.Mounts[base] = a.Routes()
+
+	return a
+}
+
+func (a *CustomMetricsAPI) Register(app server.Server) error {
+	if err := a.Service.Register(app); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *CustomMetricsAPI) Routes() *chi.Mux {
+	r := chi.NewRouter()
+
+	// Custom metrics API routes
+	r.Get("/", a.listCustomMetrics)
+	r.Get("/namespaces/{namespace}/pods", a.listPodsMetrics)
+	r.Get("/namespaces/{namespace}/pods/{pod}/{metric}", a.getCustomMetricForPod)
+	r.Get("/namespaces/{namespace}/pods/{metric}", a.getCustomMetricForPods)
+
+	return r
+}
+
+// CustomMetricsWithDiscoveryAPI combines custom metrics API with discovery endpoints
+type CustomMetricsWithDiscoveryAPI struct {
+	api.Service
+	customMetricsAPI *CustomMetricsAPI
+}
+
+// NewCustomMetricsWithDiscoveryAPI creates a new API that includes both custom metrics and discovery endpoints
+func NewCustomMetricsWithDiscoveryAPI(base string, collector *domain.MetricCollector, k8sClient kubernetes.Interface) *CustomMetricsWithDiscoveryAPI {
+	customMetricsAPI := &CustomMetricsAPI{
+		collector: collector,
+		k8sClient: k8sClient,
+	}
+
+	a := &CustomMetricsWithDiscoveryAPI{
+		customMetricsAPI: customMetricsAPI,
+		Service: api.Service{
+			APIName: "custom-metrics-with-discovery",
+			Mounts:  map[string]*chi.Mux{},
+		},
+	}
+
+	// Mount custom metrics API at its base path
+	a.Service.Mounts[base] = customMetricsAPI.Routes()
+
+	// Mount discovery endpoints at root level
+	a.Service.Mounts["/apis"] = a.createAPIGroupsRoute()
+	a.Service.Mounts["/openapi/v2"] = a.createOpenAPIv2Route()
+
+	return a
+}
+
+func (a *CustomMetricsWithDiscoveryAPI) Register(app server.Server) error {
+	if err := a.Service.Register(app); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createAPIGroupsRoute creates a router for the /apis endpoint
+func (a *CustomMetricsWithDiscoveryAPI) createAPIGroupsRoute() *chi.Mux {
+	r := chi.NewRouter()
+	r.Get("/", a.customMetricsAPI.getAPIGroups)
+	return r
+}
+
+// createOpenAPIv2Route creates a router for the /openapi/v2 endpoint
+func (a *CustomMetricsWithDiscoveryAPI) createOpenAPIv2Route() *chi.Mux {
+	r := chi.NewRouter()
+	r.Get("/", a.customMetricsAPI.getOpenAPIv2Spec)
+	return r
+}
+
+// listCustomMetrics returns the list of available custom metrics
+func (a *CustomMetricsAPI) listCustomMetrics(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Return APIResourceList according to Kubernetes custom metrics API v1beta1 spec
+	apiResourceList := metav1.APIResourceList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIResourceList",
+			APIVersion: "v1",
+		},
+		GroupVersion: apiVersion,
+		APIResources: []metav1.APIResource{
+			{
+				Name:       "pods/" + metricName,
+				Namespaced: true,
+				Kind:       "MetricValueList",
+				Verbs:      []string{"get"},
+			},
+		},
+	}
+
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
+	if err := json.NewEncoder(w).Encode(apiResourceList); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode metrics list")
+		request.Reply(r, w, "failed to encode metrics list", http.StatusInternalServerError)
+		return
+	}
+}
+
+// listPodsMetrics returns the list of available metrics for pods
+func (a *CustomMetricsAPI) listPodsMetrics(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	metrics := []string{metricName}
+
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
+	if err := json.NewEncoder(w).Encode(metrics); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode pods metrics list")
+		request.Reply(r, w, "failed to encode pods metrics list", http.StatusInternalServerError)
+		return
+	}
+}
+
+// getCustomMetricForPod returns the custom metric value for a specific pod
+func (a *CustomMetricsAPI) getCustomMetricForPod(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	namespace := chi.URLParam(r, "namespace")
+	pod := chi.URLParam(r, "pod")
+	metric := chi.URLParam(r, "metric")
+
+	if metric != metricName {
+		request.Reply(r, w, fmt.Sprintf("metric %s not found", metric), http.StatusNotFound)
+		return
+	}
+
+	// Special case: if pod is "*", return metrics for all pods (HPA compatibility)
+	if pod == "*" {
+		a.getCustomMetricForPods(w, r)
+		return
+	}
+
+	// Get the current metric value from Prometheus
+	value, err := a.getCurrentMetricValue()
+	if err != nil {
+		log.Ctx(ctx).Err(err).Msg(errorMsgFailedToGetMetricValue)
+		request.Reply(r, w, errorMsgFailedToGetMetricValue, http.StatusInternalServerError)
+		return
+	}
+
+	metricValue := &v1beta1.MetricValue{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MetricValue",
+			APIVersion: apiVersion,
+		},
+		DescribedObject: corev1.ObjectReference{
+			Kind:       "Pod",
+			Namespace:  namespace,
+			Name:       pod,
+			APIVersion: "v1",
+		},
+		MetricName: metric,
+		Timestamp:  metav1.NewTime(time.Now()),
+		Value:      *value,
+		Selector:   nil, // No label selector for this metric
+	}
+
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
+	if err := json.NewEncoder(w).Encode(metricValue); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode metric value")
+		request.Reply(r, w, "failed to encode metric value", http.StatusInternalServerError)
+		return
+	}
+}
+
+// getCustomMetricForPods returns the custom metric values for multiple pods
+func (a *CustomMetricsAPI) getCustomMetricForPods(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	namespace := chi.URLParam(r, "namespace")
+	metric := chi.URLParam(r, "metric")
+
+	if metric != metricName {
+		request.Reply(r, w, fmt.Sprintf("metric %s not found", metric), http.StatusNotFound)
+		return
+	}
+
+	// Get the current metric value from Prometheus
+	value, err := a.getCurrentMetricValue()
+	if err != nil {
+		log.Ctx(ctx).Err(err).Msg(errorMsgFailedToGetMetricValue)
+		request.Reply(r, w, errorMsgFailedToGetMetricValue, http.StatusInternalServerError)
+		return
+	}
+
+	// Create metric values for pods
+	var items []v1beta1.MetricValue
+
+	if a.k8sClient != nil {
+		// Query actual pods from the namespace that match our deployment
+		pods, err := a.k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/component=aggregator",
+		})
+		if err != nil {
+			log.Ctx(ctx).Err(err).Msg("failed to list pods")
+			request.Reply(r, w, "failed to list pods", http.StatusInternalServerError)
+			return
+		}
+
+		// Create metric values for all running aggregator pods
+		items = make([]v1beta1.MetricValue, 0, len(pods.Items))
+		for _, pod := range pods.Items {
+			// Only include running pods
+			if pod.Status.Phase == corev1.PodRunning {
+				items = append(items, v1beta1.MetricValue{
+					DescribedObject: corev1.ObjectReference{
+						Kind:       "Pod",
+						Namespace:  namespace,
+						Name:       pod.Name,
+						APIVersion: "v1",
+					},
+					MetricName: metric,
+					Timestamp:  metav1.NewTime(time.Now()),
+					Value:      *value,
+					Selector:   nil, // No label selector for this metric
+				})
+			}
+		}
+	} else {
+		// Fallback: return a single metric value with wildcard name when k8s client is not available
+		items = []v1beta1.MetricValue{
+			{
+				DescribedObject: corev1.ObjectReference{
+					Kind:       "Pod",
+					Namespace:  namespace,
+					Name:       "*",
+					APIVersion: "v1",
+				},
+				MetricName: metric,
+				Timestamp:  metav1.NewTime(time.Now()),
+				Value:      *value,
+				Selector:   nil, // No label selector for this metric
+			},
+		}
+	}
+
+	metricValueList := &v1beta1.MetricValueList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MetricValueList",
+			APIVersion: apiVersion,
+		},
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "1",
+		},
+		Items: items,
+	}
+
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
+	if err := json.NewEncoder(w).Encode(metricValueList); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode metric value list")
+		request.Reply(r, w, "failed to encode metric value list", http.StatusInternalServerError)
+		return
+	}
+}
+
+// getCurrentMetricValue retrieves the current value of the shipping progress metric from Prometheus
+func (a *CustomMetricsAPI) getCurrentMetricValue() (*resource.Quantity, error) {
+	// Get metrics from the default Prometheus registry
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("failed to gather metrics: %w", err)
+	}
+
+	// Find the czo_cost_metrics_shipping_progress metric
+	for _, mf := range metricFamilies {
+		if mf.GetName() == metricName {
+			metrics := mf.GetMetric()
+			if len(metrics) > 0 {
+				// Get the gauge value
+				gauge := metrics[0].GetGauge()
+				if gauge != nil {
+					value := gauge.GetValue()
+					// Convert to Kubernetes resource.Quantity
+					// Parse the value as a decimal string to preserve precision
+					quantityStr := fmt.Sprintf("%.0fm", value*1000)
+					quantity, err := resource.ParseQuantity(quantityStr)
+					if err != nil {
+						return nil, fmt.Errorf("failed to parse quantity %s: %w", quantityStr, err)
+					}
+					return &quantity, nil
+				}
+			}
+		}
+	}
+
+	// If metric not found, return 0
+	quantity := resource.NewMilliQuantity(0, resource.DecimalSI)
+	return quantity, nil
+}
+
+// getAPIGroups returns the API groups available for discovery
+func (a *CustomMetricsAPI) getAPIGroups(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log.Ctx(ctx).Info().Str("path", r.URL.Path).Msg("CustomMetricsAPI: getAPIGroups called")
+
+	// Return the API group list that includes custom.metrics.k8s.io
+	apiGroupList := metav1.APIGroupList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIGroupList",
+			APIVersion: kubernetesAPIVersion,
+		},
+		Groups: []metav1.APIGroup{
+			{
+				Name: "custom.metrics.k8s.io",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{
+						GroupVersion: "custom.metrics.k8s.io/v1beta1",
+						Version:      "v1beta1",
+					},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{
+					GroupVersion: "custom.metrics.k8s.io/v1beta1",
+					Version:      "v1beta1",
+				},
+				ServerAddressByClientCIDRs: []metav1.ServerAddressByClientCIDR{
+					{
+						ClientCIDR:    "0.0.0.0/0",
+						ServerAddress: "",
+					},
+				},
+			},
+		},
+	}
+
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
+	if err := json.NewEncoder(w).Encode(apiGroupList); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode API group list")
+		request.Reply(r, w, "failed to encode API group list", http.StatusInternalServerError)
+		return
+	}
+}
+
+// getOpenAPIv2Spec returns an OpenAPI v2 specification
+func (a *CustomMetricsAPI) getOpenAPIv2Spec(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log.Ctx(ctx).Info().Str("path", r.URL.Path).Msg("CustomMetricsAPI: getOpenAPIv2Spec called")
+
+	// Return minimal OpenAPI v2 spec for our custom metrics API
+	openAPISpec := map[string]interface{}{
+		"swagger": "2.0",
+		"info": map[string]interface{}{
+			"title":   "CloudZero Custom Metrics API",
+			"version": "v1beta1",
+		},
+		"host":     "",
+		"basePath": rootPath,
+		"schemes":  []string{"https"},
+		"consumes": []string{contentTypeJSON},
+		"produces": []string{contentTypeJSON},
+		"paths": map[string]interface{}{
+			"/apis/custom.metrics.k8s.io/v1beta1": map[string]interface{}{
+				"get": map[string]interface{}{
+					"description": "List available custom metrics",
+					"operationId": "listCustomMetrics",
+					"produces":    []string{contentTypeJSON},
+					"responses": map[string]interface{}{
+						"200": map[string]interface{}{
+							"description": "List of available metrics",
+						},
+					},
+					"tags": []string{"custom.metrics.k8s.io_v1beta1"},
+				},
+			},
+		},
+		"tags": []map[string]interface{}{
+			{
+				"name":        "custom.metrics.k8s.io_v1beta1",
+				"description": "Custom metrics API for autoscaling",
+			},
+		},
+	}
+
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
+	if err := json.NewEncoder(w).Encode(openAPISpec); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode OpenAPI v2 spec")
+		request.Reply(r, w, "failed to encode OpenAPI v2 spec", http.StatusInternalServerError)
+		return
+	}
+}

--- a/app/handlers/custom_metrics_test.go
+++ b/app/handlers/custom_metrics_test.go
@@ -1,0 +1,395 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-obvious/server/test"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/metrics/pkg/apis/custom_metrics/v1beta1"
+
+	config "github.com/cloudzero/cloudzero-agent/app/config/gator"
+	"github.com/cloudzero/cloudzero-agent/app/domain"
+	"github.com/cloudzero/cloudzero-agent/app/handlers"
+	"github.com/cloudzero/cloudzero-agent/app/types/mocks"
+)
+
+func TestCustomMetricsAPI_Routes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	storage := mocks.NewMockStore(ctrl)
+	// Mock the Pending method to return a value for the shipping progress metric
+	storage.EXPECT().Pending().Return(500000).AnyTimes()
+	// Mock the ElapsedTime method for the time-based shipping progress metric
+	storage.EXPECT().ElapsedTime().Return(int64(10000)).AnyTimes()
+
+	cfg := &config.Settings{
+		Database: config.Database{
+			MaxRecords: 1500000, // 1.5 million
+		},
+	}
+
+	collector, err := domain.NewMetricCollector(cfg, mockClock, storage, nil)
+	assert.NoError(t, err)
+	defer collector.Close()
+
+	handler := handlers.NewCustomMetricsAPI("/apis/custom.metrics.k8s.io/v1beta1", collector, nil)
+
+	tests := []struct {
+		name               string
+		method             string
+		path               string
+		expectedStatusCode int
+	}{
+		{
+			name:               "list_metrics",
+			method:             "GET",
+			path:               "/apis/custom.metrics.k8s.io/v1beta1/",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "get_metric_for_specific_pod",
+			method:             "GET",
+			path:               "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/test-pod/czo_cost_metrics_shipping_progress",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "get_metric_for_pods_without_specific_pod",
+			method:             "GET",
+			path:               "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/czo_cost_metrics_shipping_progress",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "unsupported_method",
+			method:             "POST",
+			path:               "/apis/custom.metrics.k8s.io/v1beta1/",
+			expectedStatusCode: http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := createRequest(tt.method, tt.path, nil)
+			resp, err := test.InvokeService(handler.Service, tt.path, *req)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.expectedStatusCode, resp.StatusCode)
+		})
+	}
+}
+
+func TestCustomMetricsAPI_ListMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	storage := mocks.NewMockStore(ctrl)
+	cfg := &config.Settings{
+		Database: config.Database{
+			MaxRecords: 1500000,
+		},
+	}
+
+	collector, err := domain.NewMetricCollector(cfg, mockClock, storage, nil)
+	assert.NoError(t, err)
+	defer collector.Close()
+
+	handler := handlers.NewCustomMetricsAPI("/apis/custom.metrics.k8s.io/v1beta1", collector, nil)
+
+	req := createRequest("GET", "/apis/custom.metrics.k8s.io/v1beta1/", nil)
+	resp, err := test.InvokeService(handler.Service, "/apis/custom.metrics.k8s.io/v1beta1/", *req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var apiResourceList metav1.APIResourceList
+	err = json.NewDecoder(resp.Body).Decode(&apiResourceList)
+	assert.NoError(t, err)
+
+	// Verify the expected structure
+	assert.Equal(t, "APIResourceList", apiResourceList.Kind)
+	assert.Equal(t, "v1", apiResourceList.APIVersion)
+	assert.Equal(t, "custom.metrics.k8s.io/v1beta1", apiResourceList.GroupVersion)
+	assert.Len(t, apiResourceList.APIResources, 1)
+	assert.Equal(t, "pods/czo_cost_metrics_shipping_progress", apiResourceList.APIResources[0].Name)
+	assert.Equal(t, true, apiResourceList.APIResources[0].Namespaced)
+	assert.Equal(t, "MetricValueList", apiResourceList.APIResources[0].Kind)
+	assert.Equal(t, metav1.Verbs{"get"}, apiResourceList.APIResources[0].Verbs)
+}
+
+func TestCustomMetricsAPI_GetCustomMetricForPod(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	storage := mocks.NewMockStore(ctrl)
+	// Mock the Pending method to return 0 for no metrics
+	storage.EXPECT().Pending().Return(0).AnyTimes()
+	// Mock the ElapsedTime method for the time-based shipping progress metric
+	storage.EXPECT().ElapsedTime().Return(int64(10000)).AnyTimes()
+
+	cfg := &config.Settings{
+		Database: config.Database{
+			MaxRecords: 1500000,
+		},
+	}
+
+	collector, err := domain.NewMetricCollector(cfg, mockClock, storage, nil)
+	assert.NoError(t, err)
+	defer collector.Close()
+
+	handler := handlers.NewCustomMetricsAPI("/apis/custom.metrics.k8s.io/v1beta1", collector, nil)
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedStatus int
+		expectedMetric string
+		expectedPod    string
+		expectedNS     string
+	}{
+		{
+			name:           "valid metric request",
+			path:           "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/test-pod/czo_cost_metrics_shipping_progress",
+			expectedStatus: http.StatusOK,
+			expectedMetric: "czo_cost_metrics_shipping_progress",
+			expectedPod:    "test-pod",
+			expectedNS:     "cza",
+		},
+		{
+			name:           "unknown metric",
+			path:           "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/test-pod/unknown_metric",
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := createRequest("GET", tt.path, nil)
+			resp, err := test.InvokeService(handler.Service, tt.path, *req)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+			if tt.expectedStatus == http.StatusOK {
+				assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+				var metricValue v1beta1.MetricValue
+				err = json.NewDecoder(resp.Body).Decode(&metricValue)
+				assert.NoError(t, err)
+
+				assert.Equal(t, "MetricValue", metricValue.Kind)
+				assert.Equal(t, "custom.metrics.k8s.io/v1beta1", metricValue.APIVersion)
+				assert.Equal(t, tt.expectedMetric, metricValue.MetricName)
+				assert.Equal(t, tt.expectedPod, metricValue.DescribedObject.Name)
+				assert.Equal(t, tt.expectedNS, metricValue.DescribedObject.Namespace)
+				assert.Equal(t, "Pod", metricValue.DescribedObject.Kind)
+				assert.Equal(t, "v1", metricValue.DescribedObject.APIVersion)
+
+				// Check that the value is a valid quantity (any format is acceptable)
+				assert.NotNil(t, metricValue.Value)
+				assert.True(t, metricValue.Value.IsZero() || !metricValue.Value.IsZero(), "value should be a valid quantity")
+
+				// Check that timestamp is recent (within last minute)
+				timeDiff := time.Since(metricValue.Timestamp.Time)
+				assert.True(t, timeDiff < time.Minute, "timestamp should be recent")
+			}
+		})
+	}
+}
+
+func TestCustomMetricsAPI_GetCustomMetricForPods(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	storage := mocks.NewMockStore(ctrl)
+	// Mock the Pending method to return 0 for no metrics
+	storage.EXPECT().Pending().Return(0).AnyTimes()
+	// Mock the ElapsedTime method for the time-based shipping progress metric
+	storage.EXPECT().ElapsedTime().Return(int64(10000)).AnyTimes()
+
+	cfg := &config.Settings{
+		Database: config.Database{
+			MaxRecords: 1500000,
+		},
+	}
+
+	collector, err := domain.NewMetricCollector(cfg, mockClock, storage, nil)
+	assert.NoError(t, err)
+	defer collector.Close()
+
+	handler := handlers.NewCustomMetricsAPI("/apis/custom.metrics.k8s.io/v1beta1", collector, nil)
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedStatus int
+		expectedMetric string
+		expectedNS     string
+	}{
+		{
+			name:           "valid metric request for pods",
+			path:           "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/czo_cost_metrics_shipping_progress",
+			expectedStatus: http.StatusOK,
+			expectedMetric: "czo_cost_metrics_shipping_progress",
+			expectedNS:     "cza",
+		},
+		{
+			name:           "unknown metric for pods",
+			path:           "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/unknown_metric",
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := createRequest("GET", tt.path, nil)
+			resp, err := test.InvokeService(handler.Service, tt.path, *req)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+
+			if tt.expectedStatus == http.StatusOK {
+				assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+				var metricValueList v1beta1.MetricValueList
+				err = json.NewDecoder(resp.Body).Decode(&metricValueList)
+				assert.NoError(t, err)
+
+				assert.Equal(t, "MetricValueList", metricValueList.Kind)
+				assert.Equal(t, "custom.metrics.k8s.io/v1beta1", metricValueList.APIVersion)
+				assert.Len(t, metricValueList.Items, 1)
+
+				metricValue := metricValueList.Items[0]
+				assert.Equal(t, tt.expectedMetric, metricValue.MetricName)
+				assert.Equal(t, tt.expectedNS, metricValue.DescribedObject.Namespace)
+				assert.Equal(t, "Pod", metricValue.DescribedObject.Kind)
+				assert.Equal(t, "v1", metricValue.DescribedObject.APIVersion)
+
+				// Check that the value is a valid quantity (any format is acceptable)
+				assert.NotNil(t, metricValue.Value)
+				assert.True(t, metricValue.Value.IsZero() || !metricValue.Value.IsZero(), "value should be a valid quantity")
+			}
+		})
+	}
+}
+
+func TestCustomMetricsAPI_GetCurrentMetricValue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	storage := mocks.NewMockStore(ctrl)
+	// Mock the Pending method to return 0 for no metrics
+	storage.EXPECT().Pending().Return(0).AnyTimes()
+	// Mock the ElapsedTime method for the time-based shipping progress metric
+	storage.EXPECT().ElapsedTime().Return(int64(10000)).AnyTimes()
+
+	cfg := &config.Settings{
+		Database: config.Database{
+			MaxRecords: 1500000,
+		},
+	}
+
+	collector, err := domain.NewMetricCollector(cfg, mockClock, storage, nil)
+	assert.NoError(t, err)
+	defer collector.Close()
+
+	handler := handlers.NewCustomMetricsAPI("/apis/custom.metrics.k8s.io/v1beta1", collector, nil)
+
+	req := createRequest("GET", "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/test-pod/czo_cost_metrics_shipping_progress", nil)
+	resp, err := test.InvokeService(handler.Service, "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/test-pod/czo_cost_metrics_shipping_progress", *req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var metricValue v1beta1.MetricValue
+	err = json.NewDecoder(resp.Body).Decode(&metricValue)
+	assert.NoError(t, err)
+
+	// Check that the value is a valid quantity (any format is acceptable)
+	assert.NotNil(t, metricValue.Value)
+	assert.True(t, metricValue.Value.IsZero() || !metricValue.Value.IsZero(), "value should be a valid quantity")
+}
+
+func TestCustomMetricsAPI_PrometheusIntegration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	storage := mocks.NewMockStore(ctrl)
+	observabilityStorage := mocks.NewMockStore(ctrl)
+
+	// Mock the Pending method to return a value that gives us 50% progress
+	storage.EXPECT().Pending().Return(750000).AnyTimes() // 750k / 1.5M = 0.5
+	// Mock the ElapsedTime method for the time-based shipping progress metric
+	storage.EXPECT().ElapsedTime().Return(int64(10000)).AnyTimes()
+	// Mock the Flush method for both stores
+	storage.EXPECT().Flush().Return(nil).AnyTimes()
+	observabilityStorage.EXPECT().Flush().Return(nil).AnyTimes()
+
+	cfg := &config.Settings{
+		Database: config.Database{
+			MaxRecords: 1500000,
+		},
+	}
+
+	collector, err := domain.NewMetricCollector(cfg, mockClock, storage, observabilityStorage)
+	assert.NoError(t, err)
+	defer collector.Close()
+
+	// The metric is already registered by the collector, so we don't need to register it again
+	// Just trigger an update to set the value
+	collector.Flush(context.Background())
+
+	handler := handlers.NewCustomMetricsAPI("/apis/custom.metrics.k8s.io/v1beta1", collector, nil)
+
+	req := createRequest("GET", "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/test-pod/czo_cost_metrics_shipping_progress", nil)
+	resp, err := test.InvokeService(handler.Service, "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/test-pod/czo_cost_metrics_shipping_progress", *req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Parse the response
+	var result v1beta1.MetricValue
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	assert.NoError(t, err)
+
+	// Verify the basic structure
+	assert.Equal(t, "czo_cost_metrics_shipping_progress", result.MetricName)
+	assert.Equal(t, "test-pod", result.DescribedObject.Name)
+	assert.Equal(t, "cza", result.DescribedObject.Namespace)
+
+	// Check that the value is a valid quantity and not zero (should be 50% progress)
+	assert.NotNil(t, result.Value)
+	assert.False(t, result.Value.IsZero(), "value should not be zero for 50% progress")
+}

--- a/app/handlers/discovery.go
+++ b/app/handlers/discovery.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-obvious/server"
+	"github.com/go-obvious/server/api"
+	"github.com/go-obvious/server/request"
+	"github.com/rs/zerolog/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// descriptionKey is the key for description in OpenAPI spec
+	descriptionKey = "description"
+	// applicationJSON is the content type for JSON responses
+	applicationJSON = "application/json"
+)
+
+// DiscoveryAPI provides API discovery endpoints required by HPA controller
+type DiscoveryAPI struct {
+	api.Service
+}
+
+// NewDiscoveryAPI creates a new API discovery handler
+func NewDiscoveryAPI() *DiscoveryAPI {
+	d := &DiscoveryAPI{
+		Service: api.Service{
+			APIName: "discovery",
+			Mounts:  map[string]*chi.Mux{},
+		},
+	}
+	d.Service.Mounts["/"] = d.Routes()
+	return d
+}
+
+func (d *DiscoveryAPI) Register(app server.Server) error {
+	if err := d.Service.Register(app); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DiscoveryAPI) Routes() *chi.Mux {
+	r := chi.NewRouter()
+
+	// API discovery endpoints (required by HPA controller) - ONLY these endpoints
+	r.Get("/apis", d.listAPIGroups)
+	r.Get("/openapi/v2", d.getOpenAPISpec)
+
+	return r
+}
+
+// listAPIGroups returns the API groups available for discovery
+func (d *DiscoveryAPI) listAPIGroups(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log.Ctx(ctx).Info().Str("path", r.URL.Path).Msg("DiscoveryAPI: listAPIGroups called")
+
+	// Return the API group list that includes custom.metrics.k8s.io
+	apiGroupList := metav1.APIGroupList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIGroupList",
+			APIVersion: "v1",
+		},
+		Groups: []metav1.APIGroup{
+			{
+				Name: "custom.metrics.k8s.io",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{
+						GroupVersion: "custom.metrics.k8s.io/v1beta1",
+						Version:      "v1beta1",
+					},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{
+					GroupVersion: "custom.metrics.k8s.io/v1beta1",
+					Version:      "v1beta1",
+				},
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", applicationJSON)
+	if err := json.NewEncoder(w).Encode(apiGroupList); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode API group list")
+		request.Reply(r, w, "failed to encode API group list", http.StatusInternalServerError)
+		return
+	}
+}
+
+// getOpenAPISpec returns a minimal OpenAPI v2 specification
+func (d *DiscoveryAPI) getOpenAPISpec(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log.Ctx(ctx).Info().Str("path", r.URL.Path).Msg("DiscoveryAPI: getOpenAPISpec called")
+
+	// Return a minimal OpenAPI v2 spec for our custom metrics API
+	openAPISpec := map[string]interface{}{
+		"swagger": "2.0",
+		"info": map[string]interface{}{
+			"title":   "CloudZero Custom Metrics API",
+			"version": "v1beta1",
+		},
+		"paths": map[string]interface{}{
+			"/apis/custom.metrics.k8s.io/v1beta1/": map[string]interface{}{
+				"get": map[string]interface{}{
+					descriptionKey: "List available custom metrics",
+					"produces":     []string{"application/json"},
+					"responses": map[string]interface{}{
+						"200": map[string]interface{}{
+							descriptionKey: "List of available metrics",
+						},
+					},
+				},
+			},
+			"/apis/custom.metrics.k8s.io/v1beta1/namespaces/{namespace}/pods/{metric}": map[string]interface{}{
+				"get": map[string]interface{}{
+					descriptionKey: "Get custom metric for pods in namespace",
+					"produces":     []string{"application/json"},
+					"parameters": []map[string]interface{}{
+						{
+							"name":     "namespace",
+							"in":       "path",
+							"required": true,
+							"type":     "string",
+						},
+						{
+							"name":     "metric",
+							"in":       "path",
+							"required": true,
+							"type":     "string",
+						},
+					},
+					"responses": map[string]interface{}{
+						"200": map[string]interface{}{
+							descriptionKey: "Metric value list",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", applicationJSON)
+	if err := json.NewEncoder(w).Encode(openAPISpec); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode OpenAPI spec")
+		request.Reply(r, w, "failed to encode OpenAPI spec", http.StatusInternalServerError)
+		return
+	}
+}

--- a/app/handlers/openapi_discovery.go
+++ b/app/handlers/openapi_discovery.go
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-obvious/server"
+	"github.com/go-obvious/server/api"
+	"github.com/go-obvious/server/request"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// openAPIApplicationJSON is the content type for JSON responses
+	openAPIApplicationJSON = "application/json"
+	// openAPIDescriptionKey is the key for description in OpenAPI spec
+	openAPIDescriptionKey = "description"
+	// openAPITypeKey is the key for type in OpenAPI spec
+	openAPITypeKey = "type"
+	// openAPIStringValue is the string value for type in OpenAPI spec
+	openAPIStringValue = "string"
+	// openAPIArrayValue is the array value for type in OpenAPI spec
+	openAPIArrayValue = "array"
+	// openAPIObjectValue is the object value for type in OpenAPI spec
+	openAPIObjectValue = "object"
+	// openAPIRefKey is the key for references in OpenAPI spec
+	openAPIRefKey = "$ref"
+)
+
+// OpenAPIv2DiscoveryAPI provides OpenAPI v2 specification endpoint for API discovery
+type OpenAPIv2DiscoveryAPI struct {
+	api.Service
+}
+
+// NewOpenAPIv2DiscoveryAPI creates a new OpenAPI v2 discovery handler that mounts to the specified path
+func NewOpenAPIv2DiscoveryAPI(path string) *OpenAPIv2DiscoveryAPI {
+	h := &OpenAPIv2DiscoveryAPI{
+		Service: api.Service{
+			APIName: "openapi-v2-discovery",
+			Mounts:  map[string]*chi.Mux{},
+		},
+	}
+	h.Service.Mounts[path] = h.Routes()
+	return h
+}
+
+func (h *OpenAPIv2DiscoveryAPI) Register(app server.Server) error {
+	if err := h.Service.Register(app); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *OpenAPIv2DiscoveryAPI) Routes() *chi.Mux {
+	r := chi.NewRouter()
+	r.Get("/", h.getOpenAPIv2Spec)
+	return r
+}
+
+// getOpenAPIv2Spec returns an OpenAPI v2 specification
+func (h *OpenAPIv2DiscoveryAPI) getOpenAPIv2Spec(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log.Ctx(ctx).Info().Str("path", r.URL.Path).Msg("OpenAPIv2DiscoveryAPI: getOpenAPIv2Spec called")
+
+	// Return an aggregated OpenAPI v2 spec for our custom metrics API
+	openAPISpec := map[string]interface{}{
+		"swagger": "2.0",
+		"info": map[string]interface{}{
+			"title":   "CloudZero Custom Metrics API",
+			"version": "v1beta1",
+		},
+		"host":     "",
+		"basePath": "/",
+		"schemes":  []string{"https"},
+		"consumes": []string{openAPIApplicationJSON},
+		"produces": []string{openAPIApplicationJSON},
+		"paths": map[string]interface{}{
+			"/apis/custom.metrics.k8s.io/v1beta1": map[string]interface{}{
+				"get": map[string]interface{}{
+					openAPIDescriptionKey: "List available custom metrics",
+					"operationId":         "listCustomMetrics",
+					"produces":            []string{openAPIApplicationJSON},
+					"responses": map[string]interface{}{
+						"200": map[string]interface{}{
+							openAPIDescriptionKey: "List of available metrics",
+							"schema": map[string]interface{}{
+								openAPITypeKey: openAPIArrayValue,
+								"items": map[string]interface{}{
+									openAPITypeKey: openAPIStringValue,
+								},
+							},
+						},
+					},
+					"tags": []string{"custom.metrics.k8s.io_v1beta1"},
+				},
+			},
+			"/apis/custom.metrics.k8s.io/v1beta1/namespaces/{namespace}/pods/{metric}": map[string]interface{}{
+				"get": map[string]interface{}{
+					openAPIDescriptionKey: "Get custom metric for pods in namespace",
+					"operationId":         "getCustomMetricForPods",
+					"produces":            []string{openAPIApplicationJSON},
+					"parameters": []map[string]interface{}{
+						{
+							"name":                "namespace",
+							"in":                  "path",
+							openAPIDescriptionKey: "object name and auth scope, such as for teams and projects",
+							"required":            true,
+							openAPITypeKey:        openAPIStringValue,
+						},
+						{
+							"name":                "metric",
+							"in":                  "path",
+							openAPIDescriptionKey: "the name of the metric",
+							"required":            true,
+							openAPITypeKey:        openAPIStringValue,
+						},
+					},
+					"responses": map[string]interface{}{
+						"200": map[string]interface{}{
+							openAPIDescriptionKey: "Metric value list",
+							"schema": map[string]interface{}{
+								openAPIRefKey: "#/definitions/io.k8s.metrics.pkg.apis.custom_metrics.v1beta1.MetricValueList",
+							},
+						},
+					},
+					"tags": []string{"custom.metrics.k8s.io_v1beta1"},
+				},
+			},
+		},
+		"definitions": map[string]interface{}{
+			"io.k8s.metrics.pkg.apis.custom_metrics.v1beta1.MetricValue": map[string]interface{}{
+				openAPITypeKey: openAPIObjectValue,
+				"properties": map[string]interface{}{
+					"describedObject": map[string]interface{}{
+						openAPIRefKey: "#/definitions/io.k8s.api.core.v1.ObjectReference",
+					},
+					"metricName": map[string]interface{}{
+						openAPITypeKey: openAPIStringValue,
+					},
+					"timestamp": map[string]interface{}{
+						openAPIRefKey: "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+					},
+					"value": map[string]interface{}{
+						openAPIRefKey: "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+					},
+				},
+			},
+			"io.k8s.metrics.pkg.apis.custom_metrics.v1beta1.MetricValueList": map[string]interface{}{
+				openAPITypeKey: openAPIObjectValue,
+				"properties": map[string]interface{}{
+					"items": map[string]interface{}{
+						openAPITypeKey: openAPIArrayValue,
+						"items": map[string]interface{}{
+							openAPIRefKey: "#/definitions/io.k8s.metrics.pkg.apis.custom_metrics.v1beta1.MetricValue",
+						},
+					},
+					"metadata": map[string]interface{}{
+						openAPIRefKey: "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+					},
+				},
+			},
+		},
+		"tags": []map[string]interface{}{
+			{
+				"name":                "custom.metrics.k8s.io_v1beta1",
+				openAPIDescriptionKey: "Custom metrics API for autoscaling",
+			},
+		},
+	}
+
+	// Support both JSON and protobuf as per Kubernetes API docs
+	acceptHeader := r.Header.Get("Accept")
+	if acceptHeader == "application/com.github.proto-openapi.spec.v2@v1.0+protobuf" {
+		w.Header().Set("Content-Type", "application/com.github.proto-openapi.spec.v2@v1.0+protobuf")
+		// For now, return JSON even for protobuf requests since we don't have protobuf encoding
+	} else {
+		w.Header().Set("Content-Type", openAPIApplicationJSON)
+	}
+
+	if err := json.NewEncoder(w).Encode(openAPISpec); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode OpenAPI v2 spec")
+		request.Reply(r, w, "failed to encode OpenAPI v2 spec", http.StatusInternalServerError)
+		return
+	}
+}
+
+// OpenAPIv3DiscoveryAPI provides OpenAPI v3 specification endpoint
+type OpenAPIv3DiscoveryAPI struct {
+	api.Service
+}
+
+// NewOpenAPIv3DiscoveryAPI creates a new OpenAPI v3 discovery handler that mounts to the specified path
+func NewOpenAPIv3DiscoveryAPI(path string) *OpenAPIv3DiscoveryAPI {
+	h := &OpenAPIv3DiscoveryAPI{
+		Service: api.Service{
+			APIName: "openapi-v3-discovery",
+			Mounts:  map[string]*chi.Mux{},
+		},
+	}
+	h.Service.Mounts[path] = h.Routes()
+	return h
+}
+
+func (h *OpenAPIv3DiscoveryAPI) Register(app server.Server) error {
+	if err := h.Service.Register(app); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *OpenAPIv3DiscoveryAPI) Routes() *chi.Mux {
+	r := chi.NewRouter()
+	// This serves OpenAPI v3 discovery at /openapi/v3
+	r.Get("/", h.getOpenAPIv3Discovery)
+	return r
+}
+
+// getOpenAPIv3Discovery returns OpenAPI v3 discovery information
+func (h *OpenAPIv3DiscoveryAPI) getOpenAPIv3Discovery(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log.Ctx(ctx).Info().Str("path", r.URL.Path).Msg("OpenAPIv3DiscoveryAPI: getOpenAPIv3Discovery called")
+
+	// Return OpenAPI v3 discovery with available API groups
+	discovery := map[string]interface{}{
+		"paths": map[string]interface{}{
+			"apis/custom.metrics.k8s.io/v1beta1": map[string]interface{}{
+				"serverRelativeURL": "/openapi/v3/apis/custom.metrics.k8s.io/v1beta1",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", openAPIApplicationJSON)
+	if err := json.NewEncoder(w).Encode(discovery); err != nil {
+		log.Ctx(ctx).Err(err).Msg("failed to encode OpenAPI v3 discovery")
+		request.Reply(r, w, "failed to encode OpenAPI v3 discovery", http.StatusInternalServerError)
+		return
+	}
+}

--- a/app/handlers/prom_metrics.go
+++ b/app/handlers/prom_metrics.go
@@ -37,5 +37,6 @@ func (a *PromMetricsAPI) Register(app server.Server) error {
 func (a *PromMetricsAPI) Routes() *chi.Mux {
 	r := chi.NewRouter()
 	r.Get("/", promhttp.Handler().ServeHTTP)
+
 	return r
 }

--- a/app/handlers/remote_write_test.go
+++ b/app/handlers/remote_write_test.go
@@ -57,6 +57,10 @@ func TestRemoteWriteMethods(t *testing.T) {
 
 	storage.EXPECT().Put(gomock.Any(), gomock.Any()).Return(nil)
 	storage.EXPECT().Flush().Return(nil)
+	// Add the Pending() expectation for the shipping progress metric
+	storage.EXPECT().Pending().Return(0).AnyTimes()
+	// Add the ElapsedTime() expectation for the time-based shipping progress metric
+	storage.EXPECT().ElapsedTime().Return(int64(10000)).AnyTimes()
 
 	payload, _, _, err := testdata.BuildWriteRequest(testdata.WriteRequestFixture.Timeseries, nil, nil, nil, nil, "snappy")
 	assert.NoError(t, err)

--- a/app/logging/store_sink_test.go
+++ b/app/logging/store_sink_test.go
@@ -88,6 +88,11 @@ func (ms *mockStore) GetLastError() error {
 	return ms.lastError
 }
 
+func (ms *mockStore) ElapsedTime() int64 {
+	// Return a mock elapsed time in milliseconds
+	return 1000
+}
+
 // TestUnit_Logging_StoreWriter_Write_Basic tests basic functionality of a single write.
 func TestUnit_Logging_StoreWriter_Write_Basic(t *testing.T) {
 	store := newMockStore()

--- a/app/storage/disk/disk.go
+++ b/app/storage/disk/disk.go
@@ -275,6 +275,14 @@ func (d *DiskStore) Pending() int {
 	return d.rowCount
 }
 
+// ElapsedTime returns the duration in milliseconds since the current buffer was started
+func (d *DiskStore) ElapsedTime() int64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return timestamp.Milli() - d.startTime
+}
+
 func (d *DiskStore) GetFiles(paths ...string) ([]string, error) {
 	// set to root path
 	allPaths := []string{d.dirPath}

--- a/app/types/mocks/store_mock.go
+++ b/app/types/mocks/store_mock.go
@@ -58,6 +58,20 @@ func (mr *MockStoreMockRecorder) All(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "All", reflect.TypeOf((*MockStore)(nil).All), arg0, arg1)
 }
 
+// ElapsedTime mocks base method.
+func (m *MockStore) ElapsedTime() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ElapsedTime")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// ElapsedTime indicates an expected call of ElapsedTime.
+func (mr *MockStoreMockRecorder) ElapsedTime() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ElapsedTime", reflect.TypeOf((*MockStore)(nil).ElapsedTime))
+}
+
 // Find mocks base method.
 func (m *MockStore) Find(ctx context.Context, filterName, filterExtension string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/app/types/store.go
+++ b/app/types/store.go
@@ -27,6 +27,10 @@ type WritableStore interface {
 	// Pending returns the number of rows currently buffered and not yet written to disk.
 	// This can be used to monitor when a flush may be needed.
 	Pending() int
+
+	// ElapsedTime returns the duration in milliseconds since the current buffer was started.
+	// This is used for time-based metric calculations.
+	ElapsedTime() int64
 }
 
 // ReadableStore is for performing read operations against the store

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.30.0
 	helm.sh/helm/v3 v3.18.4
+	k8s.io/metrics v0.33.2
 	sigs.k8s.io/gateway-api v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -857,6 +857,8 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUy
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/kubectl v0.33.2 h1:7XKZ6DYCklu5MZQzJe+CkCjoGZwD1wWl7t/FxzhMz7Y=
 k8s.io/kubectl v0.33.2/go.mod h1:8rC67FB8tVTYraovAGNi/idWIK90z2CHFNMmGJZJ3KI=
+k8s.io/metrics v0.33.2 h1:gNCBmtnUMDMCRg9Ly5ehxP3OdKISMsOnh1vzk01iCgE=
+k8s.io/metrics v0.33.2/go.mod h1:yxoAosKGRsZisv3BGekC5W6T1J8XSV+PoUEevACRv7c=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 mvdan.cc/gofumpt v0.8.0 h1:nZUCeC2ViFaerTcYKstMmfysj6uhQrA2vJe+2vwGU6k=

--- a/helm/docs/AUTOSCALING.md
+++ b/helm/docs/AUTOSCALING.md
@@ -1,0 +1,246 @@
+# Autoscaling the CloudZero Agent
+
+## Introduction
+
+The CloudZero Agent's autoscaling feature automatically adjusts the number of aggregator pods based on the volume of cost metrics being processed. This ensures optimal resource utilization while maintaining performance on clusters of any size.
+
+### What is Autoscaling?
+
+Autoscaling automatically increases or decreases the number of replicas based on observed metrics. Traditional autoscaling relies on CPU or memory usage, but the CloudZero Agent uses a more sophisticated approach based on business logic—specifically, how close the system is to reaching its data shipping capacity.
+
+### Why Custom Metrics?
+
+The CloudZero Agent processes cost metrics from Kubernetes clusters and ships them to the CloudZero platform. The volume of this data varies significantly based on:
+
+- **Cluster size**: Larger clusters generate more metrics
+- **Resource churn**: Frequent pod creation/deletion increases metric volume
+- **Time of day**: Peak business hours often correlate with higher metric volume
+- **Deployment patterns**: CI/CD activity and autoscaling events generate metric spikes
+
+### How It Works
+
+The aggregator component maintains an in-memory buffer of cost metrics before flushing them to disk and shipping to CloudZero. The custom metric `czo_cost_metrics_shipping_progress` tracks how full this buffer is relative to the configured thresholds.
+
+When the buffer fills up (indicating high metric volume), the HPA automatically scales up additional aggregator pods to handle the increased load. When the buffer is consistently low (indicating normal or low volume), it scales down to conserve resources.
+
+This approach provides:
+
+- **Proactive scaling**: Scale before performance degrades
+- **Cost efficiency**: Use only the resources needed for current load
+- **High availability**: Prevent data loss during metric volume spikes
+- **Predictable performance**: Maintain consistent shipping rates regardless of load
+
+## Implementation Details
+
+### Custom Metrics API
+
+The chart automatically registers the custom metrics API with Kubernetes by creating an `APIService` resource. This allows the HPA controller to discover and query the custom metrics endpoint exposed by the aggregator pods.
+
+### The `czo_cost_metrics_shipping_progress` Metric
+
+The autoscaling system is built around a single custom metric that represents how close the system is to its in-memory buffer capacity. This metric is calculated based on two flush triggers that occur during normal operation:
+
+1. **Record Count**: Flush when `currentPending >= maxRecords`
+2. **Time Interval**: Flush when `elapsedTime >= costMaxInterval`
+
+#### Calculation Formula
+
+The metric is calculated as:
+
+$$\frac{\text{Records Pending}}{\frac{\text{Elapsed Time}}{\text{Max Interval}} \times \text{Max Records}}$$
+
+This formula normalizes the current buffer state against the expected capacity over time, providing a percentage-based value where:
+
+- **0.0**: Buffer is empty
+- **1.0**: Buffer is at expected capacity for the elapsed time
+- **> 1.0**: Buffer is over capacity and needs scaling
+
+#### Example Values
+
+Based on the default `maxRecords = 1,500,000` and `costMaxInterval = 30m`:
+
+- **5 minutes elapsed, 250,000 records**: `progress = 250,000 / (5/30 * 1,500,000) = 1.0` (100% of expected rate)
+- **10 minutes elapsed, 300,000 records**: `progress = 300,000 / (10/30 * 1,500,000) = 0.6` (60% of expected rate - could scale down)
+- **15 minutes elapsed, 900,000 records**: `progress = 900,000 / (15/30 * 1,500,000) = 1.2` (120% of expected rate - should scale up)
+- **30 minutes elapsed, 1,500,000 records**: `progress = 1,500,000 / (30/30 * 1,500,000) = 1.0` (100% at time limit)
+
+#### Relationship to System Behavior
+
+The metric directly correlates with the system's disk flushing behavior:
+
+1. **Normal Operation**: Metrics accumulate in memory buffer
+2. **Flush Trigger**: When `currentPending >= maxRecords` or time interval exceeded, system flushes to disk
+3. **Post-Flush**: `currentPending` resets to 0, metric drops to 0.0
+4. **Cycle Repeats**: Buffer fills again as new metrics arrive
+
+#### HPA Integration
+
+By default, the HPA targets `"900m"` (0.9 or 90% of capacity). The target value of 90% allows the HPA to proactively scale before the buffer becomes full, preventing data loss or performance degradation:
+
+- **Below 0.9**: May scale down to as few as `minReplicas`
+- **Above 0.9**: May scale up to as many as `maxReplicas`
+
+## Configuration
+
+### Enabling Autoscaling
+
+To enable HPA for the aggregator component:
+
+```yaml
+components:
+  aggregator:
+    autoscale: true
+```
+
+This automatically creates:
+
+- **HPA Resource**: Configured to scale based on `czo_cost_metrics_shipping_progress`
+- **APIService Registration**: Registers `v1beta1.custom.metrics.k8s.io` with Kubernetes
+- **RBAC Permissions**: Allows the HPA controller to access custom metrics
+
+### Scaling Parameters
+
+Detailed configuration is available in the (non-API-stable) `aggregator.scaling` section:
+
+```yaml
+aggregator:
+  scaling:
+    minReplicas: 1
+    maxReplicas: 10
+    targetValue: "900m" # Target 90% of capacity
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 60
+          - type: Pods
+            value: 2
+            periodSeconds: 60
+        selectPolicy: Max
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Percent
+            value: 50
+            periodSeconds: 60
+          - type: Pods
+            value: 1
+            periodSeconds: 60
+        selectPolicy: Min
+```
+
+### Target Value Format
+
+The `targetValue` supports both percentage and resource quantity formats:
+
+- **Percentage**: `"90%"` (90% of maximum records threshold)
+- **Resource Quantity**: `"900m"` (0.9 as a decimal)
+
+Both formats are equivalent and represent the same scaling threshold.
+
+## Troubleshooting
+
+### HPA Shows "Unknown" Metrics
+
+**Symptoms**: HPA status shows metrics as "unknown" or "0"
+
+**Causes**:
+
+- Collector pods not running
+- Custom metrics API not accessible
+- Network policies blocking access API server on collector container
+
+**Solutions**:
+
+1. Verify collector pods are running:
+
+   ```bash
+   kubectl get pods -l app.kubernetes.io/name=cloudzero-collector
+   ```
+
+2. Test custom metrics API directly:
+
+   ```bash
+   kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/"
+   ```
+
+3. Check collector logs for API errors:
+   ```bash
+   kubectl logs -l app.kubernetes.io/name=cloudzero-collector
+   ```
+
+### HPA Not Scaling
+
+**Symptoms**: Metric values are high but HPA doesn't scale
+
+**Causes**:
+
+- Target value too high
+- MaxReplicas already reached
+- Resource constraints
+
+**Solutions**:
+
+1. Check HPA configuration:
+
+   ```bash
+   kubectl describe hpa cloudzero-aggregator
+   ```
+
+2. Verify resource quotas:
+
+   ```bash
+   kubectl describe resourcequota
+   ```
+
+3. Review HPA events:
+   ```bash
+   kubectl get events --field-selector involvedObject.name=cloudzero-aggregator
+   ```
+
+### Metric Values Seem Wrong
+
+**Symptoms**: Metric values don't match expected shipping progress
+
+**Causes**:
+
+- Configuration mismatch between aggregator and collector
+- Metric calculation errors
+- Time synchronization issues
+
+**Solutions**:
+
+1. Compare aggregator configuration:
+
+   ```bash
+   kubectl get configmap cloudzero-aggregator-config -o yaml
+   ```
+
+2. Check Prometheus metrics directly:
+   ```bash
+   kubectl port-forward svc/cloudzero-collector 8080:8080
+   curl localhost:8080/metrics | grep czo_cost_metrics_shipping_progress
+   ```
+
+## Security
+
+### RBAC Requirements
+
+The HPA requires specific permissions to access custom metrics:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hpa-custom-metrics-reader
+rules:
+  - apiGroups: ["custom.metrics.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list"]
+```
+
+### Network Policies
+
+Ensure network policies allow HPA to communicate with collector pods on the custom metrics API port.

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -55,9 +55,20 @@ metrics:
   {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "cost_labels" "filters"          (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.cost.labels) | nindent 2 }}
   {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability" "filters"        (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.name) | nindent 2 }}
   {{- include "cloudzero-agent.generateMetricFilters" (dict "name" "observability_labels" "filters" (include "cloudzero-agent.defaults" . | fromYaml).metricFilters.observability.labels) | nindent 2 }}
+{{- if .Values.components.aggregator.autoscale }}
+certificate:
+  key: {{ .Values.aggregator.collector.tls.mountPath }}/tls.key
+  cert: {{ .Values.aggregator.collector.tls.mountPath }}/tls.crt
+{{- end }}
 server:
+  {{- if .Values.components.aggregator.autoscale }}
+  mode: dual
+  port: {{ .Values.aggregator.collector.port }}
+  tls_port: {{ .Values.aggregator.collector.tls.port | default 8443 }}
+  {{- else }}
   mode: http
   port: {{ .Values.aggregator.collector.port }}
+  {{- end }}
   profiling: {{ .Values.aggregator.profiling }}
   reconnect_frequency: {{ .Values.aggregator.reconnectFrequency }}
 logging:

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -635,6 +635,23 @@ Name for the secret holding TLS certificates
 {{- end }}
 
 {{/*
+Name for the secret holding aggregator TLS certificates
+*/}}
+{{- define "cloudzero-agent.aggregator.tlsSecretName" -}}
+{{- .Values.aggregator.collector.tls.secret.name | default (printf "%s-tls" (include "cloudzero-agent.aggregator.name" .)) }}
+{{- end }}
+
+{{/*
+CA Bundle for aggregator custom metrics API
+*/}}
+{{- define "cloudzero-agent.aggregator.caBundle" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (include "cloudzero-agent.aggregator.tlsSecretName" .) -}}
+{{- if $secret -}}
+{{- index $secret.data "tls.crt" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Volume mount for the API key
 */}}
 {{- define "cloudzero-agent.apiKeyVolumeMount" -}}

--- a/helm/templates/agent-clusterrole.yaml
+++ b/helm/templates/agent-clusterrole.yaml
@@ -79,4 +79,16 @@ rules:
       - "/metrics"
     verbs:
       - get
+  {{- if and .Values.aggregator.collector.tls.secret.create .Values.components.aggregator.autoscale }}
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+  {{- end }}
 {{- end }}

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -37,10 +37,18 @@ spec:
           ports:
             - name: port-collector
               containerPort: {{ .Values.aggregator.collector.port }}
+            {{- if .Values.components.aggregator.autoscale }}
+            - name: port-coll-tls
+              containerPort: {{ .Values.aggregator.collector.tls.port | default 8443 }}
+            {{- end }}
           command: ["/app/cloudzero-collector", "-config", "{{ .Values.aggregator.mountRoot }}/config/config.yml"]
           env:
             - name: SERVER_PORT
               value: "{{ .Values.aggregator.collector.port }}"
+            {{- if .Values.components.aggregator.autoscale }}
+            - name: SERVER_TLS_PORT
+              value: "{{ .Values.aggregator.collector.tls.port | default 8443 }}"
+            {{- end }}
           volumeMounts:
             {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
             - name: aggregator-config-volume
@@ -48,10 +56,16 @@ spec:
               readOnly: true
             - name: aggregator-persistent-storage
               mountPath: {{ .Values.aggregator.mountRoot }}/data
+            {{- if .Values.components.aggregator.autoscale }}
+            - name: aggregator-tls-certs
+              mountPath: {{ .Values.aggregator.collector.tls.mountPath }}
+              readOnly: true
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.aggregator.collector.port }}
+              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
@@ -59,6 +73,7 @@ spec:
             httpGet:
               path: /healthz
               port: {{ .Values.aggregator.collector.port }}
+              scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
@@ -84,14 +99,14 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.aggregator.collector.port }}
+              port: {{ .Values.aggregator.shipper.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.aggregator.collector.port }}
+              port: {{ .Values.aggregator.shipper.port }}
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
@@ -149,6 +164,11 @@ spec:
         - name: aggregator-config-volume
           configMap:
             name: {{ include "cloudzero-agent.aggregator.name" . }}
+        {{- if .Values.components.aggregator.autoscale }}
+        - name: aggregator-tls-certs
+          secret:
+            secretName: {{ include "cloudzero-agent.aggregator.tlsSecretName" . }}
+        {{- end }}
         - name: aggregator-persistent-storage
         {{- if .Values.aggregator.database.emptyDir.enabled }}
           emptyDir:

--- a/helm/templates/aggregator-hpa.yaml
+++ b/helm/templates/aggregator-hpa.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.components.aggregator.autoscale }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cloudzero-agent.aggregator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge
+      (deepCopy .Values.defaults.annotations)
+      .Values.aggregator.scaling.annotations
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "globals" .
+      "labels" (merge (include "cloudzero-agent.aggregator.matchLabels" . | fromYaml) .Values.commonMetaLabels)
+      "component" "aggregator"
+    ) | nindent 2 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cloudzero-agent.aggregator.name" . }}
+  minReplicas: {{ .Values.aggregator.scaling.minReplicas }}
+  maxReplicas: {{ .Values.aggregator.scaling.maxReplicas }}
+  metrics:
+  - type: Pods
+    pods:
+      metric:
+        name: czo_cost_metrics_shipping_progress
+      target:
+        type: AverageValue
+        averageValue: {{ .Values.aggregator.scaling.targetValue | default "900m" }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.aggregator.scaling.behavior.scaleUp.stabilizationWindowSeconds | default 300 }}
+      policies:
+      {{- range .Values.aggregator.scaling.behavior.scaleUp.policies }}
+      - type: {{ .type }}
+        value: {{ .value }}
+        periodSeconds: {{ .periodSeconds }}
+      {{- end }}
+      selectPolicy: {{ .Values.aggregator.scaling.behavior.scaleUp.selectPolicy | default "Max" }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.aggregator.scaling.behavior.scaleDown.stabilizationWindowSeconds | default 300 }}
+      policies:
+      {{- range .Values.aggregator.scaling.behavior.scaleDown.policies }}
+      - type: {{ .type }}
+        value: {{ .value }}
+        periodSeconds: {{ .periodSeconds }}
+      {{- end }}
+      selectPolicy: {{ .Values.aggregator.scaling.behavior.scaleDown.selectPolicy | default "Min" }}
+{{- end }}

--- a/helm/templates/aggregator-init-cert-job.yaml
+++ b/helm/templates/aggregator-init-cert-job.yaml
@@ -1,0 +1,74 @@
+{{- if and .Values.aggregator.collector.tls.secret.create .Values.components.aggregator.autoscale }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cloudzero-agent.aggregator.name" . }}-init-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cloudzero-agent.aggregator.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+spec:
+  template:
+    metadata:
+      name: {{ include "cloudzero-agent.aggregator.name" . }}-init-cert
+      labels:
+        {{- include "cloudzero-agent.aggregator.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}
+      {{- include "cloudzero-agent.server.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: create-cert
+        {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.kubectl.image "compat" .Values.initCertJob.image) | nindent 8 }}
+        command: ["/bin/bash", "-c"]
+        workingDir: /var/tmp
+        args:
+          - |
+            #!/bin/bash
+            set -e
+            
+            SECRET_NAME="{{ include "cloudzero-agent.aggregator.tlsSecretName" . }}"
+            SERVICE_NAME="{{ include "cloudzero-agent.aggregator.name" . }}"
+            NAMESPACE="{{ .Release.Namespace }}"
+            
+            EXISTING_TLS_CRT=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.tls\.crt}' 2>/dev/null || echo "")
+            EXISTING_TLS_KEY=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.tls\.key}' 2>/dev/null || echo "")
+            
+            GENERATE_CERTIFICATE=false
+            
+            if [[ -n "$EXISTING_TLS_CRT" && -n "$EXISTING_TLS_KEY" ]]; then
+              # Check if the certificate is valid for our service
+              SAN=$(echo "$EXISTING_TLS_CRT" | base64 -d | openssl x509 -text -noout | grep DNS | sed 's/.*DNS://' || echo "")
+              if [[ "$SAN" != "$SERVICE_NAME.$NAMESPACE.svc" ]]; then
+                echo "The SANs in the certificate do not match the service name."
+                GENERATE_CERTIFICATE=true
+              fi
+            else
+              echo "TLS Secret is missing or incomplete."
+              GENERATE_CERTIFICATE=true
+            fi
+            
+            if [[ $GENERATE_CERTIFICATE == "true" ]]; then
+              echo "Generating new TLS certificate for $SERVICE_NAME.$NAMESPACE.svc"
+              
+              # Generate self-signed certificate and private key
+              openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 36500 -nodes \
+                -subj "/CN=$SERVICE_NAME.$NAMESPACE.svc" \
+                -addext "subjectAltName = DNS:$SERVICE_NAME.$NAMESPACE.svc"
+              
+              # Base64 encode the certificate and key
+              TLS_CRT=$(cat tls.crt | base64 | tr -d '\n')
+              TLS_KEY=$(cat tls.key | base64 | tr -d '\n')
+              
+              # Create or update the TLS Secret
+              kubectl create secret tls $SECRET_NAME \
+                --cert=tls.crt \
+                --key=tls.key \
+                --namespace=$NAMESPACE \
+                --dry-run=client -o yaml | kubectl apply -f -
+              
+              echo "TLS certificate created/updated successfully"
+            else
+              echo "Valid certificate already exists for $SERVICE_NAME.$NAMESPACE.svc"
+            fi
+{{- end }} 

--- a/helm/templates/aggregator-service.yaml
+++ b/helm/templates/aggregator-service.yaml
@@ -9,7 +9,14 @@ spec:
   selector:
     {{- include "cloudzero-agent.aggregator.matchLabels" . | nindent 4 }}
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 80
       targetPort: {{ .Values.aggregator.collector.port }}
+    {{- if .Values.components.aggregator.autoscale }}
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: {{ .Values.aggregator.collector.tls.port | default 8443 }}
+    {{- end }}
   type: ClusterIP

--- a/helm/templates/custom-metrics-apiservice.yaml
+++ b/helm/templates/custom-metrics-apiservice.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.components.aggregator.autoscale }}
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.custom.metrics.k8s.io
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cloudzero-agent.aggregator.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+spec:
+  service:
+    name: {{ include "cloudzero-agent.aggregator.name" . }}
+    namespace: {{ .Release.Namespace }}
+{{- if .Values.components.aggregator.autoscale }}
+    port: 443
+{{- else }}
+    port: 80
+{{- end }}
+  group: custom.metrics.k8s.io
+  version: v1beta1
+  groupPriorityMinimum: 100
+  versionPriority: 100
+{{- if .Values.components.aggregator.autoscale }}
+  caBundle: {{ include "cloudzero-agent.aggregator.caBundle" . }}
+{{- else }}
+  insecureSkipTLSVerify: true
+{{- end }}
+{{- end }} 

--- a/helm/templates/custom-metrics-rbac.yaml
+++ b/helm/templates/custom-metrics-rbac.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.components.aggregator.autoscale }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "cloudzero-agent.aggregator.name" . }}-custom-metrics-reader
+  labels:
+    {{- include "cloudzero-agent.aggregator.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+rules:
+- apiGroups: ["custom.metrics.k8s.io"]
+  resources: ["*"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cloudzero-agent.aggregator.name" . }}-custom-metrics-reader
+  labels:
+    {{- include "cloudzero-agent.aggregator.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cloudzero-agent.aggregator.name" . }}-custom-metrics-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:controller:horizontal-pod-autoscaler
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "cloudzero-agent.aggregator.name" . }}-custom-metrics-reader-hpa
+  labels:
+    {{- include "cloudzero-agent.aggregator.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "cloudzero-agent.aggregator.name" . }}-custom-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+{{- end }} 

--- a/helm/templates/init-cert-clusterrole.yaml
+++ b/helm/templates/init-cert-clusterrole.yaml
@@ -23,10 +23,27 @@ rules:
       - "secrets"
     resourceNames:
       - {{ include "cloudzero-agent.tlsSecretName" . }}
+      {{- if and .Values.aggregator.collector.tls.secret.create .Values.components.aggregator.autoscale }}
+      - {{ include "cloudzero-agent.aggregator.tlsSecretName" . }}
+      {{- end }}
     verbs:
       - get
       - list
       - patch
+      - create
+      - update
+  {{- if and .Values.aggregator.collector.tls.secret.create .Values.components.aggregator.autoscale }}
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+  {{- end }}
   - apiGroups:
       - "admissionregistration.k8s.io"
     resources:

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -233,6 +233,261 @@
       },
       "type": "object"
     },
+    "io.k8s.api.autoscaling.v2.ContainerResourceMetricSource": {
+      "additionalProperties": false,
+      "properties": {
+        "container": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget"
+        }
+      },
+      "required": ["name", "target", "container"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.CrossVersionObjectReference": {
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["kind", "name"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.ExternalMetricSource": {
+      "additionalProperties": false,
+      "properties": {
+        "metric": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricIdentifier"
+        },
+        "target": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget"
+        }
+      },
+      "required": ["metric", "target"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.HPAScalingPolicy": {
+      "additionalProperties": false,
+      "properties": {
+        "periodSeconds": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": ["type", "value", "periodSeconds"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.HPAScalingRules": {
+      "additionalProperties": false,
+      "properties": {
+        "policies": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HPAScalingPolicy"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "selectPolicy": {
+          "type": "string"
+        },
+        "stabilizationWindowSeconds": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "tolerance": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler": {
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "enum": ["HorizontalPodAutoscaler"],
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec"
+        },
+        "status": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerStatus"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "autoscaling",
+          "kind": "HorizontalPodAutoscaler",
+          "version": "v2"
+        }
+      ]
+    },
+    "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior": {
+      "additionalProperties": false,
+      "properties": {
+        "scaleDown": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HPAScalingRules"
+        },
+        "scaleUp": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HPAScalingRules"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "behavior": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior"
+        },
+        "maxReplicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "metrics": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricSpec"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "minReplicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "scaleTargetRef": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.CrossVersionObjectReference"
+        }
+      },
+      "required": ["scaleTargetRef", "maxReplicas"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.MetricIdentifier": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
+        }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.MetricSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "containerResource": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ContainerResourceMetricSource"
+        },
+        "external": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ExternalMetricSource"
+        },
+        "object": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ObjectMetricSource"
+        },
+        "pods": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.PodsMetricSource"
+        },
+        "resource": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.ResourceMetricSource"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["type"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.MetricTarget": {
+      "additionalProperties": false,
+      "properties": {
+        "averageUtilization": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "averageValue": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+        }
+      },
+      "required": ["type"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.ObjectMetricSource": {
+      "additionalProperties": false,
+      "properties": {
+        "describedObject": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.CrossVersionObjectReference"
+        },
+        "metric": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricIdentifier"
+        },
+        "target": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget"
+        }
+      },
+      "required": ["describedObject", "target", "metric"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.PodsMetricSource": {
+      "additionalProperties": false,
+      "properties": {
+        "metric": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricIdentifier"
+        },
+        "target": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget"
+        }
+      },
+      "required": ["metric", "target"],
+      "type": "object"
+    },
+    "io.k8s.api.autoscaling.v2.ResourceMetricSource": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/$defs/io.k8s.api.autoscaling.v2.MetricTarget"
+        }
+      },
+      "required": ["name", "target"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {
       "additionalProperties": false,
       "properties": {
@@ -3210,6 +3465,30 @@
             },
             "resources": {
               "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+            },
+            "tls": {
+              "additionalProperties": false,
+              "properties": {
+                "mountPath": {
+                  "default": "/etc/certs",
+                  "type": "string"
+                },
+                "secret": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "create": {
+                      "default": true,
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object"
@@ -3279,7 +3558,7 @@
               "type": "boolean"
             },
             "level": {
-              "enum": ["debug", "info", "warn", "error"],
+              "enum": ["trace", "debug", "info", "warn", "error"],
               "type": "string"
             }
           },
@@ -3301,6 +3580,27 @@
         "reconnectFrequency": {
           "minimum": 0,
           "type": "integer"
+        },
+        "scaling": {
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            },
+            "behavior": {
+              "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior"
+            },
+            "maxReplicas": {
+              "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec/properties/maxReplicas"
+            },
+            "minReplicas": {
+              "$ref": "#/$defs/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec/properties/minReplicas"
+            },
+            "targetValue": {
+              "type": "string"
+            }
+          },
+          "type": "object"
         },
         "shipper": {
           "additionalProperties": false,
@@ -3375,6 +3675,9 @@
           "properties": {
             "annotations": {
               "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            },
+            "autoscale": {
+              "type": "boolean"
             },
             "podDisruptionBudget": {
               "oneOf": [

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -305,6 +305,18 @@ properties:
             type:
               - integer
               - "null"
+          autoscale:
+            description: |
+              Whether to enable horizontal pod autoscaling for the aggregator.
+              When enabled, the aggregator will automatically scale based on the
+              czo_cost_metrics_shipping_progress metric. Detailed scaling
+              configuration is found under the aggregator.scaling section.
+
+              This creates:
+              - HPA resource with custom metrics configuration
+              - APIService registration for custom.metrics.k8s.io
+              - RBAC permissions for HPA to access custom metrics
+            type: boolean
           tolerations:
             description: |
               Tolerations configuration for the aggregator pods.
@@ -400,6 +412,7 @@ properties:
           level:
             type: string
             enum:
+              - trace
               - debug
               - info
               - warn
@@ -497,6 +510,37 @@ properties:
           # Resource requirements for the collector
           resources:
             $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+          tls:
+            description: |
+              TLS configuration for the collector. When autoscaling is enabled,
+              the collector runs in dual mode (HTTP + HTTPS) to serve both
+              regular metrics collection and the custom metrics API for HPA.
+              When autoscaling is disabled, the collector runs in HTTP-only
+              mode.
+            type: object
+            additionalProperties: false
+            properties:
+              mountPath:
+                description: |
+                  Path where the TLS certificate and key will be mounted in the container
+                type: string
+                default: "/etc/certs"
+              secret:
+                description: |
+                  Configuration for the TLS certificate Secret
+                type: object
+                additionalProperties: false
+                properties:
+                  create:
+                    description: |
+                      Whether to create a Secret to store the TLS certificate and key
+                    type: boolean
+                    default: true
+                  name:
+                    description: |
+                      Name of the Secret to create. If empty, a name will be generated
+                    type: string
+                    default: ""
       shipper:
         type: object
         additionalProperties: false
@@ -515,6 +559,34 @@ properties:
       # Affinity settings for the aggregator
       affinity:
         $ref: "#/$defs/io.k8s.api.core.v1.Affinity"
+      # Scaling configuration for the aggregator
+      scaling:
+        description: |
+          Detailed scaling configuration for the aggregator deployment.
+          This section is only used when components.aggregator.autoscale is enabled.
+        additionalProperties: false
+        type: object
+        properties:
+          minReplicas:
+            $ref: "#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec/properties/minReplicas"
+          maxReplicas:
+            $ref: "#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerSpec/properties/maxReplicas"
+          targetValue:
+            description: |
+              Target value for the czo_cost_metrics_shipping_progress metric.
+              "900m" = scale when metrics projected to reach 90% of MaxRecords
+              capacity. scaling.
+            type: string
+          annotations:
+            description: |
+              Annotations to be added to the HPA resource.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+          behavior:
+            description: |
+              HPA scaling behavior configuration. Configures the scaling
+              behavior of the target in both Up and Down directions. If not set,
+              the default HPAScalingRules for scale up and scale down are used.
+            $ref: "#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior"
 
   prometheusConfig:
     description: |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -225,6 +225,9 @@ components:
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
   # after some processing.
   aggregator:
+    # The number of replicas to run. Note that, if autoscale is enabled, this
+    # will be the starting number of replicas, which may or may not be the
+    # number of replicas in the cluster due to the HPA.
     replicas: 3
     podDisruptionBudget:
       # enabled:
@@ -232,6 +235,8 @@ components:
       # maxUnavailable:
     tolerations: []
     annotations: {}
+    # Enable autoscaling for the aggregator deployment
+    autoscale: false
 
   # Settings for the webhook server.
   webhookServer:
@@ -935,6 +940,16 @@ aggregator:
       limits:
         memory: "1024Mi"
         cpu: "2000m"
+    # TLS configuration for the collector (automatically enabled when autoscaling is enabled)
+    tls:
+      # Path where the TLS certificate and key will be mounted in the container
+      mountPath: /etc/certs
+      # Configuration for the TLS certificate Secret
+      secret:
+        # Whether to create a Secret to store the TLS certificate and key
+        create: true
+        # Name of the Secret to create. If empty, a name will be generated
+        name: ""
   # Configuration for the shipper component of the aggregator.
   shipper:
     # Port that the shipper listens on for internal communication.
@@ -965,6 +980,51 @@ aggregator:
   # See the Kubernetes documentation for details:
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+  # Detailed scaling configuration for the aggregator deployment
+  scaling:
+    # Minimum number of replicas for the aggregator
+    minReplicas: 1
+    # Maximum number of replicas for the aggregator
+    maxReplicas: 10
+    # Target value for czo_cost_metrics_shipping_progress metric
+    # "900m" = scale when metrics reach 90% of MaxRecords capacity
+    # Values >1.0 indicate saturation and trigger more aggressive scaling
+    targetValue: "900m"
+    # Annotations to apply to the HPA resource
+    annotations: {}
+    # Scaling behavior configuration
+    behavior:
+      scaleUp:
+        # Time to wait before allowing another scale up
+        stabilizationWindowSeconds: 300
+        # Scale up policies
+        policies:
+          # Allow up to 100% increase
+          - type: Percent
+            value: 100
+            periodSeconds: 60
+          # Allow up to 2 pod increase
+          - type: Pods
+            value: 2
+            periodSeconds: 60
+        # Use the maximum of the policies
+        selectPolicy: Max
+      scaleDown:
+        # Time to wait before allowing another scale down
+        stabilizationWindowSeconds: 300
+        # Scale down policies
+        policies:
+          # Allow up to 50% decrease
+          - type: Percent
+            value: 50
+            periodSeconds: 60
+          # Allow up to 1 pod decrease
+          - type: Pods
+            value: 1
+            periodSeconds: 60
+        # Use the minimum of the policies
+        selectPolicy: Min
+
 
 # -- Deprecated. Override the name of the chart. Used in resource naming.
 nameOverride:

--- a/tests/helm/template/autoscale-overrides.yml
+++ b/tests/helm/template/autoscale-overrides.yml
@@ -1,0 +1,15 @@
+cloudAccountId: "1234567890"
+clusterName: "my-cluster"
+region: "us-east-1"
+apiKey: "not-a-real-api-key"
+
+# For testing only, you should never use this property in production.
+jobConfigID: "DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E"
+
+components:
+  aggregator:
+    autoscale: true
+
+aggregator:
+  logging:
+    level: debug

--- a/tests/helm/template/autoscale.yaml
+++ b/tests/helm/template/autoscale.yaml
@@ -666,13 +666,17 @@ data:
         - pattern: "czo_"
           match: prefix
       
+    certificate:
+      key: /etc/certs/tls.key
+      cert: /etc/certs/tls.crt
     server:
-      mode: http
+      mode: dual
       port: 8080
+      tls_port: 8443
       profiling: false
       reconnect_frequency: 16
     logging:
-      level: "info"
+      level: "debug"
       capture: true
     database:
       storage_path: /cloudzero/data
@@ -752,7 +756,7 @@ data:
         tag: null
       logging:
         capture: true
-        level: info
+        level: debug
       mountRoot: /cloudzero
       name: null
       nodeSelector: {}
@@ -806,7 +810,7 @@ data:
         podDisruptionBudget: null
       aggregator:
         annotations: {}
-        autoscale: false
+        autoscale: true
         podDisruptionBudget: null
         replicas: 3
         tolerations: []
@@ -1740,6 +1744,35 @@ rules:
       - "/metrics"
     verbs:
       - get
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+---
+# Source: cloudzero-agent/templates/custom-metrics-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cz-agent-aggregator-custom-metrics-reader
+  labels:
+    app.kubernetes.io/component: aggregator
+    app.kubernetes.io/instance: cz-agent
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
+    app.kubernetes.io/part-of: cloudzero-agent
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: cloudzero-agent-1.1.0-dev
+  
+rules:
+- apiGroups: ["custom.metrics.k8s.io"]
+  resources: ["*"]
+  verbs: ["get", "list"]
 ---
 # Source: cloudzero-agent/templates/init-cert-clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1772,11 +1805,22 @@ rules:
       - "secrets"
     resourceNames:
       - cz-agent-cloudzero-agent-webhook-server-tls
+      - cz-agent-aggregator-tls
     verbs:
       - get
       - list
       - patch
       - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - create
+      - get
+      - list
+      - patch
       - update
   - apiGroups:
       - "admissionregistration.k8s.io"
@@ -1833,6 +1877,52 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cz-agent-cloudzero-agent-server
+---
+# Source: cloudzero-agent/templates/custom-metrics-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cz-agent-aggregator-custom-metrics-reader
+  labels:
+    app.kubernetes.io/component: aggregator
+    app.kubernetes.io/instance: cz-agent
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
+    app.kubernetes.io/part-of: cloudzero-agent
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: cloudzero-agent-1.1.0-dev
+  
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cz-agent-aggregator-custom-metrics-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:controller:horizontal-pod-autoscaler
+---
+# Source: cloudzero-agent/templates/custom-metrics-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cz-agent-aggregator-custom-metrics-reader-hpa
+  labels:
+    app.kubernetes.io/component: aggregator
+    app.kubernetes.io/instance: cz-agent
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
+    app.kubernetes.io/part-of: cloudzero-agent
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: cloudzero-agent-1.1.0-dev
+  
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cz-agent-aggregator-custom-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
 ---
 # Source: cloudzero-agent/templates/init-cert-clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1908,6 +1998,10 @@ spec:
       protocol: TCP
       port: 80
       targetPort: 8080
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 8443
   type: ClusterIP
 ---
 # Source: cloudzero-agent/templates/webhook-service.yaml
@@ -2263,10 +2357,14 @@ spec:
           ports:
             - name: port-collector
               containerPort: 8080
+            - name: port-coll-tls
+              containerPort: 8443
           command: ["/app/cloudzero-collector", "-config", "/cloudzero/config/config.yml"]
           env:
             - name: SERVER_PORT
               value: "8080"
+            - name: SERVER_TLS_PORT
+              value: "8443"
           volumeMounts:
             - name: cloudzero-api-key
               mountPath: /etc/config/secrets/
@@ -2277,6 +2375,9 @@ spec:
               readOnly: true
             - name: aggregator-persistent-storage
               mountPath: /cloudzero/data
+            - name: aggregator-tls-certs
+              mountPath: /etc/certs
+              readOnly: true
           readinessProbe:
             httpGet:
               path: /healthz
@@ -2368,6 +2469,9 @@ spec:
         - name: aggregator-config-volume
           configMap:
             name: cz-agent-aggregator
+        - name: aggregator-tls-certs
+          secret:
+            secretName: cz-agent-aggregator-tls
         - name: aggregator-persistent-storage
           emptyDir:
             {}
@@ -2482,6 +2586,145 @@ spec:
         - name: cloudzero-api-key
           secret:
             secretName: cz-agent-api-key
+---
+# Source: cloudzero-agent/templates/aggregator-hpa.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: cz-agent-aggregator
+  namespace: cz-agent
+  
+  labels:
+    app.kubernetes.io/component: aggregator
+    app.kubernetes.io/instance: cz-agent
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
+    app.kubernetes.io/part-of: cloudzero-agent
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: cloudzero-agent-1.1.0-dev
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cz-agent-aggregator
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Pods
+    pods:
+      metric:
+        name: czo_cost_metrics_shipping_progress
+      target:
+        type: AverageValue
+        averageValue: 900m
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+      selectPolicy: Max
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60
+      - type: Pods
+        value: 1
+        periodSeconds: 60
+      selectPolicy: Min
+---
+# Source: cloudzero-agent/templates/aggregator-init-cert-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cz-agent-aggregator-init-cert
+  namespace: cz-agent
+  labels:
+    app.kubernetes.io/component: aggregator
+    app.kubernetes.io/instance: cz-agent
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
+    app.kubernetes.io/part-of: cloudzero-agent
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: cloudzero-agent-1.1.0-dev
+  
+spec:
+  template:
+    metadata:
+      name: cz-agent-aggregator-init-cert
+      labels:
+        app.kubernetes.io/component: aggregator
+        app.kubernetes.io/instance: cz-agent
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cz-agent-aggregator
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v2.55.1
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: cz-agent-cloudzero-agent-server
+      
+      containers:
+      - name: create-cert
+        image: "docker.io/bitnami/kubectl:1.33.1"
+        imagePullPolicy: "IfNotPresent"
+        command: ["/bin/bash", "-c"]
+        workingDir: /var/tmp
+        args:
+          - |
+            #!/bin/bash
+            set -e
+            
+            SECRET_NAME="cz-agent-aggregator-tls"
+            SERVICE_NAME="cz-agent-aggregator"
+            NAMESPACE="cz-agent"
+            
+            EXISTING_TLS_CRT=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.tls\.crt}' 2>/dev/null || echo "")
+            EXISTING_TLS_KEY=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.tls\.key}' 2>/dev/null || echo "")
+            
+            GENERATE_CERTIFICATE=false
+            
+            if [[ -n "$EXISTING_TLS_CRT" && -n "$EXISTING_TLS_KEY" ]]; then
+              # Check if the certificate is valid for our service
+              SAN=$(echo "$EXISTING_TLS_CRT" | base64 -d | openssl x509 -text -noout | grep DNS | sed 's/.*DNS://' || echo "")
+              if [[ "$SAN" != "$SERVICE_NAME.$NAMESPACE.svc" ]]; then
+                echo "The SANs in the certificate do not match the service name."
+                GENERATE_CERTIFICATE=true
+              fi
+            else
+              echo "TLS Secret is missing or incomplete."
+              GENERATE_CERTIFICATE=true
+            fi
+            
+            if [[ $GENERATE_CERTIFICATE == "true" ]]; then
+              echo "Generating new TLS certificate for $SERVICE_NAME.$NAMESPACE.svc"
+              
+              # Generate self-signed certificate and private key
+              openssl req -x509 -newkey rsa:2048 -keyout tls.key -out tls.crt -days 36500 -nodes \
+                -subj "/CN=$SERVICE_NAME.$NAMESPACE.svc" \
+                -addext "subjectAltName = DNS:$SERVICE_NAME.$NAMESPACE.svc"
+              
+              # Base64 encode the certificate and key
+              TLS_CRT=$(cat tls.crt | base64 | tr -d '\n')
+              TLS_KEY=$(cat tls.key | base64 | tr -d '\n')
+              
+              # Create or update the TLS Secret
+              kubectl create secret tls $SECRET_NAME \
+                --cert=tls.crt \
+                --key=tls.key \
+                --namespace=$NAMESPACE \
+                --dry-run=client -o yaml | kubectl apply -f -
+              
+              echo "TLS certificate created/updated successfully"
+            else
+              echo "Valid certificate already exists for $SERVICE_NAME.$NAMESPACE.svc"
+            fi
 ---
 # Source: cloudzero-agent/templates/backfill-job.yaml
 apiVersion: batch/v1
@@ -2813,6 +3056,32 @@ spec:
                 --type='json' \
                 -p="[{'op': 'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value':'$CA_BUNDLE'}]"
               exit 0
+---
+# Source: cloudzero-agent/templates/custom-metrics-apiservice.yaml
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.custom.metrics.k8s.io
+  namespace: cz-agent
+  labels:
+    app.kubernetes.io/component: aggregator
+    app.kubernetes.io/instance: cz-agent
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: cz-agent-aggregator
+    app.kubernetes.io/part-of: cloudzero-agent
+    app.kubernetes.io/version: v2.55.1
+    helm.sh/chart: cloudzero-agent-1.1.0-dev
+  
+spec:
+  service:
+    name: cz-agent-aggregator
+    namespace: cz-agent
+    port: 443
+  group: custom.metrics.k8s.io
+  version: v1beta1
+  groupPriorityMinimum: 100
+  versionPriority: 100
+  caBundle:
 ---
 # Source: cloudzero-agent/templates/webhook-validating-config.yaml
 apiVersion: admissionregistration.k8s.io/v1

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -711,6 +711,11 @@ data:
           requests:
             cpu: 100m
             memory: 64Mi
+        tls:
+          mountPath: /etc/certs
+          secret:
+            create: true
+            name: ""
       database:
         compressionLevel: 8
         costMaxInterval: 30m
@@ -737,6 +742,32 @@ data:
       nodeSelector: {}
       profiling: false
       reconnectFrequency: 16
+      scaling:
+        annotations: {}
+        behavior:
+          scaleDown:
+            policies:
+            - periodSeconds: 60
+              type: Percent
+              value: 50
+            - periodSeconds: 60
+              type: Pods
+              value: 1
+            selectPolicy: Min
+            stabilizationWindowSeconds: 300
+          scaleUp:
+            policies:
+            - periodSeconds: 60
+              type: Percent
+              value: 100
+            - periodSeconds: 60
+              type: Pods
+              value: 2
+            selectPolicy: Max
+            stabilizationWindowSeconds: 300
+        maxReplicas: 10
+        minReplicas: 1
+        targetValue: 900m
       shipper:
         port: 8081
         resources:
@@ -759,6 +790,7 @@ data:
         podDisruptionBudget: null
       aggregator:
         annotations: {}
+        autoscale: false
         podDisruptionBudget: null
         replicas: 3
         tolerations: []
@@ -1728,6 +1760,8 @@ rules:
       - get
       - list
       - patch
+      - create
+      - update
   - apiGroups:
       - "admissionregistration.k8s.io"
     resources:
@@ -1854,7 +1888,8 @@ spec:
     app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/instance: cz-agent
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 80
       targetPort: 8080
   type: ClusterIP
@@ -2230,6 +2265,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
@@ -2237,6 +2273,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+              scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
@@ -2271,14 +2308,14 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: 8081
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: 8081
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -780,6 +780,11 @@ data:
           requests:
             cpu: 100m
             memory: 64Mi
+        tls:
+          mountPath: /etc/certs
+          secret:
+            create: true
+            name: ""
       database:
         compressionLevel: 8
         costMaxInterval: 30m
@@ -806,6 +811,32 @@ data:
       nodeSelector: {}
       profiling: false
       reconnectFrequency: 16
+      scaling:
+        annotations: {}
+        behavior:
+          scaleDown:
+            policies:
+            - periodSeconds: 60
+              type: Percent
+              value: 50
+            - periodSeconds: 60
+              type: Pods
+              value: 1
+            selectPolicy: Min
+            stabilizationWindowSeconds: 300
+          scaleUp:
+            policies:
+            - periodSeconds: 60
+              type: Percent
+              value: 100
+            - periodSeconds: 60
+              type: Pods
+              value: 2
+            selectPolicy: Max
+            stabilizationWindowSeconds: 300
+        maxReplicas: 10
+        minReplicas: 1
+        targetValue: 900m
       shipper:
         port: 8081
         resources:
@@ -828,6 +859,7 @@ data:
         podDisruptionBudget: null
       aggregator:
         annotations: {}
+        autoscale: false
         podDisruptionBudget: null
         replicas: 3
         tolerations: []
@@ -1797,6 +1829,8 @@ rules:
       - get
       - list
       - patch
+      - create
+      - update
   - apiGroups:
       - "admissionregistration.k8s.io"
     resources:
@@ -1923,7 +1957,8 @@ spec:
     app.kubernetes.io/name: cz-agent-aggregator
     app.kubernetes.io/instance: cz-agent
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 80
       targetPort: 8080
   type: ClusterIP
@@ -2448,6 +2483,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+              scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
@@ -2455,6 +2491,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+              scheme: HTTP
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
@@ -2489,14 +2526,14 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: 8081
             initialDelaySeconds: 10
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8080
+              port: 8081
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3


### PR DESCRIPTION
## Why?

To automatically scale aggregator replicas up/down.

## What

This change adds Kubernetes Horizontal Pod Autoscaler (HPA) support with a custom metrics API implementation for the CloudZero agent. The existing agent relied on manual scaling, which wasn't responsive to actual workload demands and could lead to resource inefficiencies.

The implementation exposes a Kubernetes custom metrics API v1beta1 endpoint that serves the `czo_cost_metrics_shipping_progress` metric from the collector. This metric represents the percentage of pending metrics relative to the maximum record limit, allowing HPA to scale the aggregator deployment based on actual workload pressure.

Key technical changes include:
 - Custom metrics API handlers implementing the v1beta1 specification
 - Discovery endpoints for API resource enumeration
 - Integration with existing metric collector to expose shipping progress
 - HPA configuration templates with proper RBAC permissions
 - Comprehensive test coverage and documentation

The approach eliminates external dependencies like Prometheus Adapter by implementing the custom metrics API directly in the collector, creating a self-contained autoscaling solution that scales based on the agent's own internal metrics rather than external observability infrastructure.

## How Tested

Lots of deploying and, and *lots and lots* of waiting.