### PR TITLE
CP-33369: add easy way to toggle Replicated builds

### DIFF
--- a/.github/workflows/test-matrix-replicated-k8s-clusters.yaml
+++ b/.github/workflows/test-matrix-replicated-k8s-clusters.yaml
@@ -46,6 +46,7 @@ concurrency:
 jobs:
   compatibility-matrix:
     name: replicated-test-${{ matrix.cluster.distribution }}-${{ matrix.cluster.arch }}-${{ matrix.cluster.version }}
+    if: ${{ vars.ENABLE_REPLICATED == 'true' }}
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
Sometimes it would be nice to have an easy way to circumvent Replicated builds, such as when we run out of credits and want to merge something. Or if we just know we're going to need to merge a bunch of PRs for which we don't want to incur the expense of testing on Replicated.

This just checks whether the value of a GitHub Repository Variable (see [1]) is "true" and, if so, runs the tests.

Another nice benefit of this is that things should keep working when the repo is forked without having to set up Replicated.

[1]: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables