### PR TITLE
CP-30788: add release notes for v1.2.4

### DIFF
--- a/helm/docs/releases/1.2.4.md
+++ b/helm/docs/releases/1.2.4.md
@@ -1,0 +1,25 @@
+## [1.2.4](https://github.com/Cloudzero/cloudzero-agent/compare/v1.2.3...v1.2.4) (2025-07-17)
+
+Release 1.2.4 is a maintenance release including **Improved Metrics Filtering**, and **Collector Interval Adjustments** for better performance. This release focuses on operational improvements, build efficiency, and enhanced visibility into metric processing.
+
+### Key Features
+
+- **Optimized Collection Intervals**: Increased cost metrics collection interval from 10 minutes to 30 minutes for better performance in smaller clusters, while reducing observability metrics timeout to 10 minutes to maintain cluster connectivity visibility.
+- **Enhanced Scout Auto-Detection**: The confload job now leverages the Scout system to automatically detect cloud environment metadata (region, account ID, cluster name) when these values are not explicitly provided, significantly simplifying deployment configuration.
+- **Dramatic Docker Build Performance**: Build times reduced from 2:30-3:00 minutes to ~12 seconds through multi-stage builds with platform-specific caching, selective file copying, and conditional dependency generation.
+- **Dropped Metrics Tracking**: The metric filter now provides visibility into filtered-out metrics through debug logging, making it easier to debug filter configurations and understand metric processing behavior.
+
+### Additional Enhancements
+
+- **Backfiller Reliability**: Fixed GroupVersionKind issues and race conditions in namespace and node processing, with comprehensive integration testing.
+- **Test Infrastructure**: Improved test reliability by fixing flaky tests related to file monitoring, file locking, and SQL timestamp formatting.
+- **Development Tooling**: Added semantic diff targets (`*.{yaml,json}-semdiff`) for better visibility into Helm template changes during development.
+- **Dependency Management**: Updated Dependabot to run on Wednesdays instead of Fridays for better alignment with patch release cycles.
+
+### Upgrade Steps
+
+To upgrade to version 1.2.4, run the following command:
+
+```sh
+helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.2.4
+```


### PR DESCRIPTION
## Why?

So we can release v1.2.4

## What

Add release notes.

## How Tested

`[ -e helm/docs/releases/1.2.4.md ] && echo ":)" || echo ":("`