### PR TITLE
 Explicitly set appProtocol for the webhook server service

### DIFF
--- a/helm/templates/webhook-service.yaml
+++ b/helm/templates/webhook-service.yaml
@@ -12,5 +12,6 @@ spec:
     - port: {{ .Values.insightsController.service.port }}
       targetPort: 8443
       name: http
+      appProtocol: https
   selector:
     {{- include "cloudzero-agent.insightsController.server.matchLabels" . | nindent 4 }}


### PR DESCRIPTION
## Why?

We are deploying the CloudZero Agent into multiple clusters that have an Istio service mesh deployed. We noticed that the `backfill` job was continuously throwing an error that the webhook API was not available:

<img width="2760" height="832" alt="image (11)" src="https://github.com/user-attachments/assets/c20620f8-8576-4f45-82df-b3b4f7a869b1" />

Upon further investigation, we notice that Istio was throwing errors about traffic being redirected to the `BlackholeCluster` i.e. traffic was not being allowed to continue on to the Service. Below is the output we saw in the `istio-proxy` container on the `backfill` job:
```
{"x_b3_sampled":null,"user_agent":null,"upstream_cluster":"BlackHoleCluster;","method":null,"downstream_remote_address":"10.0.180.113:40216","bytes_sent":0,"request_duration":null,"response_flags":"UH","protocol":null,"authority":null,"path":null,"upstream_host":null,"requested_server_name":"cloudzero-agent-webhook-server-svc.platform-delivery.svc.cluster.local","bytes_received":0,"response_duration":null,"x_b3_parentspanid":null,"x_forwarded_for":null,"x_b3_traceid":null,"downstream_local_address":"172.20.70.217:443","response_tx_duration":null,"response_code":0,"request_id":null,"start_time":"2025-09-24T18:35:18.852Z","duration":0,"upstream_local_address":null,"connection_termination_details":null,"x_b3_spanid":null}
```


However, this was odd as this is in cluster traffic. We have seen a similar error with other third party deployments. Looking closer, we notice that the name of the port for the Agent Webhook Server Service was hardcoded to `http`: https://github.com/Cloudzero/cloudzero-agent/blob/010f5ced95ee253e5a82af54df735968724e252a/helm/templates/webhook-service.yaml#L14

Istio will attempt to use the name of the port for a service to determine which protocol to use to handle the traffic: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

However, since the `backfill` cronjob is attempting to establish a TLS connection with the Service, this hardcoded `http` value is causing failures. Simply editing the name of the port to `https` and triggering a new `backfill` job worked immediately.

We chose to go this route instead of disabling Istio injection on the job pod. We would prefer to keep it on.

## What

This adds a simple change that allows us to rename the port of the service, while maintaining the original hardcoded value via `.Values.insightsController.service.portName`

## How Tested

First, we ensured this was the issue manually in our cluster. We edited the port name on the Service and restarted the job. It immediately began working.

I further confirmed this change to the chart works by creating a simple YAML overrides file that overrode the port name, and confirmed the expected results by running `helm template -f overrides.yaml ...` and inspecting the Service in the resulting manifest. 
