### PR TITLE
CP-33747: add release notes for 1.2.8

### DIFF
--- a/helm/docs/releases/1.2.8.md
+++ b/helm/docs/releases/1.2.8.md
@@ -1,0 +1,28 @@
+## [1.2.8](https://github.com/Cloudzero/cloudzero-agent/compare/v1.2.7...v1.2.8) (2025-10-10)
+
+Release 1.2.8 is a maintenance release focused on quality assurance improvements, with enhanced testing infrastructure, better configuration validation, and useful configuration enhancements.
+
+### Key Features
+
+- **Configurable Labels and Annotations**: All Kubernetes resources now support customizable labels and annotations through Helm values, providing better integration with organizational policies and tooling.
+- **Enhanced Build System**: Specialized build configurations now support environment-specific customization (e.g., Replicated builds), simplifying multi-environment deployments.
+
+### Configuration Improvements
+
+- **Centralized Validation**: Moved `apiKey`/`existingSecretName` validation from Helm templates to JSON Schema, centralizing all configuration validation in a single location for improved maintainability.
+- **Service Port Protocol**: Added configurable `protocol` field for webhook server service ports, improving compatibility with service mesh configurations.
+
+### Quality Assurance
+
+- **CI/CD Infrastructure Overhaul**: Restructured the entire CI testing infrastructure to support more comprehensive testing during development, including expanded Kubernetes version coverage (now testing against 1.33 and 1.34) and improved test isolation.
+- **Unified Testing Framework**: Introduced consolidated testing infrastructure with new `test-all` target covering unit tests, integration tests, Helm tests, and KUTTL end-to-end tests.
+- **Workflow Validation**: Added actionlint for GitHub Actions workflow validation and markdownlint-cli2 for documentation quality checks.
+- **Documentation Expansion**: Significantly expanded project documentation with comprehensive guides for development, testing, architecture, and troubleshooting.
+
+### Upgrade Steps
+
+To upgrade to version 1.2.8, run the following command:
+
+```sh
+helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.2.8
+```


### PR DESCRIPTION
# Why?

So we can release 1.2.8

# What

Add release notes for 1.2.8

# How Tested

Tested?