### PR TITLE
CP-29890: remove observability files on upload

### DIFF
--- a/app/domain/shipper/shipper.go
+++ b/app/domain/shipper/shipper.go
@@ -318,8 +318,8 @@ func (m *MetricShipper) HandleRequest(ctx context.Context, files []types.File) e
 						return err
 					}
 
-					// if log file, remove it. we do not need to store these after upload
-					if strings.HasPrefix(req.File.UniqueID(), disk.LogsContentIdentifider) {
+					// if not a metric file, remove it. we do not need to store these after upload
+					if !strings.HasPrefix(req.File.UniqueID(), disk.CostContentIdentifier) {
 						if err := os.Remove(req.File.Location()); err != nil {
 							logger.Err(err).Str("file", req.File.UniqueID()).Msg("failed to remove log file")
 						}

--- a/tests/smoke/client_test.go
+++ b/tests/smoke/client_test.go
@@ -77,7 +77,7 @@ func TestSmoke_ClientApplication_Runs(t *testing.T) {
 		// number of s3 files that are not logs
 		countUploaded := 0
 		for _, item := range response.Objects {
-			if !strings.HasPrefix(item.Key, "logs") {
+			if strings.HasPrefix(item.Key, "metrics") {
 				countUploaded++
 			}
 		}

--- a/tests/smoke/shipper_test.go
+++ b/tests/smoke/shipper_test.go
@@ -77,7 +77,8 @@ func TestSmoke_Shipper_WithMockRemoteWrite(t *testing.T) {
 		uploaded, err := filepath.Glob(filepath.Join(t.dataLocation, "uploaded", "*_*_*.json.br"))
 		require.NoError(t, err, "failed to read the uploaded directory")
 		// ensure all files were uploaded, but account for the shipper purging up to 20% of the files
-		require.GreaterOrEqual(t, len(uploaded), int(float64(numMetricFiles)*0.8))
+		// (divide by 2 since t.WriteTestMetrics creates half metric files half observability files)
+		require.GreaterOrEqual(t, len(uploaded), int(float64(numMetricFiles/2)*0.8))
 	}, withConfigOverride(func(settings *config.Settings) {
 		settings.Cloudzero.SendInterval = time.Second * 10
 		settings.Cloudzero.UseHTTP = true
@@ -218,7 +219,8 @@ func TestSmoke_Shipper_ReplayRequest_Invalid_Payload(t *testing.T) {
 		uploaded, err := filepath.Glob(filepath.Join(t.dataLocation, "uploaded", "*_*_*.json.br"))
 		require.NoError(t, err, "failed to read the uploaded directory")
 		// ensure all files were uploaded, but account for the shipper purging up to 20% of the files
-		require.GreaterOrEqual(t, len(uploaded), int(float64(numMetricFiles)*0.8))
+		// (divide by 2 since t.WriteTestMetrics creates half metric files half observability files)
+		require.GreaterOrEqual(t, len(uploaded), int(float64(numMetricFiles/2)*0.8))
 	}, withConfigOverride(func(settings *config.Settings) {
 		settings.Cloudzero.SendInterval = time.Second * 10
 		settings.Cloudzero.UseHTTP = true


### PR DESCRIPTION
## Why?

We are never going to need to replay observability files, so why store them in uploaded? We should only be using the customer's space for information they themselves will need.

## What

Quick change to the file processing code post-upload to remove observability files in addition to log files.

## How Tested

Our existing tests are enough to cover this change
