### PR TITLE
CP-30788: fix release-to-main action

### DIFF
--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Update image version in Helm chart
         run: |
           sed -ri "s/^( *[a-z]*): +[^ ]+  (# <- Software release corresponding to this chart version.)$/\1: ${{ github.event.inputs.version }}  \2/" helm/values.yaml helm/templates/_helpers.tpl
-          make helm-generate-tests format app/functions/helmless/default-values.yaml
+          make helm-test-template app/functions/helmless/default-values.yaml format
           git add helm/values.yaml helm/templates/*.tpl tests/helm/template/*.yaml app/functions/helmless/default-values.yaml
           if ! git diff --quiet --staged; then
             git commit -m "Update image version in Helm chart to ${{ github.event.inputs.version }}"


### PR DESCRIPTION
## Why?

One of the make targets (`helm-generate-tests`) moved (to `helm-test-template`, for consistency with other `helm-test-*` targets), but I forgot to update this workflow.

## What

Replace `helm-generate-tests` with `helm-test-template`

## How Tested

`make helm-test-template`, but the we can really only test the action by running it :(
