### PR TITLE
CP-31334: return project *number* not project ID, from scout

### DIFF
--- a/app/utils/scout/google/google.go
+++ b/app/utils/scout/google/google.go
@@ -19,7 +19,7 @@ import (
 const (
 	// GCP metadata service endpoints
 	metadataBaseURL     = "http://metadata.google.internal/computeMetadata/v1"
-	projectEndpoint     = metadataBaseURL + "/project/project-id"
+	projectEndpoint     = metadataBaseURL + "/project/numeric-project-id"
 	zoneEndpoint        = metadataBaseURL + "/instance/zone"
 	clusterNameEndpoint = metadataBaseURL + "/instance/attributes/cluster-name"
 
@@ -41,10 +41,10 @@ func NewScout() *Scout {
 
 // EnvironmentInfo retrieves GCP environment information from metadata service
 func (s *Scout) EnvironmentInfo(ctx context.Context) (*types.EnvironmentInfo, error) {
-	// Get project ID (equivalent to account ID)
-	projectID, err := s.getMetadata(ctx, projectEndpoint)
+	// Get project number (equivalent to account ID)
+	projectNumber, err := s.getMetadata(ctx, projectEndpoint)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get project ID: %w", err)
+		return nil, fmt.Errorf("failed to get project number: %w", err)
 	}
 
 	// Get zone (to extract region)
@@ -67,7 +67,7 @@ func (s *Scout) EnvironmentInfo(ctx context.Context) (*types.EnvironmentInfo, er
 	return &types.EnvironmentInfo{
 		CloudProvider: types.CloudProviderGoogle,
 		Region:        strings.TrimSpace(region),
-		AccountID:     strings.TrimSpace(projectID),
+		AccountID:     strings.TrimSpace(projectNumber),
 		ClusterName:   strings.TrimSpace(clusterName),
 	}, nil
 }

--- a/app/utils/scout/google/google_test.go
+++ b/app/utils/scout/google/google_test.go
@@ -106,9 +106,9 @@ func TestEnvironmentInfo_Success(t *testing.T) {
 		}
 
 		switch r.URL.Path {
-		case "/computeMetadata/v1/project/project-id":
+		case "/computeMetadata/v1/project/numeric-project-id":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("test-project-123"))
+			w.Write([]byte("123456789"))
 
 		case "/computeMetadata/v1/instance/zone":
 			w.WriteHeader(http.StatusOK)
@@ -142,8 +142,8 @@ func TestEnvironmentInfo_Success(t *testing.T) {
 		t.Errorf("Expected region 'us-central1', got '%s'", info.Region)
 	}
 
-	if info.AccountID != "test-project-123" {
-		t.Errorf("Expected account ID 'test-project-123', got '%s'", info.AccountID)
+	if info.AccountID != "123456789" {
+		t.Errorf("Expected account ID '123456789', got '%s'", info.AccountID)
 	}
 
 	if info.ClusterName != "test-cluster-name" {
@@ -158,7 +158,7 @@ func TestEnvironmentInfo_ProjectIDFailure(t *testing.T) {
 			return
 		}
 
-		if r.URL.Path == "/computeMetadata/v1/project/project-id" {
+		if r.URL.Path == "/computeMetadata/v1/project/numeric-project-id" {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -173,11 +173,11 @@ func TestEnvironmentInfo_ProjectIDFailure(t *testing.T) {
 
 	_, err := scout.EnvironmentInfo(ctx)
 	if err == nil {
-		t.Error("Expected error for project ID failure")
+		t.Error("Expected error for project number failure")
 	}
 
-	if !strings.Contains(err.Error(), "failed to get project ID") {
-		t.Errorf("Expected project ID error, got: %v", err)
+	if !strings.Contains(err.Error(), "failed to get project number") {
+		t.Errorf("Expected project number error, got: %v", err)
 	}
 }
 
@@ -190,9 +190,9 @@ func TestEnvironmentInfo_ClusterNameNotAvailable(t *testing.T) {
 		}
 
 		switch r.URL.Path {
-		case "/computeMetadata/v1/project/project-id":
+		case "/computeMetadata/v1/project/numeric-project-id":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("test-project-123"))
+			w.Write([]byte("123456789"))
 
 		case "/computeMetadata/v1/instance/zone":
 			w.WriteHeader(http.StatusOK)
@@ -225,8 +225,8 @@ func TestEnvironmentInfo_ClusterNameNotAvailable(t *testing.T) {
 		t.Errorf("Expected region 'us-central1', got '%s'", info.Region)
 	}
 
-	if info.AccountID != "test-project-123" {
-		t.Errorf("Expected account ID 'test-project-123', got '%s'", info.AccountID)
+	if info.AccountID != "123456789" {
+		t.Errorf("Expected account ID '123456789', got '%s'", info.AccountID)
 	}
 
 	// Cluster name should be empty when not available
@@ -243,9 +243,9 @@ func TestEnvironmentInfo_ZoneFailure(t *testing.T) {
 		}
 
 		switch r.URL.Path {
-		case "/computeMetadata/v1/project/project-id":
+		case "/computeMetadata/v1/project/numeric-project-id":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("test-project-123"))
+			w.Write([]byte("123456789"))
 
 		case "/computeMetadata/v1/instance/zone":
 			w.WriteHeader(http.StatusInternalServerError)
@@ -291,7 +291,7 @@ func TestEnvironmentInfo_MissingMetadataHeader(t *testing.T) {
 	defer cancel()
 
 	// Make a request without the header (this tests our implementation sets it correctly)
-	req, err := http.NewRequestWithContext(ctx, "GET", server.URL+"/computeMetadata/v1/project/project-id", nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", server.URL+"/computeMetadata/v1/project/numeric-project-id", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -335,9 +335,9 @@ func TestEnvironmentInfo_WhitespaceHandling(t *testing.T) {
 		}
 
 		switch r.URL.Path {
-		case "/computeMetadata/v1/project/project-id":
+		case "/computeMetadata/v1/project/numeric-project-id":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("  test-project-123  ")) // Whitespace
+			w.Write([]byte("  123456789  ")) // Whitespace
 
 		case "/computeMetadata/v1/instance/zone":
 			w.WriteHeader(http.StatusOK)
@@ -364,8 +364,8 @@ func TestEnvironmentInfo_WhitespaceHandling(t *testing.T) {
 		t.Errorf("Expected region 'us-central1', got '%s'", info.Region)
 	}
 
-	if info.AccountID != "test-project-123" {
-		t.Errorf("Expected account ID 'test-project-123', got '%s'", info.AccountID)
+	if info.AccountID != "123456789" {
+		t.Errorf("Expected account ID '123456789', got '%s'", info.AccountID)
 	}
 }
 
@@ -490,7 +490,7 @@ func TestConstants(t *testing.T) {
 	}
 
 	// Verify endpoints are correctly constructed
-	expectedProjectEndpoint := metadataBaseURL + "/project/project-id"
+	expectedProjectEndpoint := metadataBaseURL + "/project/numeric-project-id"
 	if projectEndpoint != expectedProjectEndpoint {
 		t.Errorf("Expected projectEndpoint %q, got %q", expectedProjectEndpoint, projectEndpoint)
 	}


### PR DESCRIPTION
## Why?

Because we want the project number, not the project ID

## What

Tweak the scout to return the project number

## How Tested

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: scout-job
  namespace: cza
spec:
  ttlSecondsAfterFinished: 3600
  template:
    spec:
      restartPolicy: Never
      containers:
      - name: scout
        image: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:dev-599b04627281ad4fb8bbdbff63046f7d3ae3d572
        command: ["/app/cloudzero-scout", "info"]
        resources:
          requests:
            memory: "64Mi"
            cpu: "50m"
          limits:
            memory: "128Mi"
            cpu: "100m"
```

Then `kubectl logs` on the job.