### PR TITLE
CP-33222: specialized cluster configuration testing infrastructure

### DIFF
--- a/.github/workflows/test-matrix-k8s.yaml
+++ b/.github/workflows/test-matrix-k8s.yaml
@@ -179,3 +179,131 @@ jobs:
           CLUSTER_NAME="kind-${{ matrix.kver.platform == 'linux/amd64' && 'amd64' || matrix.kver.platform == 'linux/arm64' && 'arm64' || matrix.kver.platform }}-${{ matrix.kver.k8s }}"
           # kind-test handles its own cleanup, but ensure cluster is deleted using Make target
           make kind-down CLUSTER_NAME=$CLUSTER_NAME || true
+
+  specialized-config-test:
+    name: config-test-${{ matrix.config.name }}
+    runs-on: ubuntu-latest
+    # These should match the permissions in the calling job.
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      config-test-status: ${{ job.status }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test specialized configurations that require different Helm values
+        config:
+          - name: "federated-mode"
+            description: "CloudZero Agent in federated mode with DaemonSet deployment"
+            overrides: |
+              defaults:
+                federation:
+                  enabled: true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - uses: azure/setup-kubectl@v4
+
+      - name: Install Krew and Plugins
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 4
+          command: |
+            (
+              set -x; cd "$(mktemp -d)" &&
+              OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+              ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+              KREW="krew-${OS}_${ARCH}" &&
+              curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+              tar zxvf "${KREW}.tar.gz" &&
+              ./"${KREW}" install krew
+            )
+            echo "$HOME/.krew/bin" >> "$GITHUB_PATH"
+            export PATH="$HOME/.krew/bin:$PATH"
+            kubectl krew install stern
+
+      - name: Install Dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 4
+          command: |
+            make install-tools
+
+      - name: Create Specialized Configuration Override File
+        run: |
+          echo "Creating specialized configuration override file for ${{ matrix.config.name }}..."
+          # Create temporary file for extra overrides
+          EXTRA_OVERRIDES_FILE="${{ runner.temp }}/extra-overrides-${{ matrix.config.name }}.yaml"
+          cat <<'EOF' > "$EXTRA_OVERRIDES_FILE"
+          ${{ matrix.config.overrides }}
+          EOF
+          echo "HELM_EXTRA_OVERRIDES=$EXTRA_OVERRIDES_FILE" >> "$GITHUB_ENV"
+          echo "Created override file at: $EXTRA_OVERRIDES_FILE"
+          echo "Contents:"
+          cat "$EXTRA_OVERRIDES_FILE"
+
+      - name: Run Chart Tests with Specialized Configuration
+        env:
+          CLOUDZERO_DEV_API_KEY: ${{ secrets.CLOUDZERO_DEV_API_KEY }}
+        run: |
+          echo "Running chart tests with specialized configuration: ${{ matrix.config.name }}"
+          echo "Description: ${{ matrix.config.description }}"
+          # Create unique cluster name for this configuration test
+          CLUSTER_NAME="kind-config-${{ matrix.config.name }}"
+          # Clean up any existing cluster using Make target
+          make kind-down CLUSTER_NAME=$CLUSTER_NAME || true
+          # Create cluster configuration files for this test run
+          cp clusters/kind.yaml "clusters/$CLUSTER_NAME.yaml"
+          cp clusters/kind-overrides.yaml "clusters/$CLUSTER_NAME-overrides.yaml"
+          # Run the complete test workflow using Kind with extra overrides
+          make kind-test "CLUSTER_NAME=$CLUSTER_NAME" "HELM_EXTRA_OVERRIDES=$HELM_EXTRA_OVERRIDES"
+
+      - name: Set config output
+        id: set-output
+        run: |
+          {
+            echo "kubeconfig=tests/kuttl/kubeconfig"
+            echo "config-name=${{ matrix.config.name }}"
+            echo "config-description=${{ matrix.config.description }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Collect Logs
+        id: logs
+        if: failure()
+        continue-on-error: true
+        run: |
+          rm -f "${{ runner.temp }}/${{ matrix.config.name }}.log"
+          touch "${{ runner.temp }}/${{ matrix.config.name }}.log"
+          echo "---Kubectl Get All-----------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.config.name }}.log
+          kubectl get all -A &>> ${{ runner.temp }}/${{ matrix.config.name }}.log || echo "[ERROR] Kubectl get all command exited error." &>> ${{ runner.temp }}/${{ matrix.config.name }}.log
+          echo "---Kubectl Events------------------------------------------------------" &>> ${{ runner.temp }}/${{ matrix.config.name }}.log
+          kubectl events -A &>> ${{ runner.temp }}/${{ matrix.config.name }}.log || echo "[ERROR] Kubectl events command exited error." &>> ${{ runner.temp }}/${{ matrix.config.name }}.log
+          echo "---Stern Logs (im-a-namespace)----------------------------------------" &>> ${{ runner.temp }}/${{ matrix.config.name }}.log
+          kubectl stern -n im-a-namespace --since=3m --no-follow -t . | sort -k4 &>> ${{ runner.temp }}/${{ matrix.config.name }}.log || echo "[ERROR] Stern log command exited error." &>> ${{ runner.temp }}/${{ matrix.config.name }}.log
+
+      - name: Upload Failure Logs
+        uses: actions/upload-artifact@v4
+        if: always() && steps.logs.conclusion == 'success'
+        with:
+          name: config-${{ matrix.config.name }}.log
+          path: ${{ runner.temp }}/${{ matrix.config.name }}.log
+          retention-days: 1
+          if-no-files-found: warn
+
+      - name: Cleanup
+        if: always()
+        run: |
+          echo "Cleaning up Kind cluster..."
+          CLUSTER_NAME="kind-config-${{ matrix.config.name }}"
+          # kind-test handles its own cleanup, but ensure cluster is deleted using Make target
+          make kind-down CLUSTER_NAME=$CLUSTER_NAME || true
+          # Clean up temporary override file
+          rm -f "$HELM_EXTRA_OVERRIDES" || true

--- a/Makefile
+++ b/Makefile
@@ -411,50 +411,6 @@ tests/kuttl/kubeconfig: ## Create kind cluster kubeconfig for testing
 	KUBECONFIG="$@" $(KUBECTL) wait --for=condition=Ready nodes --all --timeout=4m
 	KUBECONFIG="$@" $(KUBECTL) wait --for=condition=Available deployment/coredns --namespace kube-system --timeout=4m
 
-# ----------- CI TESTING ------------
-
-# Generate the secrets file used by the `act` tool for local GitHub Action development.
-.github/workflows/.secrets:
-	@if [[ "$(CLOUDZERO_DEV_API_KEY)" == "" ]] || [[ "$(GITHUB_TOKEN)" == "" ]]; then echo "CLOUDZERO_DEV_API_KEY and GITHUB_TOKEN are required to generate the .github/workflows/.secrets file, but at least one of them is not set. Consider adding to local-config.mk."; exit 1; fi
-	@echo "CLOUDZERO_DEV_API_KEY=$(CLOUDZERO_DEV_API_KEY)" > $@
-	@echo "GITHUB_TOKEN=$(GITHUB_TOKEN)" >> $@
-
-# Use ACT to run the chart-complete.yaml workflow (new unified system)
-.PHONY: test-ci-chart-kuttl
-test-ci-chart-kuttl: .github/workflows/.secrets ## Use ACT to run chart-complete.yaml workflow
-	$(ECHO) "Running chart-complete workflow with ACT..."
-	$(ACT) workflow_dispatch -W .github/workflows/chart-complete.yaml \
-		--artifact-server-path /tmp/artifacts \
-		--env-file .github/workflows/.secrets \
-		--platform ubuntu-latest=ghcr.io/catthehacker/ubuntu:js-latest \
-		--container-architecture linux/amd64 \
-		--env ACTIONS_RUNNER_DEBUG=1 \
-		--input image-repo=$(IMAGE_REPO) \
-		--input image-path=$(IMAGE_PATH) \
-		--input image-tag=$(TAG) \
-		--pull=false \
-		$(NULL)
-
-# Use ACT to run the docker-build.yml workflow
-.PHONY: test-ci-docker-build
-test-ci-docker-build: .github/workflows/.secrets ## Use ACT to run docker-build.yml workflow
-	$(ECHO) "Running docker-build workflow with ACT..."
-	$(ECHO) "Note: docker-build.yml doesn't have workflow_dispatch trigger, testing syntax only..."
-	$(ACT) push -W .github/workflows/docker-build.yml \
-		--artifact-server-path /tmp/artifacts \
-		--env-file .github/workflows/.secrets \
-		--platform ubuntu-latest=ghcr.io/catthehacker/ubuntu:js-latest \
-		--container-architecture linux/amd64 \
-		--pull=false \
-		--list \
-		$(NULL)
-
-# Main CI test target that runs all CI test suites
-.PHONY: test-ci
-test-ci: test-ci-chart-kuttl test-ci-docker-build
-test-ci: ## Run all CI test suites
-	$(ECHO) "✅ All CI test suites completed successfully"
-
 # ----------- DOCKER IMAGE ------------
 
 DEBUG_IMAGE ?= busybox:stable-uclibc
@@ -504,6 +460,11 @@ KUBE_VERSION               ?= 1.33.0
 CLUSTER_CONFIG_NAME       ?= $(CLUSTER_NAME)
 CLUSTER_CONFIG_FILE       ?= clusters/$(CLUSTER_CONFIG_NAME).yaml
 CLUSTER_OVERRIDES_FILE    ?= clusters/$(CLUSTER_CONFIG_NAME)-overrides.yaml
+
+# Additional helm overrides for specialized configurations (optional)
+# Set HELM_EXTRA_OVERRIDES to path of additional values file that takes precedence
+# Example: HELM_EXTRA_OVERRIDES=clusters/federated-mode-overrides.yaml
+HELM_EXTRA_OVERRIDES      ?=
 
 # =============================================================================
 # CLUSTER CONFIGURATION HELPER FUNCTIONS
@@ -579,6 +540,24 @@ define invoke-kubectl
 $(call get-kubeconfig-env) $(KUBECTL) $(call get-kubectx-arg,--context)
 endef
 
+# get-helm-extra-overrides - Generate additional --values argument if HELM_EXTRA_OVERRIDES is set
+#
+# This function enables specialized Helm chart configurations by allowing additional values files
+# to be layered on top of standard cluster overrides. This is useful for testing specific
+# deployment scenarios like federated mode, cert-manager integration, etc.
+#
+# Usage: $(call get-helm-extra-overrides)
+# Returns: "--values <file>" if HELM_EXTRA_OVERRIDES is set and non-empty, empty otherwise
+#
+# Priority order for values (later takes precedence):
+#   1. helm/values.yaml (chart defaults)
+#   2. $(CLUSTER_OVERRIDES_FILE) (cluster-specific overrides)
+#   3. $(HELM_EXTRA_OVERRIDES) (specialized configuration overrides)
+#   4. --set arguments (command-line overrides)
+define get-helm-extra-overrides
+$(if $(HELM_EXTRA_OVERRIDES),--values $(HELM_EXTRA_OVERRIDES),)
+endef
+
 # invoke-helm - Generate helm command with kubeconfig, context, and namespace
 # Returns: KUBECONFIG=<path> helm --kube-context <context> --namespace <namespace> [additional args]
 # Usage: $(call invoke-helm) install my-release ./chart
@@ -612,6 +591,7 @@ helm-install: ## Install the Helm chart (uses CLUSTER_CONFIG_NAME)
 		./helm \
 		--create-namespace \
 		--values $(CLUSTER_OVERRIDES_FILE) \
+		$(call get-helm-extra-overrides) \
 		$(NULL)
 
 # helm-install-current is the same as helm-install, except that it
@@ -623,12 +603,17 @@ helm-install-current: ## Install chart with test image
 		./helm \
 		--create-namespace \
 		--values $(CLUSTER_OVERRIDES_FILE) \
+		$(call get-helm-extra-overrides) \
 		--set components.agent.image.tag=dev-$(shell git rev-parse HEAD) \
 		$(NULL)
 
 .PHONY: helm-wait
 helm-wait: ## Wait for chart to be ready after installation
-	$(call invoke-kubectl) wait --for=condition=Available deployment/$(call get-cluster-property,.release)-cloudzero-agent-server --namespace $(call get-cluster-property,.namespace) --timeout=5m
+	$(call invoke-kubectl) wait --for=condition=Available \
+		--namespace $(call get-cluster-property,.namespace) \
+		--timeout=5m \
+		$(foreach deployment,cloudzero-agent-server cloudzero-agent-webhook-server aggregator cloudzero-state-metrics,deployment/$(call get-cluster-property,.release)-$(deployment)) \
+		$(NULL)
 
 .PHONY: helm-uninstall
 helm-uninstall: $(CLUSTER_CONFIG_FILE) ## Uninstall the Helm chart (uses CLUSTER_CONFIG_NAME)
@@ -640,6 +625,7 @@ helm-lint: helm/values.schema.json $(CLUSTER_CONFIG_FILE) $(CLUSTER_OVERRIDES_FI
 helm-lint: ## Lint the Helm chart (uses CLUSTER_CONFIG_NAME)
 	$(call invoke-helm) lint ./helm \
 		--values $(CLUSTER_OVERRIDES_FILE) \
+		$(call get-helm-extra-overrides) \
 		$(NULL)
 
 # Generate list of all schema test targets (file paths without .yaml extension)

--- a/clusters/README.md
+++ b/clusters/README.md
@@ -59,12 +59,6 @@ clusterName: kind
 apiKey: "test-api-key-for-local-testing"
 cloudAccountId: "1234567890"
 region: "us-east-1"
-
-components:
-  agent:
-    image:
-      repository: ghcr.io/cloudzero/cloudzero-agent
-      tag: "intentionally-invalid-tag"
 ```
 
 ## Using the CLUSTER_NAME Variable
@@ -74,8 +68,11 @@ The `CLUSTER_NAME` environment variable selects which cluster configuration to u
 ### Basic Usage
 
 ```bash
-# Use KIND cluster (default)
+# Use KIND cluster (this is the default if CLUSTER_NAME is not set)
 CLUSTER_NAME=kind make helm-install
+
+# Or simply use the default
+make helm-install  # Same as CLUSTER_NAME=kind
 
 # Use development cluster
 CLUSTER_NAME=dev make helm-install
@@ -91,7 +88,7 @@ When `CLUSTER_NAME=dev`, the system uses:
 - **Cluster config:** `clusters/dev.yaml`
 - **Helm overrides:** `clusters/dev-overrides.yaml`
 
-If `CLUSTER_NAME` is not set, it defaults to `kind`.
+**Default:** If `CLUSTER_NAME` is not set, it defaults to `kind`.
 
 ## Makefile Integration
 
@@ -101,20 +98,39 @@ The cluster configuration system is deeply integrated with Make targets:
 
 ```bash
 # Install chart to specific cluster
-CLUSTER_NAME=brahms make helm-install
+CLUSTER_NAME=my-cluster make helm-install
 
-# Install with current image tag
-CLUSTER_NAME=brahms make helm-install-current
+# Install with current image tag (uses dev-$(git rev-parse HEAD) tag)
+CLUSTER_NAME=my-cluster make helm-install-current
+
+# Install and wait for deployment to be ready
+CLUSTER_NAME=my-cluster make helm-install helm-wait
 
 # Uninstall from cluster
-CLUSTER_NAME=brahms make helm-uninstall
+CLUSTER_NAME=my-cluster make helm-uninstall
+```
+
+### Common Development Tasks
+
+```bash
+# List available clusters
+ls clusters/*.yaml | sed 's/clusters\///g' | sed 's/\.yaml//g' | grep -v overrides
+
+# Wait for deployment to be fully ready
+CLUSTER_NAME=my-cluster make helm-wait
+
+# Get logs for specific service (example)
+kubectl --context="$(.tools/bin/gojq --yaml-input -r .context clusters/my-cluster.yaml)" -n "$(.tools/bin/gojq --yaml-input -r .namespace clusters/my-cluster.yaml)" logs deployment/my-release-aggregator -c my-release-aggregator-collector
+
+# Run KUTTL integration tests
+CLUSTER_NAME=my-cluster make helm-test-kuttl
 ```
 
 ### Testing Operations
 
 ```bash
 # Run KUTTL tests against specific cluster
-CLUSTER_NAME=brahms make helm-test-kuttl
+CLUSTER_NAME=my-cluster make helm-test-kuttl
 ```
 
 ### Low-Level Operations
@@ -184,7 +200,7 @@ The `.gitignore` file in this directory:
 **This means:**
 
 - **`kind.yaml` and `kind-overrides.yaml`** - Committed as examples for testing
-- **All other `*.yaml` files** - Ignored, allowing personal cluster configs
+- **All other `*.yaml` files** - Ignored by git, allowing personal cluster configs
 - **You can freely add your own cluster files** without affecting the repository
 
 ## Common Cluster Configurations
@@ -276,6 +292,45 @@ Use `local-config.mk` for sensitive data and personal settings:
 CLOUDZERO_DEV_API_KEY = your-dev-api-key
 CLUSTER_NAME = brahms
 ```
+
+## Specialized Configurations (Advanced)
+
+Specialized configurations allow us to test cluster configurations that are relatively uncommon using the exact same tests that we run on our standard clusters. This increases test coverage of these more obscure configurations by ensuring they work with the full test suite.
+
+### Using HELM_EXTRA_OVERRIDES
+
+The `HELM_EXTRA_OVERRIDES` environment variable allows you to specify an additional values file that overrides both the chart defaults and cluster overrides:
+
+**Priority Order (later takes precedence):**
+
+1. `helm/values.yaml` (chart defaults)
+2. `clusters/$(CLUSTER_NAME)-overrides.yaml` (cluster-specific overrides)
+3. `$(HELM_EXTRA_OVERRIDES)` (specialized configuration overrides)
+4. `--set` arguments (command-line overrides)
+
+### Example: Using Specialized Configuration
+
+```sh
+# Create temporary specialized configuration
+cat <<EOF > /tmp/test-config-overrides.yaml
+# Enable specific features for this test run
+defaults:
+  federation:
+    enabled: true
+EOF
+
+# Deploy and test
+make helm-install-current HELM_EXTRA_OVERRIDES=/tmp/test-config-overrides.yaml
+make helm-test-kuttl
+make helm-uninstall
+```
+
+### Notes
+
+- Extra overrides files are only used if they exist (no error if file not found)
+- This system is designed for testing specialized configurations, not for production deployments
+- For production, use proper cluster-specific overrides files instead
+- The `get-helm-extra-overrides` function in the Makefile handles the conditional inclusion
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Why?

We want to be able to test non-standard configurations in CI; for example, spin up a cluster in federated mode and verify that the KUTTL tests still pass.

## What

Previously this required creating an entirely new cluster in clusters/. This tweaks the helm invocation a bit so that, if `HELM_EXTRA_OVERRIDES` is provided when `helm-install`/`helm-install-current` is invoked, we use the file specified by it as an additional layer of overrides.

I also threw some extra stuff I've been working on in here, sorry... this translates primarily to more documentation, plus I added the markdownlint-cli2 linter to help keep our documentation tidy. Oh, and I also added a linter for github actions, which runs shell stuff through shellcheck, which uncovered a bunch of stuff (mainly around quoting).

## How Tested

I tested locally as best I could, the main question will be how CI feels about the changes...