### PR TITLE
CP-29621: Improve shipper logging and fix replay file processing

### DIFF
--- a/app/domain/shipper/abandon.go
+++ b/app/domain/shipper/abandon.go
@@ -94,7 +94,12 @@ func (m *MetricShipper) AbandonFiles(ctx context.Context, payload []*AbandonAPIP
 
 		defer resp.Body.Close()
 
-		logger.Debug().Msg("Successfully abandoned files")
+		for _, file := range payload {
+			logger.Debug().
+				Str("reference_id", file.ReferenceID).
+				Str("reason", file.Reason).
+				Msg("Successfully abandoned file")
+		}
 
 		// success
 		return nil

--- a/app/domain/shipper/shipper.go
+++ b/app/domain/shipper/shipper.go
@@ -281,7 +281,7 @@ func (m *MetricShipper) HandleRequest(ctx context.Context, files []types.File) e
 
 			// search the file tree for the replay request files
 			for k, v := range urlResponse.Replay {
-				if paths, err := m.store.Find(ctx, GetRootFileID(k), ".json.br"); err != nil {
+				if paths, err := m.store.Find(ctx, GetRootFileID(k), ".json.br"); err == nil {
 					for _, path := range paths {
 						if file, err := disk.NewMetricFile(path); err == nil {
 							requests = append(requests, &UploadFileRequest{


### PR DESCRIPTION
## Summary
- Enhanced abandon operation logging to include file-specific details (reference_id and reason) for better observability
- Fixed replay file processing logic to correctly handle successful Find operations by changing error condition

## Test plan
- [x] All unit tests pass
- [x] Integration tests pass  
- [x] Build completes successfully
- [x] Linting and formatting checks pass
- [x] Static analysis passes