### PR TITLE
CP-33371: add Kubernetes 1.33 and 1.34 to our test matrix

### DIFF
--- a/.github/workflows/test-matrix-k8s.yaml
+++ b/.github/workflows/test-matrix-k8s.yaml
@@ -68,6 +68,8 @@ jobs:
             { k8s: v1.30.11, platform: linux/arm64 },
             { k8s: v1.31.7, platform: linux/amd64 },
             { k8s: v1.32.3, platform: linux/arm64 },
+            { k8s: v1.33.5, platform: linux/arm64 },
+            { k8s: v1.34.1, platform: linux/arm64 },
           ]
 
     steps:


### PR DESCRIPTION
## Why?

To make sure k8s 1.33 and 1.34 keep working.

## What

Add them to the bulid matrix.

## How Tested

In CI for this PR.
