### PR TITLE
CP-33939: remove usage of obsolete golang.org/x/exp/rand package

### DIFF
--- a/app/domain/pusher/pusher.go
+++ b/app/domain/pusher/pusher.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"sync"
@@ -22,7 +23,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/rs/zerolog/log"
-	"golang.org/x/exp/rand"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/protoadapt"
 
@@ -452,7 +452,7 @@ func (h *MetricsPusher) pushMetrics(remoteWriteURL string, apiKey string, timeSe
 			RemoteWriteResponseCodes.WithLabelValues(endpoint, "no_response").Inc()
 		}
 		backoff := time.Duration(math.Pow(2, float64(attempt))) * time.Second
-		jitter := time.Duration(rand.Int63n(int64(time.Second)))
+		jitter := time.Duration(rand.Int64N(int64(time.Second))) //nolint:gosec // cryptographically secure PRNG here is not necessary
 		time.Sleep(backoff + jitter)
 	}
 


### PR DESCRIPTION
# Why?

`app/domain/pusher/pusher.go:25:2: "golang.org/x/exp/rand" is deprecated: use the math/rand/v2 package instead. This package is scheduled to be tagged and deleted, per https://go.dev/issue/61716.  (SA1019)`

# What

Update the code to use math/rand/v2

Note that This commit changes from using `Int63n` to `Int64n`, however the documentation for `Int64n` is clear that the return value will be a non-negative integer in [0,n), which matches the behavior of the old Int64n function (though with a somewhat less clear name).

# How Tested

`make test{,-integration,-smoke}`
