### PR TITLE
Support post-processing of helm templating

### DIFF
--- a/helm/templates/aggregator-secret.yaml
+++ b/helm/templates/aggregator-secret.yaml
@@ -9,8 +9,5 @@ metadata:
   namespace: {{ include "cloudzero-agent.namespace" . }}
 data:
   {{ .Values.serverConfig.containerSecretFileName }}: {{- $apiKey := .Values.apiKey | toString }}
-          {{- if not (regexMatch "^[a-zA-Z0-9-_.~!*'();]+$" $apiKey) }}
-          {{- fail "The provided apiKey is invalid. Check that the provided value from apiKey matches exactly what is found in the CloudZero admin page." }}
-          {{- end }}
           {{ $apiKey | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
### Description

This regex validation prevents the use of this chart with post helm-templating secrets engines. 
Example: The argocd plugin for Vault when used with helm charts. https://argocd-vault-plugin.readthedocs.io/en/stable/


### References

The vault plugin for argocd applies secrets templating post helm templating. 
No obvious reason to include a regex validation here.

<code>{"dir":"/tmp/_cmp_server/c26aa731-ed23-4bd9-a549-3bc43995ac04/charts/cloudzero-agent","execID":"70d36","level":"info","msg":"sh -c \"RELEASE_NAME=\\\"${ARGOCD_ENV_HELM_RELEASE_NAME:-$ARGOCD_APP_NAME}\\\";\\necho \\\"$ARGOCD_ENV_HELM_VALUES\\\" \u003e ARGOCD_ENV_HELM_VALUES.yaml |\\nhelm template $RELEASE_NAME -n $ARGOCD_APP_NAMESPACE --values ARGOCD_ENV_HELM_VALUES.yaml . |\\nargocd-vault-plugin generate -\\n\"","time":"2025-10-01T23:39:34Z"}
{"command":{"command":["sh","-c","RELEASE_NAME=\"${ARGOCD_ENV_HELM_RELEASE_NAME:-$ARGOCD_APP_NAME}\";\necho \"$ARGOCD_ENV_HELM_VALUES\" \u003e ARGOCD_ENV_HELM_VALUES.yaml |\nhelm template $RELEASE_NAME -n $ARGOCD_APP_NAMESPACE --values ARGOCD_ENV_HELM_VALUES.yaml . |\nargocd-vault-plugin generate -\n"]},"execID":"70d36","level":"warning","msg":"Plugin command returned zero output","stderr":"Error: execution error at (cloudzero-agent/templates/aggregator-secret.yaml:13:14): The provided apiKey is invalid. Check that the provided value from apiKey matches exactly what is found in the CloudZero admin page.\n\nUse --debug flag to render out invalid YAML\n","time":"2025-10-01T23:39:35Z"}</code>

### Testing

No effectual change to the chart installation. Test with install

<code>helm upgrade --install cloudzero \
    --repo https://cloudzero.github.io/cloudzero-charts cloudzero-agent \
    --namespace cloudzero --create-namespace \
    --set apiKey=<CLOUDZERO_API_KEY>
    --set clusterName=<NAME_OF_YOUR_CLUSTER>
</code>
