### PR TITLE
CP-31763: allow quoted cloudAccountId in JSON schema

### DIFF
--- a/helm/tests/cleanstring_quote_stripping_test.yaml
+++ b/helm/tests/cleanstring_quote_stripping_test.yaml
@@ -1,0 +1,33 @@
+suite: test cleanString quote stripping functionality
+templates:
+  - templates/config-loader-job.yaml
+tests:
+  # Test that quoted numeric cloudAccountId values are stripped of quotes in config-loader job command
+  - it: should strip quotes from quoted numeric cloudAccountId in config-loader job command
+    set:
+      cloudAccountId: "'123456789012'"
+      apiKey: "fake-key"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: "123456789012"
+
+  # Test that quoted UUID cloudAccountId values are stripped of quotes in config-loader job command
+  - it: should strip quotes from quoted UUID cloudAccountId in config-loader job command
+    set:
+      cloudAccountId: "'123e4567-e89b-12d3-a456-426614174000'"
+      apiKey: "fake-key"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: "123e4567-e89b-12d3-a456-426614174000"
+
+  # Test that unquoted cloudAccountId values remain unchanged in config-loader job command
+  - it: should preserve unquoted numeric cloudAccountId in config-loader job command
+    set:
+      cloudAccountId: "123456789012"
+      apiKey: "fake-key"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: "123456789012"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -3620,7 +3620,7 @@
       "type": ["string", "null"]
     },
     "cloudAccountId": {
-      "pattern": "^$|^[0-9]+$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "pattern": "^$|^[0-9]+$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$|^'[0-9]+'$|^'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'$",
       "type": "string"
     },
     "clusterName": {

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -117,22 +117,33 @@ properties:
   cloudAccountId:
     type: "string"
     # Empty string or numeric string or UUID
-    pattern: "^$|^[0-9]+$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    pattern: "^$|^[0-9]+$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$|^'[0-9]+'$|^'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'$"
     description: |
+      *WARNING*: use of this property is generally discouraged as in most cases
+      it can be detected automatically.
+
       The cloud account ID. Must be either:
         - Empty string (use auto-detected value)
         - Numeric string (AWS account ID or Google Cloud project number)
         - UUID (Azure subscription ID)
+        - Any of the above enclosed in balanced single quotes (e.g., '1234567890')
   clusterName:
     type: string
     pattern: ^(|[a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,251}[a-zA-Z0-9])?)$
     description: |
+      *NOTE*: use of this property on Google Cloud is generally discouraged as
+      in most cases it can be detected automatically. However, on AWS and Azure
+      it is required.
+
       The name of the Kubernetes cluster.
   region:
     type:
       - string
       - "null"
     description: |
+      *WARNING*: use of this property is generally discouraged as in most cases
+      it can be detected automatically.
+
       The cloud provider region.
   apiKey:
     type:

--- a/tests/helm/schema/cloudAccountId.double-quotes.fail.yaml
+++ b/tests/helm/schema/cloudAccountId.double-quotes.fail.yaml
@@ -1,0 +1,2 @@
+# Test that double quotes fail validation
+cloudAccountId: '"123456789012"'

--- a/tests/helm/schema/cloudAccountId.empty-quotes.fail.yaml
+++ b/tests/helm/schema/cloudAccountId.empty-quotes.fail.yaml
@@ -1,0 +1,2 @@
+# Test that empty quotes fail validation
+cloudAccountId: "''"

--- a/tests/helm/schema/cloudAccountId.empty.fail.yaml
+++ b/tests/helm/schema/cloudAccountId.empty.fail.yaml
@@ -1,2 +1,0 @@
-# Test that invalid values fail validation
-cloudAccountId: "invalid-value"

--- a/tests/helm/schema/cloudAccountId.mixed-quotes.fail.yaml
+++ b/tests/helm/schema/cloudAccountId.mixed-quotes.fail.yaml
@@ -1,0 +1,2 @@
+# Test that mixed quotes in the middle fail validation
+cloudAccountId: "12345'67890"

--- a/tests/helm/schema/cloudAccountId.quoted-numeric.pass.yaml
+++ b/tests/helm/schema/cloudAccountId.quoted-numeric.pass.yaml
@@ -1,0 +1,2 @@
+# Test that quoted numeric strings pass validation (AWS account ID or Google Cloud project number)
+cloudAccountId: "'123456789012'"

--- a/tests/helm/schema/cloudAccountId.quoted-uuid.pass.yaml
+++ b/tests/helm/schema/cloudAccountId.quoted-uuid.pass.yaml
@@ -1,0 +1,2 @@
+# Test that quoted UUID strings pass validation (Azure subscription ID)
+cloudAccountId: "'123e4567-e89b-12d3-a456-426614174000'"

--- a/tests/helm/schema/cloudAccountId.unbalanced-quotes-end.fail.yaml
+++ b/tests/helm/schema/cloudAccountId.unbalanced-quotes-end.fail.yaml
@@ -1,0 +1,2 @@
+# Test that unbalanced quotes at the end fail validation
+cloudAccountId: "123456789012'"

--- a/tests/helm/schema/cloudAccountId.unbalanced-quotes.fail.yaml
+++ b/tests/helm/schema/cloudAccountId.unbalanced-quotes.fail.yaml
@@ -1,0 +1,2 @@
+# Test that unbalanced quotes fail validation
+cloudAccountId: "'123456789012"


### PR DESCRIPTION
This change addresses user experience issues with numeric cloudAccountId values and provides clearer guidance on manual configuration.

- Modified schema pattern to allow balanced single quotes around values (e.g., '1234567890', '123e4567-e89b-12d3-a456-426614174000')
- Added comprehensive test coverage for all quote scenarios:
  * Valid: quoted numeric, quoted UUID
  * Invalid: unbalanced quotes, mixed quotes, double quotes, empty quotes
- Added Helm unittest test to verify quote stripping functionality

Helm can interpret numeric strings as integers and convert them to scientific notation (e.g., 1234567890 becomes 1.2e+09 or something). By allowing quoted values, users can ensure numeric cloudAccountIds are treated as strings even when using templating like `cloudAccountId: {{ $myCloudAccountId }}` instead of `cloudAccountId: "{{ $myCloudAccountId }}"`.

I also added warning notes to discourage manual configuration of properties which can typically be auto-detected. `cloudAccountId` and `region` can generally be detected automatically, and `clusterName` can be detected on Google Cloud.

## How Tested

I've added several tests, both schema tests and helm unittest tests.