### PR TITLE
CP-29639: update KSM, kubectl, and prometheus-config-reloader images

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -201,7 +201,7 @@ components:
   kubectl:
     image:
       repository: docker.io/bitnami/kubectl
-      tag: "1.33.1"
+      tag: "1.33.3"
 
   # prometheus contains details about where to find the Prometheus image.
   # Prometheus is critical to the functionality of this chart, and is used to
@@ -219,7 +219,7 @@ components:
   prometheusReloader:
     image:
       repository: quay.io/prometheus-operator/prometheus-config-reloader
-      tag: "v0.83.0"
+      tag: "v0.84.0"
 
   # Settings for the aggregator component. This is the piece which accepts
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
@@ -264,7 +264,7 @@ kubeStateMetrics:
   image:
     registry: registry.k8s.io
     repository: kube-state-metrics/kube-state-metrics
-    tag: "v2.15.0"
+    tag: "v2.16.0"
     sha:
     pullPolicy: IfNotPresent
   imagePullSecrets: []

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -765,7 +765,7 @@ data:
       kubectl:
         image:
           repository: docker.io/bitnami/kubectl
-          tag: 1.33.1
+          tag: 1.33.3
       prometheus:
         image:
           repository: quay.io/prometheus/prometheus
@@ -773,7 +773,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.83.0
+          tag: v0.84.0
       webhookServer:
         podDisruptionBudget: null
         replicas: 3
@@ -993,7 +993,7 @@ data:
         pullPolicy: IfNotPresent
         registry: registry.k8s.io
         repository: kube-state-metrics/kube-state-metrics
-        tag: v2.15.0
+        tag: v2.16.0
       imagePullSecrets: []
       initContainers: []
       kubeRBACProxy:
@@ -1937,7 +1937,7 @@ spec:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2061,7 +2061,7 @@ spec:
               mountPath: /checks/config/
       containers:
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -834,7 +834,7 @@ data:
       kubectl:
         image:
           repository: docker.io/bitnami/kubectl
-          tag: 1.33.1
+          tag: 1.33.3
       prometheus:
         image:
           repository: quay.io/prometheus/prometheus
@@ -842,7 +842,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.83.0
+          tag: v0.84.0
       webhookServer:
         podDisruptionBudget: null
         replicas: 3
@@ -1062,7 +1062,7 @@ data:
         pullPolicy: IfNotPresent
         registry: registry.k8s.io
         repository: kube-state-metrics/kube-state-metrics
-        tag: v2.15.0
+        tag: v2.16.0
       imagePullSecrets: []
       initContainers: []
       kubeRBACProxy:
@@ -1997,7 +1997,7 @@ spec:
         # in the prometheus.yml.in file with the actual node name, then use that
         # processed file in the container.
         - name: config-subst
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/sh
@@ -2015,7 +2015,7 @@ spec:
               mountPath: /etc/config/prometheus/configmaps/processed/
       containers:
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -2155,7 +2155,7 @@ spec:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2279,7 +2279,7 @@ spec:
               mountPath: /checks/config/
       containers:
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -2903,7 +2903,7 @@ spec:
       
       containers:
         - name: init-cert
-          image: "docker.io/bitnami/kubectl:1.33.1"
+          image: "docker.io/bitnami/kubectl:1.33.3"
           imagePullPolicy: "IfNotPresent"
           command: ["/bin/bash", "-c"]
           workingDir: /var/tmp

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -781,7 +781,7 @@ data:
       kubectl:
         image:
           repository: docker.io/bitnami/kubectl
-          tag: 1.33.1
+          tag: 1.33.3
       prometheus:
         image:
           repository: quay.io/prometheus/prometheus
@@ -789,7 +789,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.83.0
+          tag: v0.84.0
       webhookServer:
         podDisruptionBudget: null
         replicas: 3
@@ -1009,7 +1009,7 @@ data:
         pullPolicy: IfNotPresent
         registry: registry.k8s.io
         repository: kube-state-metrics/kube-state-metrics
-        tag: v2.15.0
+        tag: v2.16.0
       imagePullSecrets: []
       initContainers: []
       kubeRBACProxy:
@@ -1953,7 +1953,7 @@ spec:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2077,7 +2077,7 @@ spec:
               mountPath: /checks/config/
       containers:
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -2701,7 +2701,7 @@ spec:
       
       containers:
         - name: init-cert
-          image: "docker.io/bitnami/kubectl:1.33.1"
+          image: "docker.io/bitnami/kubectl:1.33.3"
           imagePullPolicy: "IfNotPresent"
           command: ["/bin/bash", "-c"]
           workingDir: /var/tmp


### PR DESCRIPTION
## Why?

These are just the dependencies Dependabot can't handle updating for us.

## What

* kubectl 1.33.1 -> 1.33.3
* prometheus-config-reloader 0.83.0 -> 0.84.0
* kube-state-metrics 2.15.0 -> 2.16.0

All three are the latest release

## How Tested

Deploy, make sure nothing breaks horribly.