### PR TITLE
CP-33387: use protoc installed by arduino/setup-protoc action

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -120,6 +120,7 @@ jobs:
           go-version-file: go.mod
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+        id: setup-protoc
         with:
           version: "29.3"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -127,6 +128,8 @@ jobs:
         run: make install-tools
       - name: Generate code
         run: make generate
+        env:
+          PROTOC: ${{ steps.setup-protoc.outputs.path }}
       - name: Format code
         run: make format
       - name: Check file format

--- a/Makefile
+++ b/Makefile
@@ -851,7 +851,7 @@ generate: generate-protobuf
 
 # Pattern rule for generating protobuf files
 %.pb.go: %.proto
-	@$(PROTOC) \
+	$(PROTOC) \
 	  --plugin=.tools/bin/protoc-gen-go \
 	  --proto_path=$(dir $@) \
 	  --go_out=$(dir $<) \


### PR DESCRIPTION
We have been getting sporadic errors from CI for a while now due to a version difference in protoc (it embeds the version number the files were generated with in the source code, so when it changes CI detects the difference and, correctly, fails).

This tweaks the workflow ever so slightly to make sure that the protoc we invoke is the one setup-protoc installs. Hopefully this will clear up those sporadic errors.