### PR TITLE
CP-32958: correct typo (thinko?) in cloudAccountID property name

### DIFF
--- a/app/utils/scout/detect_configuration.go
+++ b/app/utils/scout/detect_configuration.go
@@ -52,7 +52,7 @@ func DetectConfiguration(ctx context.Context, logger *zerolog.Logger, scout type
 			}
 			return nil
 		}
-		return fmt.Errorf("failed to detect cloud provider: %w. Manual configuration (setting cloudAccountID, region, and clusterName in the Helm chart) may be required", innerErr)
+		return fmt.Errorf("failed to detect cloud provider: %w. Manual configuration (setting cloudAccountId, region, and clusterName in the Helm chart) may be required", innerErr)
 	}
 
 	if ei.CloudProvider == types.CloudProviderUnknown {
@@ -63,7 +63,7 @@ func DetectConfiguration(ctx context.Context, logger *zerolog.Logger, scout type
 			}
 			return nil
 		}
-		return errors.New("cloud provider could not be auto-detected, manual configuration (setting cloudAccountID, region, and clusterName in the Helm chart) may be required")
+		return errors.New("cloud provider could not be auto-detected, manual configuration (setting cloudAccountId, region, and clusterName in the Helm chart) may be required")
 	}
 
 	// Handle region configuration
@@ -90,7 +90,7 @@ func DetectConfiguration(ctx context.Context, logger *zerolog.Logger, scout type
 		if *accountID == "" {
 			// Empty field - set with detected value
 			if ei.AccountID == "" {
-				return errors.New("account ID could not be auto-detected, manual configuration (setting cloudAccountID in the Helm chart) may be required")
+				return errors.New("account ID could not be auto-detected, manual configuration (setting cloudAccountId in the Helm chart) may be required")
 			}
 			*accountID = ei.AccountID
 		} else if ei.AccountID != "" && *accountID != ei.AccountID {

--- a/app/utils/scout/detect_configuration_test.go
+++ b/app/utils/scout/detect_configuration_test.go
@@ -145,7 +145,7 @@ func TestDetectConfiguration_DetectionFailures(t *testing.T) {
 			inputAccountID:   stringPtr(""),
 			inputClusterName: stringPtr(""),
 			envInfoError:     errors.New("environment info failed"),
-			expectedErrorMsg: "failed to detect cloud provider: environment info failed. Manual configuration (setting cloudAccountID, region, and clusterName in the Helm chart) may be required",
+			expectedErrorMsg: "failed to detect cloud provider: environment info failed. Manual configuration (setting cloudAccountId, region, and clusterName in the Helm chart) may be required",
 		},
 		{
 			name:             "cloud provider unknown after detection",
@@ -157,7 +157,7 @@ func TestDetectConfiguration_DetectionFailures(t *testing.T) {
 				Region:        "us-west-2",
 				ClusterName:   "test-cluster",
 			},
-			expectedErrorMsg: "cloud provider could not be auto-detected, manual configuration (setting cloudAccountID, region, and clusterName in the Helm chart) may be required",
+			expectedErrorMsg: "cloud provider could not be auto-detected, manual configuration (setting cloudAccountId, region, and clusterName in the Helm chart) may be required",
 		},
 		{
 			name:             "region detection fails when required",
@@ -183,7 +183,7 @@ func TestDetectConfiguration_DetectionFailures(t *testing.T) {
 				AccountID:     "", // Empty account ID should cause error
 				ClusterName:   "test-cluster",
 			},
-			expectedErrorMsg: "account ID could not be auto-detected, manual configuration (setting cloudAccountID in the Helm chart) may be required",
+			expectedErrorMsg: "account ID could not be auto-detected, manual configuration (setting cloudAccountId in the Helm chart) may be required",
 		},
 		{
 			name:             "cluster name detection fails when required",
@@ -1025,7 +1025,7 @@ func TestDetectConfiguration_AWSTokenMethodNotAllowed(t *testing.T) {
 	}
 
 	// Verify the full error chain is preserved (without the settings validation wrapper)
-	expectedFullError := "failed to detect cloud provider: failed to get IMDSv2 token: IMDSv2 token endpoint does not support PUT method (status: 405). This may indicate an IMDSv1-only environment or misconfigured metadata service. Manual configuration (setting cloudAccountID, region, and clusterName in the Helm chart) may be required"
+	expectedFullError := "failed to detect cloud provider: failed to get IMDSv2 token: IMDSv2 token endpoint does not support PUT method (status: 405). This may indicate an IMDSv1-only environment or misconfigured metadata service. Manual configuration (setting cloudAccountId, region, and clusterName in the Helm chart) may be required"
 	if err.Error() != expectedFullError {
 		t.Errorf("Expected error %q, got %q", expectedFullError, err.Error())
 	}


### PR DESCRIPTION
Several errors from the Scout mention the "cloudAccountID" property, but while this is the name of the property it is mapped to in Go, in Helm the correct name is "cloudAccountId".

See
https://github.com/Cloudzero/cloudzero-agent/blob/c38f3633712838571de7e376d9c4ae32493aaaf7/helm/values.yaml#L15