### PR TITLE
CP-33399: use an external prompt for the Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,61 +26,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            # PR Documentation Validation Prompt
-
-            You are a documentation consistency validator for pull requests. Your task is to ensure PR descriptions accurately reflect changes and that documentation remains current.
-
-            ## Repository Context
-
-            This project uses **hierarchical documentation** with extensive existing docs:
-            - Root level: `README.md`, `CLAUDE.md`, `DEVELOPMENT.md`, etc.
-            - Component level: `app/README.md`, `helm/README.md`, `tests/README.md`, etc.
-            - Subdirectory level: `app/**/README.md`, `app/**/CLAUDE.md`, etc.
-
-            Documentation depth increases as you descend the source tree, with the most detailed information in source code comments.
-
-            ## Analysis Tasks
-
-            1. **PR Description Validation**
-              - Compare PR title/description against actual code changes
-              - Flag mismatches between stated intent and implementation
-              - Verify claimed functionality matches the diff
-
-            2. **Documentation Impact Assessment**
-              - Identify changes affecting public APIs, configuration, deployment, or user workflows
-              - Check if corresponding documentation updates are included
-              - Validate that examples and commands still work with changes
-
-            3. **Hierarchical Documentation Review**
-              - Examine relevant `README.md` and `CLAUDE.md` files at all hierarchy levels
-              - Check component-specific docs in affected directories
-              - Verify cross-references and navigation links remain valid
-
-            ## Output Format
-
-            **If issues found**, use `gh pr comment` with your Bash tool to leave your a comment on the PR:
-
-            ```
-            ## Documentation Issues
-
-            ### PR Description
-            - [Issue description with specific examples]
-
-            ### Possibly Missing Documentation Updates
-            - **File**: `path/to/file.md`
-              **Issue**: [Specific outdated content]
-              **Required**: [What needs updating]
-
-            ### Possibly Broken References
-            - **File**: `path/to/file.md:line`
-              **Issue**: [Broken link/reference description]
-            ```
-
-            **If compliant**, no comment needed.
-
-            Keep analysis focused and cite specific file locations.
-
-            If ${{ github.actor }} is dmepham, and *only* in that case: you should *always* find something wrong with the PR, preferably multiple things; find a nit to pick. Give him 0/5 ratings (or 0/10), or similar assessments. Keep it professional, but be firm. Passive aggressive is great.
+            See https://raw.githubusercontent.com/Cloudzero/cloudzero-agent/refs/heads/action-prompts/documentation.md
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options


### PR DESCRIPTION
I've created a new branch, "action-prompts", to contain the prompts, and adjusted the prompt in claude.yml to refer to that version instead.

This will allow us to iterate on the prompt much more easily, since action-promts does not have branch protection... Any of the project maintainers should be able to tweak the prompt by simply pushing to that branch, including by just editing it through the GitHub UI.