### PR TITLE
CP-33382: Fix broken link for the Installation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ repository](https://github.com/Cloudzero/cloudzero-charts).
 
 ### Installation
 
-See the [Installation Guide](./INSTALL.md) for details.
+See the [Installation Guide](./helm/README.md#installation) for details.
 
 ### Configuration
 


### PR DESCRIPTION
This is pretty self explanatory. The link for the (no longer existent?) INSTALL.md wasn't working, so I've linked it to the current installation guide.