### PR TITLE
CP-33383: move apiKey/existingSecretName validation to JSON Schema

### DIFF
--- a/helm/templates/aggregator-secret.yaml
+++ b/helm/templates/aggregator-secret.yaml
@@ -9,8 +9,5 @@ metadata:
   namespace: {{ include "cloudzero-agent.namespace" . }}
 data:
   {{ .Values.serverConfig.containerSecretFileName }}: {{- $apiKey := .Values.apiKey | toString }}
-          {{- if not (regexMatch "^[a-zA-Z0-9-_.~!*'();]+$" $apiKey) }}
-          {{- fail "The provided apiKey is invalid. Check that the provided value from apiKey matches exactly what is found in the CloudZero admin page." }}
-          {{- end }}
           {{ $apiKey | b64enc | quote }}
 {{- end }}

--- a/helm/templates/aggregator-secret.yaml
+++ b/helm/templates/aggregator-secret.yaml
@@ -8,6 +8,5 @@ metadata:
   name: {{ include "cloudzero-agent.secretName" .}}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 data:
-  {{ .Values.serverConfig.containerSecretFileName }}: {{- $apiKey := .Values.apiKey | toString }}
-          {{ $apiKey | b64enc | quote }}
+  {{ .Values.serverConfig.containerSecretFileName }}: {{ .Values.apiKey | toString | b64enc | quote }}
 {{- end }}

--- a/helm/templates/validations.tpl
+++ b/helm/templates/validations.tpl
@@ -4,11 +4,6 @@ due to limitations in Helm's schema validation capabilities and/or
 limitations in JSON Schema.
 */ -}}
 
-{{- /* You must set either apiKey or existingSecretName. */ -}}
-{{- if and (not .Values.apiKey) (not .Values.existingSecretName) }}
-  {{- fail "Either apiKey or existingSecretName must be set" -}}
-{{- end -}}
-
 {{- /* Certificate algorithm-specific validations for cross-field dependencies */ -}}
 {{- with .Values.insightsController.tls.certificate -}}
   {{- if eq .algorithm "rsa" -}}

--- a/helm/tests/apikey_secret_reference_test.yaml
+++ b/helm/tests/apikey_secret_reference_test.yaml
@@ -1,0 +1,33 @@
+suite: test apiKey secret name references in manifests
+templates:
+  - aggregator-deploy.yaml
+tests:
+  # Test that existingSecretName is correctly referenced in volume definitions
+
+  - it: should reference custom existingSecretName in aggregator deployment volume
+    template: aggregator-deploy.yaml
+    set:
+      apiKey: null
+      existingSecretName: "my-custom-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cloudzero-api-key
+            secret:
+              secretName: my-custom-secret
+
+  # Test that default generated secret name is used when only apiKey is set
+
+  - it: should reference default secret name in aggregator deployment when apiKey is set
+    template: aggregator-deploy.yaml
+    set:
+      apiKey: "test-key-123"
+      existingSecretName: null
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cloudzero-api-key
+            secret:
+              secretName: RELEASE-NAME-api-key

--- a/helm/tests/apikey_secret_validation_test.yaml
+++ b/helm/tests/apikey_secret_validation_test.yaml
@@ -1,0 +1,145 @@
+suite: test apiKey and existingSecretName validation
+templates:
+  - aggregator-secret.yaml
+tests:
+  # Schema validation failure tests - these test the anyOf + oneOf constraints
+
+  - it: should fail when neither apiKey nor existingSecretName is set
+    values:
+      - ../values.yaml # Use empty base values
+    set:
+      apiKey: null
+      existingSecretName: null
+      host: api.cloudzero.com
+    asserts:
+      - failedTemplate:
+          errorPattern: "anyOf"
+
+  - it: should fail when both apiKey and existingSecretName are set
+    set:
+      apiKey: "test-key-123"
+      existingSecretName: "my-secret"
+    asserts:
+      - failedTemplate:
+          errorPattern: "oneOf"
+
+  # Pattern validation tests
+
+  - it: should fail with invalid apiKey characters (spaces)
+    set:
+      apiKey: "test-key with spaces"
+      existingSecretName: null
+    asserts:
+      - failedTemplate:
+          errorPattern: "does not match pattern"
+
+  - it: should fail with apiKey containing invalid special characters (@)
+    set:
+      apiKey: "test-key@invalid"
+      existingSecretName: null
+    asserts:
+      - failedTemplate:
+          errorPattern: "does not match pattern"
+
+  - it: should fail with apiKey containing invalid special characters (#)
+    set:
+      apiKey: "test#key"
+      existingSecretName: null
+    asserts:
+      - failedTemplate:
+          errorPattern: "does not match pattern"
+
+  - it: should fail with apiKey containing invalid special characters ($)
+    set:
+      apiKey: "test$key"
+      existingSecretName: null
+    asserts:
+      - failedTemplate:
+          errorPattern: "does not match pattern"
+
+  # Successful template rendering tests
+
+  - it: should create secret when only apiKey is set (with existingSecretName null)
+    set:
+      apiKey: "test-key-abc123"
+      existingSecretName: null
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-api-key
+      - equal:
+          path: data.value
+          value: dGVzdC1rZXktYWJjMTIz # base64 of "test-key-abc123"
+
+  - it: should create secret when only apiKey is set (existingSecretName omitted)
+    values:
+      - ../values.yaml # Use empty base values
+    set:
+      apiKey: "test-key-xyz"
+      host: api.cloudzero.com
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-api-key
+      - isNotEmpty:
+          path: data.value
+
+  - it: should not create secret when only existingSecretName is set
+    set:
+      apiKey: null
+      existingSecretName: "my-existing-secret"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should accept apiKey with all valid special characters
+    set:
+      apiKey: "test-KEY_123.abc~def!ghi*jkl'mno()pqr;stu-"
+      existingSecretName: null
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-api-key
+      - isNotEmpty:
+          path: data.value
+
+  - it: should base64 encode the apiKey in the secret
+    set:
+      apiKey: "my-secret-key"
+      existingSecretName: null
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: data.value
+          value: bXktc2VjcmV0LWtleQ== # base64 of "my-secret-key"
+
+  - it: should create secret with hyphen in apiKey
+    set:
+      apiKey: "test-key-with-hyphens"
+      existingSecretName: null
+    asserts:
+      - isKind:
+          of: Secret
+
+  - it: should create secret with underscore in apiKey
+    set:
+      apiKey: "test_key_with_underscores"
+      existingSecretName: null
+    asserts:
+      - isKind:
+          of: Secret
+
+  - it: should create secret with period in apiKey
+    set:
+      apiKey: "test.key.with.periods"
+      existingSecretName: null
+    asserts:
+      - isKind:
+          of: Secret

--- a/helm/tests/cleanstring_quote_stripping_test.yaml
+++ b/helm/tests/cleanstring_quote_stripping_test.yaml
@@ -7,6 +7,7 @@ tests:
     set:
       cloudAccountId: "'123456789012'"
       apiKey: "fake-key"
+      existingSecretName: null
     asserts:
       - contains:
           path: spec.template.spec.containers[0].command
@@ -17,6 +18,7 @@ tests:
     set:
       cloudAccountId: "'123e4567-e89b-12d3-a456-426614174000'"
       apiKey: "fake-key"
+      existingSecretName: null
     asserts:
       - contains:
           path: spec.template.spec.containers[0].command
@@ -27,6 +29,7 @@ tests:
     set:
       cloudAccountId: "123456789012"
       apiKey: "fake-key"
+      existingSecretName: null
     asserts:
       - contains:
           path: spec.template.spec.containers[0].command

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -3471,6 +3471,37 @@
   "$id": "https://raw.githubusercontent.com/Cloudzero/cloudzero-agent/refs/heads/develop/helm/values.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": ["apiKey"]
+    },
+    {
+      "required": ["existingSecretName"]
+    }
+  ],
+  "oneOf": [
+    {
+      "properties": {
+        "apiKey": {
+          "pattern": "^[a-zA-Z0-9-_.~!*'();]+$",
+          "type": "string"
+        },
+        "existingSecretName": {
+          "type": "null"
+        }
+      }
+    },
+    {
+      "properties": {
+        "apiKey": {
+          "type": "null"
+        },
+        "existingSecretName": {
+          "type": "string"
+        }
+      }
+    }
+  ],
   "properties": {
     "aggregator": {
       "additionalProperties": false,

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -113,6 +113,24 @@ additionalProperties: false
 required:
   - host
 
+# Enforce that exactly one of apiKey or existingSecretName must be set
+# anyOf ensures at least one is required, oneOf ensures only one has a non-null value
+anyOf:
+  - required: [apiKey]
+  - required: [existingSecretName]
+oneOf:
+  - properties:
+      apiKey:
+        type: string
+        pattern: "^[a-zA-Z0-9-_.~!*'();]+$"
+      existingSecretName:
+        type: "null"
+  - properties:
+      apiKey:
+        type: "null"
+      existingSecretName:
+        type: string
+
 properties:
   cloudAccountId:
     type: "string"

--- a/tests/helm/schema/apiKey.and.existingSecretName.both.fail.yaml
+++ b/tests/helm/schema/apiKey.and.existingSecretName.both.fail.yaml
@@ -1,0 +1,5 @@
+# Both apiKey and existingSecretName are set to strings
+# This should fail because oneOf requires exactly one to be non-null
+apiKey: "test-key-123"
+existingSecretName: "my-secret"
+clusterName: "test-cluster"

--- a/tests/helm/schema/apiKey.only.pass.yaml
+++ b/tests/helm/schema/apiKey.only.pass.yaml
@@ -1,0 +1,2 @@
+apiKey: "test-key-123"
+existingSecretName: null

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -124,8 +124,7 @@ metadata:
   name: cz-agent-api-key
   namespace: cz-agent
 data:
-  value:
-          "bm90LWEtcmVhbC1hcGkta2V5"
+  value: "bm90LWEtcmVhbC1hcGkta2V5"
 ---
 # Source: cloudzero-agent/templates/agent-cm.yaml
 apiVersion: v1

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -124,8 +124,7 @@ metadata:
   name: cz-agent-api-key
   namespace: cz-agent
 data:
-  value:
-          "bm90LWEtcmVhbC1hcGkta2V5"
+  value: "bm90LWEtcmVhbC1hcGkta2V5"
 ---
 # Source: cloudzero-agent/templates/webhook-tls-secret.yaml
 apiVersion: v1

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -124,8 +124,7 @@ metadata:
   name: cz-agent-api-key
   namespace: cz-agent
 data:
-  value:
-          "bm90LWEtcmVhbC1hcGkta2V5"
+  value: "bm90LWEtcmVhbC1hcGkta2V5"
 ---
 # Source: cloudzero-agent/templates/webhook-tls-secret.yaml
 apiVersion: v1


### PR DESCRIPTION
## Why?

We have received a bug report (#476) about the regular expression-based validation in the template for the API key. Apparently, this method of validation causes problems for certain tools.

Huge thanks to @megrehn-sf for doing the the initial solution and doing the legwork on this; I'm just building on that patch here. 

## What

Move the validation from the template into the JSON schema. Furthermore, replace the other API key and existing secret name validation to ensure that only one or the other is set. Finally, add tests for everything.

## How Tested

Additional helm unittest tests and schema tests.