### PR TITLE
CP-31762: bump go version from 1.24.5 to 1.24.6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG DEPLOY_IMAGE=scratch
 # 5. final: Minimal runtime image with compiled binaries
 
 # Stage 1: Base tools installation
-FROM --platform=$BUILDPLATFORM golang:1.24.5-alpine AS base-tools
+FROM --platform=$BUILDPLATFORM golang:1.24.6-alpine AS base-tools
 ARG TARGETPLATFORM
 ARG TARGETOS TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudzero/cloudzero-agent
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/tests/docker/Dockerfile.collector
+++ b/tests/docker/Dockerfile.collector
@@ -1,4 +1,4 @@
-FROM golang:1.24.5 AS builder
+FROM golang:1.24.6 AS builder
 
 WORKDIR /app
 

--- a/tests/docker/Dockerfile.controller
+++ b/tests/docker/Dockerfile.controller
@@ -1,4 +1,4 @@
-FROM golang:1.24.5 AS builder
+FROM golang:1.24.6 AS builder
 
 WORKDIR /app
 

--- a/tests/docker/Dockerfile.remotewrite
+++ b/tests/docker/Dockerfile.remotewrite
@@ -1,4 +1,4 @@
-FROM golang:1.24.5 AS builder
+FROM golang:1.24.6 AS builder
 
 WORKDIR /app
 

--- a/tests/docker/Dockerfile.shipper
+++ b/tests/docker/Dockerfile.shipper
@@ -1,4 +1,4 @@
-FROM golang:1.24.5 AS builder
+FROM golang:1.24.6 AS builder
 
 # Copy source code
 COPY go.mod go.sum ./

--- a/tests/integration/test_server/Dockerfile
+++ b/tests/integration/test_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5
+FROM golang:1.24.6
 
 WORKDIR /app
 

--- a/tests/integration/test_server/go.mod
+++ b/tests/integration/test_server/go.mod
@@ -1,3 +1,3 @@
 module main
 
-go 1.24.5
+go 1.24.6


### PR DESCRIPTION
This is primarily due to Grype flagging 1.25.5 due to CVE-2025-47907.