### PR TITLE
CP-34015: add missing transitive dependencies in JSON Schema merge

### DIFF
--- a/helm/schema/k8s.json
+++ b/helm/schema/k8s.json
@@ -1263,35 +1263,25 @@
       "type": "object",
       "additionalProperties": false
     },
-    "io.k8s.api.admissionregistration.v1beta1.AuditAnnotation": {
-      "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+    "io.k8s.api.admissionregistration.v1beta1.ApplyConfiguration": {
+      "description": "ApplyConfiguration defines the desired configuration values of an object.",
       "properties": {
-        "key": {
-          "description": "key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: \"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded.\n\nRequired.",
-          "type": "string"
-        },
-        "valueExpression": {
-          "description": "valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list.\n\nRequired.",
+        "expression": {
+          "description": "expression will be evaluated by CEL to create an apply configuration. ref: https://github.com/google/cel-spec\n\nApply configurations are declared in CEL using object initialization. For example, this CEL expression returns an apply configuration to set a single field:\n\n\tObject{\n\t  spec: Object.spec{\n\t    serviceAccountName: \"example\"\n\t  }\n\t}\n\nApply configurations may not modify atomic structs, maps or arrays due to the risk of accidental deletion of values not included in the apply configuration.\n\nCEL expressions have access to the object types needed to create apply configurations:\n\n- 'Object' - CEL type of the resource object. - 'Object.<fieldName>' - CEL type of object field (such as 'Object.spec') - 'Object.<fieldName1>.<fieldName2>...<fieldNameN>` - CEL type of nested field (such as 'Object.spec.containers')\n\nCEL expressions have access to the contents of the API request, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Required.",
           "type": "string"
         }
       },
-      "required": ["key", "valueExpression"],
       "type": "object",
       "additionalProperties": false
     },
-    "io.k8s.api.admissionregistration.v1beta1.ExpressionWarning": {
-      "description": "ExpressionWarning is a warning information that targets a specific expression.",
+    "io.k8s.api.admissionregistration.v1beta1.JSONPatch": {
+      "description": "JSONPatch defines a JSON Patch.",
       "properties": {
-        "fieldRef": {
-          "description": "The path to the field that refers the expression. For example, the reference to the expression of the first item of validations is \"spec.validations[0].expression\"",
-          "type": "string"
-        },
-        "warning": {
-          "description": "The content of type checking information in a human-readable form. Each line of the warning contains the type that the expression is checked against, followed by the type check error from the compiler.",
+        "expression": {
+          "description": "expression will be evaluated by CEL to create a [JSON patch](https://jsonpatch.com/). ref: https://github.com/google/cel-spec\n\nexpression must return an array of JSONPatch values.\n\nFor example, this CEL expression returns a JSON patch to conditionally modify a value:\n\n\t  [\n\t    JSONPatch{op: \"test\", path: \"/spec/example\", value: \"Red\"},\n\t    JSONPatch{op: \"replace\", path: \"/spec/example\", value: \"Green\"}\n\t  ]\n\nTo define an object for the patch value, use Object types. For example:\n\n\t  [\n\t    JSONPatch{\n\t      op: \"add\",\n\t      path: \"/spec/selector\",\n\t      value: Object.spec.selector{matchLabels: {\"environment\": \"test\"}}\n\t    }\n\t  ]\n\nTo use strings containing '/' and '~' as JSONPatch path keys, use \"jsonpatch.escapeKey\". For example:\n\n\t  [\n\t    JSONPatch{\n\t      op: \"add\",\n\t      path: \"/metadata/labels/\" + jsonpatch.escapeKey(\"example.com/environment\"),\n\t      value: \"test\"\n\t    },\n\t  ]\n\nCEL expressions have access to the types needed to create JSON patches and objects:\n\n- 'JSONPatch' - CEL type of JSON Patch operations. JSONPatch has the fields 'op', 'from', 'path' and 'value'.\n  See [JSON patch](https://jsonpatch.com/) for more details. The 'value' field may be set to any of: string,\n  integer, array, map or object.  If set, the 'path' and 'from' fields must be set to a\n  [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901/) string, where the 'jsonpatch.escapeKey()' CEL\n  function may be used to escape path keys containing '/' and '~'.\n- 'Object' - CEL type of the resource object. - 'Object.<fieldName>' - CEL type of object field (such as 'Object.spec') - 'Object.<fieldName1>.<fieldName2>...<fieldNameN>` - CEL type of nested field (such as 'Object.spec.containers')\n\nCEL expressions have access to the contents of the API request, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nCEL expressions have access to [Kubernetes CEL function libraries](https://kubernetes.io/docs/reference/using-api/cel/#cel-options-language-features-and-libraries) as well as:\n\n- 'jsonpatch.escapeKey' - Performs JSONPatch key escaping. '~' and  '/' are escaped as '~0' and `~1' respectively).\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Required.",
           "type": "string"
         }
       },
-      "required": ["fieldRef", "warning"],
       "type": "object",
       "additionalProperties": false
     },
@@ -1345,6 +1335,227 @@
       },
       "type": "object",
       "x-kubernetes-map-type": "atomic",
+      "additionalProperties": false
+    },
+    "io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicy": {
+      "description": "MutatingAdmissionPolicy describes the definition of an admission mutation policy that mutates the object coming into admission chain.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["MutatingAdmissionPolicy"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicySpec",
+          "description": "Specification of the desired behavior of the MutatingAdmissionPolicy."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "MutatingAdmissionPolicy",
+          "version": "v1beta1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicyBinding": {
+      "description": "MutatingAdmissionPolicyBinding binds the MutatingAdmissionPolicy with parametrized resources. MutatingAdmissionPolicyBinding and the optional parameter resource together define how cluster administrators configure policies for clusters.\n\nFor a given admission request, each binding will cause its policy to be evaluated N times, where N is 1 for policies/bindings that don't use params, otherwise N is the number of parameters selected by the binding. Each evaluation is constrained by a [runtime cost budget](https://kubernetes.io/docs/reference/using-api/cel/#runtime-cost-budget).\n\nAdding/removing policies, bindings, or params can not affect whether a given (policy, binding, param) combination is within its own CEL budget.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["MutatingAdmissionPolicyBinding"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicyBindingSpec",
+          "description": "Specification of the desired behavior of the MutatingAdmissionPolicyBinding."
+        }
+      },
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "MutatingAdmissionPolicyBinding",
+          "version": "v1beta1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicyBindingList": {
+      "description": "MutatingAdmissionPolicyBindingList is a list of MutatingAdmissionPolicyBinding.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of PolicyBinding.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicyBinding"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["MutatingAdmissionPolicyBindingList"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+        }
+      },
+      "required": ["items"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "MutatingAdmissionPolicyBindingList",
+          "version": "v1beta1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicyBindingSpec": {
+      "description": "MutatingAdmissionPolicyBindingSpec is the specification of the MutatingAdmissionPolicyBinding.",
+      "properties": {
+        "matchResources": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MatchResources",
+          "description": "matchResources limits what resources match this binding and may be mutated by it. Note that if matchResources matches a resource, the resource must also match a policy's matchConstraints and matchConditions before the resource may be mutated. When matchResources is unset, it does not constrain resource matching, and only the policy's matchConstraints and matchConditions must match for the resource to be mutated. Additionally, matchResources.resourceRules are optional and do not constraint matching when unset. Note that this is differs from MutatingAdmissionPolicy matchConstraints, where resourceRules are required. The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched. '*' matches CREATE, UPDATE and CONNECT."
+        },
+        "paramRef": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ParamRef",
+          "description": "paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in spec.ParamKind of the bound MutatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the MutatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param."
+        },
+        "policyName": {
+          "description": "policyName references a MutatingAdmissionPolicy name which the MutatingAdmissionPolicyBinding binds to. If the referenced resource does not exist, this binding is considered invalid and will be ignored Required.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicyList": {
+      "description": "MutatingAdmissionPolicyList is a list of MutatingAdmissionPolicy.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "List of ValidatingAdmissionPolicy.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicy"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["MutatingAdmissionPolicyList"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+        }
+      },
+      "required": ["items"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "admissionregistration.k8s.io",
+          "kind": "MutatingAdmissionPolicyList",
+          "version": "v1beta1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.admissionregistration.v1beta1.MutatingAdmissionPolicySpec": {
+      "description": "MutatingAdmissionPolicySpec is the specification of the desired behavior of the admission policy.",
+      "properties": {
+        "failurePolicy": {
+          "description": "failurePolicy defines how to handle failures for the admission policy. Failures can occur from CEL expression parse errors, type check errors, runtime errors and invalid or mis-configured policy definitions or bindings.\n\nA policy is invalid if paramKind refers to a non-existent Kind. A binding is invalid if paramRef.name refers to a non-existent resource.\n\nfailurePolicy does not define how validations that evaluate to false are handled.\n\nAllowed values are Ignore or Fail. Defaults to Fail.",
+          "type": "string"
+        },
+        "matchConditions": {
+          "description": "matchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the matchConstraints. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.\n\nIf a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.\n\nThe exact matching logic is (in order):\n  1. If ANY matchCondition evaluates to FALSE, the policy is skipped.\n  2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.\n  3. If any matchCondition evaluates to an error (but none are FALSE):\n     - If failurePolicy=Fail, reject the request\n     - If failurePolicy=Ignore, the policy is skipped",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MatchCondition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["name"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "matchConstraints": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MatchResources",
+          "description": "matchConstraints specifies what resources this policy is designed to validate. The MutatingAdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API MutatingAdmissionPolicy cannot match MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding. The CREATE, UPDATE and CONNECT operations are allowed.  The DELETE operation may not be matched. '*' matches CREATE, UPDATE and CONNECT. Required."
+        },
+        "mutations": {
+          "description": "mutations contain operations to perform on matching objects. mutations may not be empty; a minimum of one mutation is required. mutations are evaluated in order, and are reinvoked according to the reinvocationPolicy. The mutations of a policy are invoked for each binding of this policy and reinvocation of mutations occurs on a per binding basis.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.Mutation"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "paramKind": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ParamKind",
+          "description": "paramKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If paramKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in MutatingAdmissionPolicyBinding, the params variable will be null."
+        },
+        "reinvocationPolicy": {
+          "description": "reinvocationPolicy indicates whether mutations may be called multiple times per MutatingAdmissionPolicyBinding as part of a single admission evaluation. Allowed values are \"Never\" and \"IfNeeded\".\n\nNever: These mutations will not be called more than once per binding in a single admission evaluation.\n\nIfNeeded: These mutations may be invoked more than once per binding for a single admission request and there is no guarantee of order with respect to other admission plugins, admission webhooks, bindings of this policy and admission policies.  Mutations are only reinvoked when mutations change the object after this mutation is invoked. Required.",
+          "type": "string"
+        },
+        "variables": {
+          "description": "variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except matchConditions because matchConditions are evaluated before the rest of the policy.\n\nThe expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, variables must be sorted by the order of first appearance and acyclic.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.Variable"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.admissionregistration.v1beta1.Mutation": {
+      "description": "Mutation specifies the CEL expression which is used to apply the Mutation.",
+      "properties": {
+        "applyConfiguration": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ApplyConfiguration",
+          "description": "applyConfiguration defines the desired configuration values of an object. The configuration is applied to the admission object using [structured merge diff](https://github.com/kubernetes-sigs/structured-merge-diff). A CEL expression is used to create apply configuration."
+        },
+        "jsonPatch": {
+          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.JSONPatch",
+          "description": "jsonPatch defines a [JSON patch](https://jsonpatch.com/) operation to perform a mutation to the object. A CEL expression is used to create the JSON patch."
+        },
+        "patchType": {
+          "description": "patchType indicates the patch strategy used. Allowed values are \"ApplyConfiguration\" and \"JSONPatch\". Required.",
+          "type": "string"
+        }
+      },
+      "required": ["patchType"],
+      "type": "object",
       "additionalProperties": false
     },
     "io.k8s.api.admissionregistration.v1beta1.NamedRuleWithOperations": {
@@ -1437,290 +1648,6 @@
       },
       "type": "object",
       "x-kubernetes-map-type": "atomic",
-      "additionalProperties": false
-    },
-    "io.k8s.api.admissionregistration.v1beta1.TypeChecking": {
-      "description": "TypeChecking contains results of type checking the expressions in the ValidatingAdmissionPolicy",
-      "properties": {
-        "expressionWarnings": {
-          "description": "The type checking warnings for each expression.",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ExpressionWarning"
-          },
-          "type": "array",
-          "x-kubernetes-list-type": "atomic"
-        }
-      },
-      "type": "object",
-      "additionalProperties": false
-    },
-    "io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicy": {
-      "description": "ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string",
-          "enum": ["ValidatingAdmissionPolicy"]
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
-          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
-        },
-        "spec": {
-          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicySpec",
-          "description": "Specification of the desired behavior of the ValidatingAdmissionPolicy."
-        },
-        "status": {
-          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyStatus",
-          "description": "The status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy behaves in the expected way. Populated by the system. Read-only."
-        }
-      },
-      "type": "object",
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "admissionregistration.k8s.io",
-          "kind": "ValidatingAdmissionPolicy",
-          "version": "v1beta1"
-        }
-      ],
-      "additionalProperties": false
-    },
-    "io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBinding": {
-      "description": "ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.\n\nFor a given admission request, each binding will cause its policy to be evaluated N times, where N is 1 for policies/bindings that don't use params, otherwise N is the number of parameters selected by the binding.\n\nThe CEL expressions of a policy must have a computed CEL cost below the maximum CEL budget. Each evaluation of the policy is given an independent CEL cost budget. Adding/removing policies, bindings, or params can not affect whether a given (policy, binding, param) combination is within its own CEL budget.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type": "string"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string",
-          "enum": ["ValidatingAdmissionPolicyBinding"]
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
-          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
-        },
-        "spec": {
-          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBindingSpec",
-          "description": "Specification of the desired behavior of the ValidatingAdmissionPolicyBinding."
-        }
-      },
-      "type": "object",
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "admissionregistration.k8s.io",
-          "kind": "ValidatingAdmissionPolicyBinding",
-          "version": "v1beta1"
-        }
-      ],
-      "additionalProperties": false
-    },
-    "io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBindingList": {
-      "description": "ValidatingAdmissionPolicyBindingList is a list of ValidatingAdmissionPolicyBinding.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of PolicyBinding.",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBinding"
-          },
-          "type": "array"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string",
-          "enum": ["ValidatingAdmissionPolicyBindingList"]
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-        }
-      },
-      "required": ["items"],
-      "type": "object",
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "admissionregistration.k8s.io",
-          "kind": "ValidatingAdmissionPolicyBindingList",
-          "version": "v1beta1"
-        }
-      ],
-      "additionalProperties": false
-    },
-    "io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyBindingSpec": {
-      "description": "ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.",
-      "properties": {
-        "matchResources": {
-          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MatchResources",
-          "description": "MatchResources declares what resources match this binding and will be validated by it. Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this. If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching. If a resource is matched by the other fields of this object, it will be validated. Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required."
-        },
-        "paramRef": {
-          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ParamRef",
-          "description": "paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param."
-        },
-        "policyName": {
-          "description": "PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to. If the referenced resource does not exist, this binding is considered invalid and will be ignored Required.",
-          "type": "string"
-        },
-        "validationActions": {
-          "description": "validationActions declares how Validations of the referenced ValidatingAdmissionPolicy are enforced. If a validation evaluates to false it is always enforced according to these actions.\n\nFailures defined by the ValidatingAdmissionPolicy's FailurePolicy are enforced according to these actions only if the FailurePolicy is set to Fail, otherwise the failures are ignored. This includes compilation errors, runtime errors and misconfigurations of the policy.\n\nvalidationActions is declared as a set of action values. Order does not matter. validationActions may not contain duplicates of the same action.\n\nThe supported actions values are:\n\n\"Deny\" specifies that a validation failure results in a denied request.\n\n\"Warn\" specifies that a validation failure is reported to the request client in HTTP Warning headers, with a warning code of 299. Warnings can be sent both for allowed or denied admission responses.\n\n\"Audit\" specifies that a validation failure is included in the published audit event for the request. The audit event will contain a `validation.policy.admission.k8s.io/validation_failure` audit annotation with a value containing the details of the validation failures, formatted as a JSON list of objects, each with the following fields: - message: The validation failure message string - policy: The resource name of the ValidatingAdmissionPolicy - binding: The resource name of the ValidatingAdmissionPolicyBinding - expressionIndex: The index of the failed validations in the ValidatingAdmissionPolicy - validationActions: The enforcement actions enacted for the validation failure Example audit annotation: `\"validation.policy.admission.k8s.io/validation_failure\": \"[{\\\"message\\\": \\\"Invalid value\\\", {\\\"policy\\\": \\\"policy.example.com\\\", {\\\"binding\\\": \\\"policybinding.example.com\\\", {\\\"expressionIndex\\\": \\\"1\\\", {\\\"validationActions\\\": [\\\"Audit\\\"]}]\"`\n\nClients should expect to handle additional values by ignoring any values not recognized.\n\n\"Deny\" and \"Warn\" may not be used together since this combination needlessly duplicates the validation failure both in the API response body and the HTTP warning headers.\n\nRequired.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "x-kubernetes-list-type": "set"
-        }
-      },
-      "type": "object",
-      "additionalProperties": false
-    },
-    "io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyList": {
-      "description": "ValidatingAdmissionPolicyList is a list of ValidatingAdmissionPolicy.",
-      "properties": {
-        "apiVersion": {
-          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-          "type": "string"
-        },
-        "items": {
-          "description": "List of ValidatingAdmissionPolicy.",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicy"
-          },
-          "type": "array"
-        },
-        "kind": {
-          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-          "type": "string",
-          "enum": ["ValidatingAdmissionPolicyList"]
-        },
-        "metadata": {
-          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
-          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-        }
-      },
-      "required": ["items"],
-      "type": "object",
-      "x-kubernetes-group-version-kind": [
-        {
-          "group": "admissionregistration.k8s.io",
-          "kind": "ValidatingAdmissionPolicyList",
-          "version": "v1beta1"
-        }
-      ],
-      "additionalProperties": false
-    },
-    "io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicySpec": {
-      "description": "ValidatingAdmissionPolicySpec is the specification of the desired behavior of the AdmissionPolicy.",
-      "properties": {
-        "auditAnnotations": {
-          "description": "auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request. validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.AuditAnnotation"
-          },
-          "type": "array",
-          "x-kubernetes-list-type": "atomic"
-        },
-        "failurePolicy": {
-          "description": "failurePolicy defines how to handle failures for the admission policy. Failures can occur from CEL expression parse errors, type check errors, runtime errors and invalid or mis-configured policy definitions or bindings.\n\nA policy is invalid if spec.paramKind refers to a non-existent Kind. A binding is invalid if spec.paramRef.name refers to a non-existent resource.\n\nfailurePolicy does not define how validations that evaluate to false are handled.\n\nWhen failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.\n\nAllowed values are Ignore or Fail. Defaults to Fail.",
-          "type": "string"
-        },
-        "matchConditions": {
-          "description": "MatchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.\n\nIf a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.\n\nThe exact matching logic is (in order):\n  1. If ANY matchCondition evaluates to FALSE, the policy is skipped.\n  2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.\n  3. If any matchCondition evaluates to an error (but none are FALSE):\n     - If failurePolicy=Fail, reject the request\n     - If failurePolicy=Ignore, the policy is skipped",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MatchCondition"
-          },
-          "type": "array",
-          "x-kubernetes-list-map-keys": ["name"],
-          "x-kubernetes-list-type": "map",
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
-        },
-        "matchConstraints": {
-          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.MatchResources",
-          "description": "MatchConstraints specifies what resources this policy is designed to validate. The AdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding. Required."
-        },
-        "paramKind": {
-          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.ParamKind",
-          "description": "ParamKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null."
-        },
-        "validations": {
-          "description": "Validations contain CEL expressions which is used to apply the validation. Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.Validation"
-          },
-          "type": "array",
-          "x-kubernetes-list-type": "atomic"
-        },
-        "variables": {
-          "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.\n\nThe expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, Variables must be sorted by the order of first appearance and acyclic.",
-          "items": {
-            "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.Variable"
-          },
-          "type": "array",
-          "x-kubernetes-list-map-keys": ["name"],
-          "x-kubernetes-list-type": "map",
-          "x-kubernetes-patch-merge-key": "name",
-          "x-kubernetes-patch-strategy": "merge"
-        }
-      },
-      "type": "object",
-      "additionalProperties": false
-    },
-    "io.k8s.api.admissionregistration.v1beta1.ValidatingAdmissionPolicyStatus": {
-      "description": "ValidatingAdmissionPolicyStatus represents the status of an admission validation policy.",
-      "properties": {
-        "conditions": {
-          "description": "The conditions represent the latest available observations of a policy's current state.",
-          "items": {
-            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
-          },
-          "type": "array",
-          "x-kubernetes-list-map-keys": ["type"],
-          "x-kubernetes-list-type": "map"
-        },
-        "observedGeneration": {
-          "description": "The generation observed by the controller.",
-          "format": "int64",
-          "type": "integer"
-        },
-        "typeChecking": {
-          "$ref": "#/definitions/io.k8s.api.admissionregistration.v1beta1.TypeChecking",
-          "description": "The results of type checking for each expression. Presence of this field indicates the completion of the type checking."
-        }
-      },
-      "type": "object",
-      "additionalProperties": false
-    },
-    "io.k8s.api.admissionregistration.v1beta1.Validation": {
-      "description": "Validation specifies the CEL expression which is used to apply the validation.",
-      "properties": {
-        "expression": {
-          "description": "Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
-          "type": "string"
-        },
-        "message": {
-          "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is \"failed Expression: {Expression}\".",
-          "type": "string"
-        },
-        "messageExpression": {
-          "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: \"object.x must be less than max (\"+string(params.max)+\")\"",
-          "type": "string"
-        },
-        "reason": {
-          "description": "Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\". If not set, StatusReasonInvalid is used in the response to the client.",
-          "type": "string"
-        }
-      },
-      "required": ["expression"],
-      "type": "object",
       "additionalProperties": false
     },
     "io.k8s.api.admissionregistration.v1beta1.Variable": {
@@ -3267,7 +3194,7 @@
       "properties": {
         "fieldSelector": {
           "$ref": "#/definitions/io.k8s.api.authorization.v1.FieldSelectorAttributes",
-          "description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default)."
+          "description": "fieldSelector describes the limitation on access based on field.  It can only limit access, not broaden it."
         },
         "group": {
           "description": "Group is the API Group of the Resource.  \"*\" means all.",
@@ -3275,7 +3202,7 @@
         },
         "labelSelector": {
           "$ref": "#/definitions/io.k8s.api.authorization.v1.LabelSelectorAttributes",
-          "description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it.\n\nThis field  is alpha-level. To use this field, you must enable the `AuthorizeWithSelectors` feature gate (disabled by default)."
+          "description": "labelSelector describes the limitation on access based on labels.  It can only limit access, not broaden it."
         },
         "name": {
           "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
@@ -4801,7 +4728,7 @@
           "type": "string"
         }
       },
-      "required": ["type", "status"],
+      "required": ["type"],
       "type": "object",
       "additionalProperties": false
     },
@@ -5014,8 +4941,7 @@
         "request": {
           "description": "request contains an x509 certificate signing request encoded in a \"CERTIFICATE REQUEST\" PEM block. When serialized as JSON or YAML, the data is additionally base64-encoded.",
           "format": "byte",
-          "type": "string",
-          "x-kubernetes-list-type": "atomic"
+          "type": "string"
         },
         "signerName": {
           "description": "signerName indicates the requested signer, and is a qualified name.\n\nList/watch requests for CertificateSigningRequests can filter on this field using a \"spec.signerName=NAME\" fieldSelector.\n\nWell-known Kubernetes signers are:\n 1. \"kubernetes.io/kube-apiserver-client\": issues client certificates that can be used to authenticate to kube-apiserver.\n  Requests for this signer are never auto-approved by kube-controller-manager, can be issued by the \"csrsigning\" controller in kube-controller-manager.\n 2. \"kubernetes.io/kube-apiserver-client-kubelet\": issues client certificates that kubelets use to authenticate to kube-apiserver.\n  Requests for this signer can be auto-approved by the \"csrapproving\" controller in kube-controller-manager, and can be issued by the \"csrsigning\" controller in kube-controller-manager.\n 3. \"kubernetes.io/kubelet-serving\" issues serving certificates that kubelets use to serve TLS endpoints, which kube-apiserver can connect to securely.\n  Requests for this signer are never auto-approved by kube-controller-manager, and can be issued by the \"csrsigning\" controller in kube-controller-manager.\n\nMore details are available at https://k8s.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers\n\nCustom signerNames can also be specified. The signer defines:\n 1. Trust distribution: how trust (CA bundles) are distributed.\n 2. Permitted subjects: and behavior when a disallowed subject is requested.\n 3. Required, permitted, or forbidden x509 extensions in the request (including whether subjectAltNames are allowed, which types, restrictions on allowed values) and behavior when a disallowed extension is requested.\n 4. Required, permitted, or forbidden key usages / extended key usages.\n 5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.\n 6. Whether or not requests for CA certificates are allowed.",
@@ -5048,8 +4974,7 @@
         "certificate": {
           "description": "certificate is populated with an issued certificate by the signer after an Approved condition is present. This field is set via the /status subresource. Once populated, this field is immutable.\n\nIf the certificate signing request is denied, a condition of type \"Denied\" is added and this field remains empty. If the signer cannot issue the certificate, a condition of type \"Failed\" is added and this field remains empty.\n\nValidation requirements:\n 1. certificate must contain one or more PEM blocks.\n 2. All PEM blocks must have the \"CERTIFICATE\" label, contain no headers, and the encoded data\n  must be a BER-encoded ASN.1 Certificate structure as described in section 4 of RFC5280.\n 3. Non-PEM content may appear before or after the \"CERTIFICATE\" PEM blocks and is unvalidated,\n  to allow for explanatory text as described in section 5.2 of RFC7468.\n\nIf more than one PEM block is present, and the definition of the requested spec.signerName does not indicate otherwise, the first block is the issued certificate, and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.\n\nThe certificate is encoded in PEM format.\n\nWhen serialized as JSON or YAML, the data is additionally base64-encoded, so it consists of:\n\n    base64(\n    -----BEGIN CERTIFICATE-----\n    ...\n    -----END CERTIFICATE-----\n    )",
           "format": "byte",
-          "type": "string",
-          "x-kubernetes-list-type": "atomic"
+          "type": "string"
         },
         "conditions": {
           "description": "conditions applied to the request. Known conditions are \"Approved\", \"Denied\", and \"Failed\".",
@@ -5144,6 +5069,172 @@
         }
       },
       "required": ["trustBundle"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.certificates.v1alpha1.PodCertificateRequest": {
+      "description": "PodCertificateRequest encodes a pod requesting a certificate from a given signer.\n\nKubelets use this API to implement podCertificate projected volumes",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["PodCertificateRequest"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "metadata contains the object metadata."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.certificates.v1alpha1.PodCertificateRequestSpec",
+          "description": "spec contains the details about the certificate being requested."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.certificates.v1alpha1.PodCertificateRequestStatus",
+          "description": "status contains the issued certificate, and a standard set of conditions."
+        }
+      },
+      "required": ["spec"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "certificates.k8s.io",
+          "kind": "PodCertificateRequest",
+          "version": "v1alpha1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.certificates.v1alpha1.PodCertificateRequestList": {
+      "description": "PodCertificateRequestList is a collection of PodCertificateRequest objects",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is a collection of PodCertificateRequest objects",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.certificates.v1alpha1.PodCertificateRequest"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["PodCertificateRequestList"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "metadata contains the list metadata."
+        }
+      },
+      "required": ["items"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "certificates.k8s.io",
+          "kind": "PodCertificateRequestList",
+          "version": "v1alpha1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.certificates.v1alpha1.PodCertificateRequestSpec": {
+      "description": "PodCertificateRequestSpec describes the certificate request.  All fields are immutable after creation.",
+      "properties": {
+        "maxExpirationSeconds": {
+          "description": "maxExpirationSeconds is the maximum lifetime permitted for the certificate.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver will reject values shorter than 3600 (1 hour).  The maximum allowable value is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600 seconds (1 hour).  This constraint is enforced by kube-apiserver. `kubernetes.io` signers will never issue certificates with a lifetime longer than 24 hours.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "nodeName": {
+          "description": "nodeName is the name of the node the pod is assigned to.",
+          "type": "string"
+        },
+        "nodeUID": {
+          "description": "nodeUID is the UID of the node the pod is assigned to.",
+          "type": "string"
+        },
+        "pkixPublicKey": {
+          "description": "pkixPublicKey is the PKIX-serialized public key the signer will issue the certificate to.\n\nThe key must be one of RSA3072, RSA4096, ECDSAP256, ECDSAP384, ECDSAP521, or ED25519. Note that this list may be expanded in the future.\n\nSigner implementations do not need to support all key types supported by kube-apiserver and kubelet.  If a signer does not support the key type used for a given PodCertificateRequest, it must deny the request by setting a status.conditions entry with a type of \"Denied\" and a reason of \"UnsupportedKeyType\". It may also suggest a key type that it does support in the message field.",
+          "format": "byte",
+          "type": "string"
+        },
+        "podName": {
+          "description": "podName is the name of the pod into which the certificate will be mounted.",
+          "type": "string"
+        },
+        "podUID": {
+          "description": "podUID is the UID of the pod into which the certificate will be mounted.",
+          "type": "string"
+        },
+        "proofOfPossession": {
+          "description": "proofOfPossession proves that the requesting kubelet holds the private key corresponding to pkixPublicKey.\n\nIt is contructed by signing the ASCII bytes of the pod's UID using `pkixPublicKey`.\n\nkube-apiserver validates the proof of possession during creation of the PodCertificateRequest.\n\nIf the key is an RSA key, then the signature is over the ASCII bytes of the pod UID, using RSASSA-PSS from RFC 8017 (as implemented by the golang function crypto/rsa.SignPSS with nil options).\n\nIf the key is an ECDSA key, then the signature is as described by [SEC 1, Version 2.0](https://www.secg.org/sec1-v2.pdf) (as implemented by the golang library function crypto/ecdsa.SignASN1)\n\nIf the key is an ED25519 key, the the signature is as described by the [ED25519 Specification](https://ed25519.cr.yp.to/) (as implemented by the golang library crypto/ed25519.Sign).",
+          "format": "byte",
+          "type": "string"
+        },
+        "serviceAccountName": {
+          "description": "serviceAccountName is the name of the service account the pod is running as.",
+          "type": "string"
+        },
+        "serviceAccountUID": {
+          "description": "serviceAccountUID is the UID of the service account the pod is running as.",
+          "type": "string"
+        },
+        "signerName": {
+          "description": "signerName indicates the requested signer.\n\nAll signer names beginning with `kubernetes.io` are reserved for use by the Kubernetes project.  There is currently one well-known signer documented by the Kubernetes project, `kubernetes.io/kube-apiserver-client-pod`, which will issue client certificates understood by kube-apiserver.  It is currently unimplemented.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "signerName",
+        "podName",
+        "podUID",
+        "serviceAccountName",
+        "serviceAccountUID",
+        "nodeName",
+        "nodeUID",
+        "pkixPublicKey",
+        "proofOfPossession"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.certificates.v1alpha1.PodCertificateRequestStatus": {
+      "description": "PodCertificateRequestStatus describes the status of the request, and holds the certificate data if the request is issued.",
+      "properties": {
+        "beginRefreshAt": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "beginRefreshAt is the time at which the kubelet should begin trying to refresh the certificate.  This field is set via the /status subresource, and must be set at the same time as certificateChain.  Once populated, this field is immutable.\n\nThis field is only a hint.  Kubelet may start refreshing before or after this time if necessary."
+        },
+        "certificateChain": {
+          "description": "certificateChain is populated with an issued certificate by the signer. This field is set via the /status subresource. Once populated, this field is immutable.\n\nIf the certificate signing request is denied, a condition of type \"Denied\" is added and this field remains empty. If the signer cannot issue the certificate, a condition of type \"Failed\" is added and this field remains empty.\n\nValidation requirements:\n 1. certificateChain must consist of one or more PEM-formatted certificates.\n 2. Each entry must be a valid PEM-wrapped, DER-encoded ASN.1 Certificate as\n    described in section 4 of RFC5280.\n\nIf more than one block is present, and the definition of the requested spec.signerName does not indicate otherwise, the first block is the issued certificate, and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.  When projecting the chain into a pod volume, kubelet will drop any data in-between the PEM blocks, as well as any PEM block headers.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "conditions applied to the request.\n\nThe types \"Issued\", \"Denied\", and \"Failed\" have special handling.  At most one of these conditions may be present, and they must have status \"True\".\n\nIf the request is denied with `Reason=UnsupportedKeyType`, the signer may suggest a key type that will work in the message field.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["type"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "notAfter": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "notAfter is the time at which the certificate expires.  The value must be the same as the notAfter value in the leaf certificate in certificateChain.  This field is set via the /status subresource.  Once populated, it is immutable.  The signer must set this field at the same time it sets certificateChain."
+        },
+        "notBefore": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "notBefore is the time at which the certificate becomes valid.  The value must be the same as the notBefore value in the leaf certificate in certificateChain.  This field is set via the /status subresource.  Once populated, it is immutable. The signer must set this field at the same time it sets certificateChain."
+        }
+      },
       "type": "object",
       "additionalProperties": false
     },
@@ -6365,8 +6456,16 @@
           "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
         },
         "restartPolicy": {
-          "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+          "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Additionally, setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
           "type": "string"
+        },
+        "restartPolicyRules": {
+          "description": "Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod's RestartPolicy.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerRestartRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "securityContext": {
           "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
@@ -6424,6 +6523,26 @@
         }
       },
       "required": ["name"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.core.v1.ContainerExtendedResourceRequest": {
+      "description": "ContainerExtendedResourceRequest has the mapping of container name, extended resource name to the device request name.",
+      "properties": {
+        "containerName": {
+          "description": "The name of the container requesting resources.",
+          "type": "string"
+        },
+        "requestName": {
+          "description": "The name of the request in the special ResourceClaim which corresponds to the extended resource.",
+          "type": "string"
+        },
+        "resourceName": {
+          "description": "The name of the extended resource in that container which gets backed by DRA.",
+          "type": "string"
+        }
+      },
+      "required": ["containerName", "resourceName", "requestName"],
       "type": "object",
       "additionalProperties": false
     },
@@ -6490,6 +6609,43 @@
         }
       },
       "required": ["resourceName", "restartPolicy"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.core.v1.ContainerRestartRule": {
+      "description": "ContainerRestartRule describes how a container exit is handled.",
+      "properties": {
+        "action": {
+          "description": "Specifies the action taken on a container exit if the requirements are satisfied. The only possible value is \"Restart\" to restart the container.",
+          "type": "string"
+        },
+        "exitCodes": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes",
+          "description": "Represents the exit codes to check on container exits."
+        }
+      },
+      "required": ["action"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes": {
+      "description": "ContainerRestartRuleOnExitCodes describes the condition for handling an exited container based on its exit codes.",
+      "properties": {
+        "operator": {
+          "description": "Represents the relationship between the container exit code(s) and the specified values. Possible values are: - In: the requirement is satisfied if the container exit code is in the\n  set of specified values.\n- NotIn: the requirement is satisfied if the container exit code is\n  not in the set of specified values.",
+          "type": "string"
+        },
+        "values": {
+          "description": "Specifies the set of values to check for container exit codes. At most 255 elements are allowed.",
+          "items": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        }
+      },
+      "required": ["operator"],
       "type": "object",
       "additionalProperties": false
     },
@@ -6963,6 +7119,10 @@
           "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
           "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs."
         },
+        "fileKeyRef": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.FileKeySelector",
+          "description": "FileKeyRef selects a key of the env file. Requires the EnvFiles feature gate to be enabled."
+        },
         "resourceFieldRef": {
           "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
           "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported."
@@ -7061,8 +7221,16 @@
           "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod."
         },
         "restartPolicy": {
-          "description": "Restart policy for the container to manage the restart behavior of each container within a pod. This may only be set for init containers. You cannot set this field on ephemeral containers.",
+          "description": "Restart policy for the container to manage the restart behavior of each container within a pod. You cannot set this field on ephemeral containers.",
           "type": "string"
+        },
+        "restartPolicyRules": {
+          "description": "Represents a list of rules to be checked to determine if the container should be restarted on exit. You cannot set this field on ephemeral containers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerRestartRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "securityContext": {
           "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
@@ -7338,6 +7506,31 @@
         }
       },
       "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.core.v1.FileKeySelector": {
+      "description": "FileKeySelector selects a key of the env file.",
+      "properties": {
+        "key": {
+          "description": "The key within the env file. An invalid key will prevent the pod from starting. The keys defined within a source may consist of any printable ASCII characters except '='. During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Specify whether the file or its key must be defined. If the file or key does not exist, then the env var is not published. If optional is set to true and the specified key does not exist, the environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist, an error will be returned during Pod creation.",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path within the volume from which to select the file. Must be relative and may not contain the '..' path or start with '..'.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "The name of the volume mount containing the env file.",
+          "type": "string"
+        }
+      },
+      "required": ["volumeName", "path", "key"],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic",
       "additionalProperties": false
     },
     "io.k8s.api.core.v1.FlexPersistentVolumeSource": {
@@ -8921,7 +9114,7 @@
         },
         "resources": {
           "$ref": "#/definitions/io.k8s.api.core.v1.VolumeResourceRequirements",
-          "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+          "description": "resources represents the minimum resources the volume should have. Users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
         },
         "selector": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
@@ -8932,7 +9125,7 @@
           "type": "string"
         },
         "volumeAttributesClassName": {
-          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
+          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string or nil value indicates that no VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state, this field can be reset to its previous value (including nil) to cancel the modification. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
           "type": "string"
         },
         "volumeMode": {
@@ -8962,7 +9155,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
+          "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.",
           "type": "object",
           "x-kubernetes-map-type": "granular"
         },
@@ -8970,7 +9163,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
           },
-          "description": "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
+          "description": "allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.",
           "type": "object"
         },
         "capacity": {
@@ -8992,12 +9185,12 @@
           "x-kubernetes-patch-strategy": "merge"
         },
         "currentVolumeAttributesClassName": {
-          "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using. When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim This is a beta field and requires enabling VolumeAttributesClass feature (off by default).",
+          "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using. When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim",
           "type": "string"
         },
         "modifyVolumeStatus": {
           "$ref": "#/definitions/io.k8s.api.core.v1.ModifyVolumeStatus",
-          "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation. When this is unset, there is no ModifyVolume operation being attempted. This is a beta field and requires enabling VolumeAttributesClass feature (off by default)."
+          "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation. When this is unset, there is no ModifyVolume operation being attempted."
         },
         "phase": {
           "description": "phase represents the current phase of PersistentVolumeClaim.",
@@ -9202,7 +9395,7 @@
           "description": "storageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod. Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported. More info: https://examples.k8s.io/volumes/storageos/README.md"
         },
         "volumeAttributesClassName": {
-          "description": "Name of VolumeAttributesClass to which this persistent volume belongs. Empty value is not allowed. When this field is not set, it indicates that this volume does not belong to any VolumeAttributesClass. This field is mutable and can be changed by the CSI driver after a volume has been updated successfully to a new class. For an unbound PersistentVolume, the volumeAttributesClassName will be matched with unbound PersistentVolumeClaims during the binding process. This is a beta field and requires enabling VolumeAttributesClass feature (off by default).",
+          "description": "Name of VolumeAttributesClass to which this persistent volume belongs. Empty value is not allowed. When this field is not set, it indicates that this volume does not belong to any VolumeAttributesClass. This field is mutable and can be changed by the CSI driver after a volume has been updated successfully to a new class. For an unbound PersistentVolume, the volumeAttributesClassName will be matched with unbound PersistentVolumeClaims during the binding process.",
           "type": "string"
         },
         "volumeMode": {
@@ -9381,6 +9574,39 @@
       "type": "object",
       "additionalProperties": false
     },
+    "io.k8s.api.core.v1.PodCertificateProjection": {
+      "description": "PodCertificateProjection provides a private key and X.509 certificate in the pod filesystem.",
+      "properties": {
+        "certificateChainPath": {
+          "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.",
+          "type": "string"
+        },
+        "credentialBundlePath": {
+          "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks. The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private key.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued certificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single atomic read that retrieves a consistent key and certificate chain.  If you project them to separate files, your application code will need to additionally check that the leaf certificate was issued to the key.",
+          "type": "string"
+        },
+        "keyPath": {
+          "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.",
+          "type": "string"
+        },
+        "keyType": {
+          "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\", \"ECDSAP521\", and \"ED25519\".",
+          "type": "string"
+        },
+        "maxExpirationSeconds": {
+          "description": "maxExpirationSeconds is the maximum lifetime permitted for the certificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it generates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver will reject values shorter than 3600 (1 hour).  The maximum allowable value is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600 seconds (1 hour).  This constraint is enforced by kube-apiserver. `kubernetes.io` signers will never issue certificates with a lifetime longer than 24 hours.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "signerName": {
+          "description": "Kubelet's generated CSRs will be addressed to this signer.",
+          "type": "string"
+        }
+      },
+      "required": ["signerName", "keyType"],
+      "type": "object",
+      "additionalProperties": false
+    },
     "io.k8s.api.core.v1.PodCondition": {
       "description": "PodCondition contains details for the current condition of this pod.",
       "properties": {
@@ -9397,7 +9623,7 @@
           "type": "string"
         },
         "observedGeneration": {
-          "description": "If set, this represents the .metadata.generation that the pod condition was set based upon. This is an alpha field. Enable PodObservedGenerationTracking to be able to use this field.",
+          "description": "If set, this represents the .metadata.generation that the pod condition was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
           "format": "int64",
           "type": "integer"
         },
@@ -9461,6 +9687,26 @@
           "type": "string"
         }
       },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.core.v1.PodExtendedResourceClaimStatus": {
+      "description": "PodExtendedResourceClaimStatus is stored in the PodStatus for the extended resource requests backed by DRA. It stores the generated name for the corresponding special ResourceClaim created by the scheduler.",
+      "properties": {
+        "requestMappings": {
+          "description": "RequestMappings identifies the mapping of <container, extended resource backed by DRA> to  device request in the generated ResourceClaim.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.ContainerExtendedResourceRequest"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "resourceClaimName": {
+          "description": "ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod.",
+          "type": "string"
+        }
+      },
+      "required": ["requestMappings", "resourceClaimName"],
       "type": "object",
       "additionalProperties": false
     },
@@ -9720,7 +9966,7 @@
           "type": "boolean"
         },
         "hostNetwork": {
-          "description": "Host networking requested for this pod. Use the host's network namespace. Default to false.",
+          "description": "Host networking requested for this pod. Use the host's network namespace. When using HostNetwork you should specify ports so the scheduler is aware. When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`, and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`. Default to false.",
           "type": "boolean"
         },
         "hostPID": {
@@ -9733,6 +9979,10 @@
         },
         "hostname": {
           "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+          "type": "string"
+        },
+        "hostnameOverride": {
+          "description": "HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod. This field only specifies the pod's hostname and does not affect its DNS records. When this field is set to a non-empty string: - It takes precedence over the values set in `hostname` and `subdomain`. - The Pod's hostname will be set to this value. - `setHostnameAsFQDN` must be nil or set to false. - `hostNetwork` must be set to false.\n\nThis field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters. Requires the HostnameOverride feature gate to be enabled.",
           "type": "string"
         },
         "imagePullSecrets": {
@@ -9771,7 +10021,7 @@
         },
         "os": {
           "$ref": "#/definitions/io.k8s.api.core.v1.PodOS",
-          "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.securityContext.supplementalGroupsPolicy - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup"
+          "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.resources - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.securityContext.supplementalGroupsPolicy - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup"
         },
         "overhead": {
           "additionalProperties": {
@@ -9802,7 +10052,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "resourceClaims": {
-          "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable.",
+          "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.\n\nThis is a stable field but requires that the DynamicResourceAllocation feature gate is enabled.\n\nThis field is immutable.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.PodResourceClaim"
           },
@@ -9814,7 +10064,7 @@
         },
         "resources": {
           "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
-          "description": "Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for \"cpu\" and \"memory\" resource names only. ResourceClaims are not supported.\n\nThis field enables fine-grained control over resource allocation for the entire pod, allowing resource sharing among containers in a pod.\n\nThis is an alpha field and requires enabling the PodLevelResources feature gate."
+          "description": "Resources is the total amount of CPU and Memory resources required by all containers in the pod. It supports specifying Requests and Limits for \"cpu\", \"memory\" and \"hugepages-\" resource names only. ResourceClaims are not supported.\n\nThis field enables fine-grained control over resource allocation for the entire pod, allowing resource sharing among containers in a pod.\n\nThis is an alpha field and requires enabling the PodLevelResources feature gate."
         },
         "restartPolicy": {
           "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
@@ -9933,6 +10183,10 @@
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
+        "extendedResourceClaimStatus": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodExtendedResourceClaimStatus",
+          "description": "Status of extended resource claim backed by DRA."
+        },
         "hostIP": {
           "description": "hostIP holds the IP address of the host to which the pod is assigned. Empty if the pod has not started yet. A pod can be assigned to a node that has a problem in kubelet which in turns mean that HostIP will not be updated even if there is a node is assigned to pod",
           "type": "string"
@@ -9964,7 +10218,7 @@
           "type": "string"
         },
         "observedGeneration": {
-          "description": "If set, this represents the .metadata.generation that the pod status was set based upon. This is an alpha field. Enable PodObservedGenerationTracking to be able to use this field.",
+          "description": "If set, this represents the .metadata.generation that the pod status was set based upon. The PodObservedGenerationTracking feature gate must be enabled to use this field.",
           "format": "int64",
           "type": "integer"
         },
@@ -10695,7 +10949,7 @@
       "description": "ResourceRequirements describes the compute resource requirements.",
       "properties": {
         "claims": {
-          "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+          "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis field depends on the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.ResourceClaim"
           },
@@ -12039,6 +12293,10 @@
         "downwardAPI": {
           "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIProjection",
           "description": "downwardAPI information about the downwardAPI data to project"
+        },
+        "podCertificate": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodCertificateProjection",
+          "description": "Projects an auto-rotating credential bundle (private key and certificate chain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a PodCertificateRequest to the named signer.  Once the signer approves the request and issues a certificate chain, Kubelet writes the key and certificate chain to the pod filesystem.  The pod does not start until certificates have been issued for each podCertificate projected volume source in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated by the signer using the PodCertificateRequest.Status.BeginRefreshAt timestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath field, or separate files, indicated by the keyPath and certificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM entry is the private key (in PKCS#8 format), and the remaining PEM entries are the certificate chain issued by the signer (typically, signers will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code can read it atomically.  If you use keyPath and certificateChainPath, your application must make two separate file reads. If these coincide with a certificate rotation, it is possible that the private key and leaf certificate you read may not correspond to each other.  Your application will need to check for this condition, and re-read until they are consistent.\n\nThe named signer controls chooses the format of the certificate it issues; consult the signer implementation's documentation to learn how to use the certificates it issues."
         },
         "secret": {
           "$ref": "#/definitions/io.k8s.api.core.v1.SecretProjection",
@@ -14779,6 +15037,1164 @@
       "x-kubernetes-map-type": "atomic",
       "additionalProperties": false
     },
+    "io.k8s.api.resource.v1.AllocatedDeviceStatus": {
+      "description": "AllocatedDeviceStatus contains the status of an allocated device, if the driver chooses to report it. This may include driver-specific information.\n\nThe combination of Driver, Pool, Device, and ShareID must match the corresponding key in Status.Allocation.Devices.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions contains the latest observation of the device's state. If the device has been configured according to the class and claim config references, the `Ready` condition should be True.\n\nMust not contain more than 8 entries.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["type"],
+          "x-kubernetes-list-type": "map"
+        },
+        "data": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "description": "Data contains arbitrary driver-specific data.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
+        },
+        "device": {
+          "description": "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
+          "type": "string"
+        },
+        "driver": {
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
+          "type": "string"
+        },
+        "networkData": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.NetworkDeviceData",
+          "description": "NetworkData contains network-related information specific to the device."
+        },
+        "pool": {
+          "description": "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
+          "type": "string"
+        },
+        "shareID": {
+          "description": "ShareID uniquely identifies an individual allocation share of the device.",
+          "type": "string"
+        }
+      },
+      "required": ["driver", "pool", "device"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.AllocationResult": {
+      "description": "AllocationResult contains attributes of an allocated resource.",
+      "properties": {
+        "allocationTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "AllocationTimestamp stores the time when the resources were allocated. This field is not guaranteed to be set, in which case that time is unknown.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gate."
+        },
+        "devices": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceAllocationResult",
+          "description": "Devices is the result of allocating devices."
+        },
+        "nodeSelector": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
+          "description": "NodeSelector defines where the allocated resources are available. If unset, they are available everywhere."
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.CELDeviceSelector": {
+      "description": "CELDeviceSelector contains a CEL expression for selecting a device.",
+      "properties": {
+        "expression": {
+          "description": "Expression is a CEL expression which evaluates a single device. It must evaluate to true when the device under consideration satisfies the desired criteria, and false when it does not. Any other result is an error and causes allocation of devices to abort.\n\nThe expression's input is an object named \"device\", which carries the following properties:\n - driver (string): the name of the driver which defines this device.\n - attributes (map[string]object): the device's attributes, grouped by prefix\n   (e.g. device.attributes[\"dra.example.com\"] evaluates to an object with all\n   of the attributes which were prefixed by \"dra.example.com\".\n - capacity (map[string]object): the device's capacities, grouped by prefix.\n - allowMultipleAllocations (bool): the allowMultipleAllocations property of the device\n   (v1.34+ with the DRAConsumableCapacity feature enabled).\n\nExample: Consider a device with driver=\"dra.example.com\", which exposes two attributes named \"model\" and \"ext.example.com/family\" and which exposes one capacity named \"modules\". This input to this expression would have the following fields:\n\n    device.driver\n    device.attributes[\"dra.example.com\"].model\n    device.attributes[\"ext.example.com\"].family\n    device.capacity[\"dra.example.com\"].modules\n\nThe device.driver field can be used to check for a specific driver, either as a high-level precondition (i.e. you only want to consider devices from this driver) or as part of a multi-clause expression that is meant to consider devices from different drivers.\n\nThe value type of each attribute is defined by the device definition, and users who write these expressions must consult the documentation for their specific drivers. The value type of each capacity is Quantity.\n\nIf an unknown prefix is used as a lookup in either device.attributes or device.capacity, an empty map will be returned. Any reference to an unknown field will cause an evaluation error and allocation to abort.\n\nA robust expression should check for the existence of attributes before referencing them.\n\nFor ease of use, the cel.bind() function is enabled, and can be used to simplify expressions that access multiple attributes with the same domain. For example:\n\n    cel.bind(dra, device.attributes[\"dra.example.com\"], dra.someBool && dra.anotherBool)\n\nThe length of the expression must be smaller or equal to 10 Ki. The cost of evaluating it is also limited based on the estimated number of logical steps.",
+          "type": "string"
+        }
+      },
+      "required": ["expression"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.CapacityRequestPolicy": {
+      "description": "CapacityRequestPolicy defines how requests consume device capacity.\n\nMust not set more than one ValidRequestValues.",
+      "properties": {
+        "default": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Default specifies how much of this capacity is consumed by a request that does not contain an entry for it in DeviceRequest's Capacity."
+        },
+        "validRange": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.CapacityRequestPolicyRange",
+          "description": "ValidRange defines an acceptable quantity value range in consuming requests.\n\nIf this field is set, Default must be defined and it must fall within the defined ValidRange.\n\nIf the requested amount does not fall within the defined range, the request violates the policy, and this device cannot be allocated.\n\nIf the request doesn't contain this capacity entry, Default value is used."
+        },
+        "validValues": {
+          "description": "ValidValues defines a set of acceptable quantity values in consuming requests.\n\nMust not contain more than 10 entries. Must be sorted in ascending order.\n\nIf this field is set, Default must be defined and it must be included in ValidValues list.\n\nIf the requested amount does not match any valid value but smaller than some valid values, the scheduler calculates the smallest valid value that is greater than or equal to the request. That is: min(ceil(requestedValue) \u2208 validValues), where requestedValue \u2264 max(validValues).\n\nIf the requested amount exceeds all valid values, the request violates the policy, and this device cannot be allocated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.CapacityRequestPolicyRange": {
+      "description": "CapacityRequestPolicyRange defines a valid range for consumable capacity values.\n\n  - If the requested amount is less than Min, it is rounded up to the Min value.\n  - If Step is set and the requested amount is between Min and Max but not aligned with Step,\n    it will be rounded up to the next value equal to Min + (n * Step).\n  - If Step is not set, the requested amount is used as-is if it falls within the range Min to Max (if set).\n  - If the requested or rounded amount exceeds Max (if set), the request does not satisfy the policy,\n    and the device cannot be allocated.",
+      "properties": {
+        "max": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Max defines the upper limit for capacity that can be requested.\n\nMax must be less than or equal to the capacity value. Min and requestPolicy.default must be less than or equal to the maximum."
+        },
+        "min": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Min specifies the minimum capacity allowed for a consumption request.\n\nMin must be greater than or equal to zero, and less than or equal to the capacity value. requestPolicy.default must be more than or equal to the minimum."
+        },
+        "step": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Step defines the step size between valid capacity amounts within the range.\n\nMax (if set) and requestPolicy.default must be a multiple of Step. Min + Step must be less than or equal to the capacity value."
+        }
+      },
+      "required": ["min"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.CapacityRequirements": {
+      "description": "CapacityRequirements defines the capacity requirements for a specific device request.",
+      "properties": {
+        "requests": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Requests represent individual device resource requests for distinct resources, all of which must be provided by the device.\n\nThis value is used as an additional filtering condition against the available capacity on the device. This is semantically equivalent to a CEL selector with `device.capacity[<domain>].<name>.compareTo(quantity(<request quantity>)) >= 0`. For example, device.capacity['test-driver.cdi.k8s.io'].counters.compareTo(quantity('2')) >= 0.\n\nWhen a requestPolicy is defined, the requested amount is adjusted upward to the nearest valid value based on the policy. If the requested amount cannot be adjusted to a valid value\u2014because it exceeds what the requestPolicy allows\u2014 the device is considered ineligible for allocation.\n\nFor any capacity that is not explicitly requested: - If no requestPolicy is set, the default consumed capacity is equal to the full device capacity\n  (i.e., the whole device is claimed).\n- If a requestPolicy is set, the default consumed capacity is determined according to that policy.\n\nIf the device allows multiple allocation, the aggregated amount across all requests must not exceed the capacity value. The consumed capacity, which may be adjusted based on the requestPolicy if defined, is recorded in the resource claim\u2019s status.devices[*].consumedCapacity field.",
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.Counter": {
+      "description": "Counter describes a quantity associated with a device.",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Value defines how much of a certain device counter is available."
+        }
+      },
+      "required": ["value"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.CounterSet": {
+      "description": "CounterSet defines a named set of counters that are available to be used by devices defined in the ResourceSlice.\n\nThe counters are not allocatable by themselves, but can be referenced by devices. When a device is allocated, the portion of counters it uses will no longer be available for use by other devices.",
+      "properties": {
+        "counters": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.Counter"
+          },
+          "description": "Counters defines the set of counters for this CounterSet The name of each counter must be unique in that set and must be a DNS label.\n\nThe maximum number of counters in all sets is 32.",
+          "type": "object"
+        },
+        "name": {
+          "description": "Name defines the name of the counter set. It must be a DNS label.",
+          "type": "string"
+        }
+      },
+      "required": ["name", "counters"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.Device": {
+      "description": "Device represents one individual hardware instance that can be selected based on its attributes. Besides the name, exactly one field must be set.",
+      "properties": {
+        "allNodes": {
+          "description": "AllNodes indicates that all nodes have access to the device.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
+          "type": "boolean"
+        },
+        "allowMultipleAllocations": {
+          "description": "AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.\n\nIf AllowMultipleAllocations is set to true, the device can be allocated more than once, and all of its capacity is consumable, regardless of whether the requestPolicy is defined or not.",
+          "type": "boolean"
+        },
+        "attributes": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceAttribute"
+          },
+          "description": "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
+          "type": "object"
+        },
+        "bindingConditions": {
+          "description": "BindingConditions defines the conditions for proceeding with binding. All of these conditions must be set in the per-device status conditions with a value of True to proceed with binding the pod to the node while scheduling the pod.\n\nThe maximum number of binding conditions is 4.\n\nThe conditions must be a valid condition type string.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bindingFailureConditions": {
+          "description": "BindingFailureConditions defines the conditions for binding failure. They may be set in the per-device status conditions. If any is set to \"True\", a binding failure occurred.\n\nThe maximum number of binding failure conditions is 4.\n\nThe conditions must be a valid condition type string.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bindsToNode": {
+          "description": "BindsToNode indicates if the usage of an allocation involving this device has to be limited to exactly the node that was chosen when allocating the claim. If set to true, the scheduler will set the ResourceClaim.Status.Allocation.NodeSelector to match the node where the allocation was made.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "type": "boolean"
+        },
+        "capacity": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceCapacity"
+          },
+          "description": "Capacity defines the set of capacities for this device. The name of each capacity must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
+          "type": "object"
+        },
+        "consumesCounters": {
+          "description": "ConsumesCounters defines a list of references to sharedCounters and the set of counters that the device will consume from those counter sets.\n\nThere can only be a single entry per counterSet.\n\nThe total number of device counter consumption entries must be <= 32. In addition, the total number in the entire ResourceSlice must be <= 1024 (for example, 64 devices with 16 counters each).",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceCounterConsumption"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "name": {
+          "description": "Name is unique identifier among all devices managed by the driver in the pool. It must be a DNS label.",
+          "type": "string"
+        },
+        "nodeName": {
+          "description": "NodeName identifies the node where the device is available.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
+          "type": "string"
+        },
+        "nodeSelector": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
+          "description": "NodeSelector defines the nodes where the device is available.\n\nMust use exactly one term.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set."
+        },
+        "taints": {
+          "description": "If specified, these are the driver-defined taints.\n\nThe maximum number of taints is 4.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceTaint"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": ["name"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceAllocationConfiguration": {
+      "description": "DeviceAllocationConfiguration gets embedded in an AllocationResult.",
+      "properties": {
+        "opaque": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.OpaqueDeviceConfiguration",
+          "description": "Opaque provides driver-specific configuration parameters."
+        },
+        "requests": {
+          "description": "Requests lists the names of requests where the configuration applies. If empty, its applies to all requests.\n\nReferences to subrequests must include the name of the main request and may include the subrequest using the format <main request>[/<subrequest>]. If just the main request is given, the configuration applies to all subrequests.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "source": {
+          "description": "Source records whether the configuration comes from a class and thus is not something that a normal user would have been able to set or from a claim.",
+          "type": "string"
+        }
+      },
+      "required": ["source"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceAllocationResult": {
+      "description": "DeviceAllocationResult is the result of allocating devices.",
+      "properties": {
+        "config": {
+          "description": "This field is a combination of all the claim and class configuration parameters. Drivers can distinguish between those based on a flag.\n\nThis includes configuration parameters for drivers which have no allocated devices in the result because it is up to the drivers which configuration parameters they support. They can silently ignore unknown configuration parameters.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceAllocationConfiguration"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "results": {
+          "description": "Results lists all allocated devices.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceRequestAllocationResult"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceAttribute": {
+      "description": "DeviceAttribute must have exactly one field set.",
+      "properties": {
+        "bool": {
+          "description": "BoolValue is a true/false value.",
+          "type": "boolean"
+        },
+        "int": {
+          "description": "IntValue is a number.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "string": {
+          "description": "StringValue is a string. Must not be longer than 64 characters.",
+          "type": "string"
+        },
+        "version": {
+          "description": "VersionValue is a semantic version according to semver.org spec 2.0.0. Must not be longer than 64 characters.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceCapacity": {
+      "description": "DeviceCapacity describes a quantity associated with a device.",
+      "properties": {
+        "requestPolicy": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.CapacityRequestPolicy",
+          "description": "RequestPolicy defines how this DeviceCapacity must be consumed when the device is allowed to be shared by multiple allocations.\n\nThe Device must have allowMultipleAllocations set to true in order to set a requestPolicy.\n\nIf unset, capacity requests are unconstrained: requests can consume any amount of capacity, as long as the total consumed across all allocations does not exceed the device's defined capacity. If request is also unset, default is the full capacity value."
+        },
+        "value": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Value defines how much of a certain capacity that device has.\n\nThis field reflects the fixed total capacity and does not change. The consumed amount is tracked separately by scheduler and does not affect this value."
+        }
+      },
+      "required": ["value"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceClaim": {
+      "description": "DeviceClaim defines how to request devices with a ResourceClaim.",
+      "properties": {
+        "config": {
+          "description": "This field holds configuration for multiple potential drivers which could satisfy requests in this claim. It is ignored while allocating the claim.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceClaimConfiguration"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "constraints": {
+          "description": "These constraints must be satisfied by the set of devices that get allocated for the claim.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceConstraint"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "requests": {
+          "description": "Requests represent individual requests for distinct devices which must all be satisfied. If empty, nothing needs to be allocated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceRequest"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceClaimConfiguration": {
+      "description": "DeviceClaimConfiguration is used for configuration parameters in DeviceClaim.",
+      "properties": {
+        "opaque": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.OpaqueDeviceConfiguration",
+          "description": "Opaque provides driver-specific configuration parameters."
+        },
+        "requests": {
+          "description": "Requests lists the names of requests where the configuration applies. If empty, it applies to all requests.\n\nReferences to subrequests must include the name of the main request and may include the subrequest using the format <main request>[/<subrequest>]. If just the main request is given, the configuration applies to all subrequests.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceClass": {
+      "description": "DeviceClass is a vendor- or admin-provided resource that contains device configuration and selectors. It can be referenced in the device requests of a claim to apply these presets. Cluster scoped.\n\nThis is an alpha type and requires enabling the DynamicResourceAllocation feature gate.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["DeviceClass"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceClassSpec",
+          "description": "Spec defines what can be allocated and how to configure it.\n\nThis is mutable. Consumers have to be prepared for classes changing at any time, either because they get updated or replaced. Claim allocations are done once based on whatever was set in classes at the time of allocation.\n\nChanging the spec automatically increments the metadata.generation number."
+        }
+      },
+      "required": ["spec"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClass",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceClassConfiguration": {
+      "description": "DeviceClassConfiguration is used in DeviceClass.",
+      "properties": {
+        "opaque": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.OpaqueDeviceConfiguration",
+          "description": "Opaque provides driver-specific configuration parameters."
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceClassList": {
+      "description": "DeviceClassList is a collection of classes.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of resource classes.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceClass"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["DeviceClassList"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata"
+        }
+      },
+      "required": ["items"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "resource.k8s.io",
+          "kind": "DeviceClassList",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceClassSpec": {
+      "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
+      "properties": {
+        "config": {
+          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceClassConfiguration"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "extendedResourceName": {
+          "description": "ExtendedResourceName is the extended resource name for the devices of this class. The devices of this class can be used to satisfy a pod's extended resource requests. It has the same format as the name of a pod's extended resource. It should be unique among all the device classes in a cluster. If two device classes have the same name, then the class created later is picked to satisfy a pod's extended resource requests. If two classes are created at the same time, then the name of the class lexicographically sorted first is picked.\n\nThis is an alpha field.",
+          "type": "string"
+        },
+        "selectors": {
+          "description": "Each selector must be satisfied by a device which is claimed via this class.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceSelector"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceConstraint": {
+      "description": "DeviceConstraint must have exactly one field set besides Requests.",
+      "properties": {
+        "distinctAttribute": {
+          "description": "DistinctAttribute requires that all devices in question have this attribute and that its type and value are unique across those devices.\n\nThis acts as the inverse of MatchAttribute.\n\nThis constraint is used to avoid allocating multiple requests to the same device by ensuring attribute-level differentiation.\n\nThis is useful for scenarios where resource requests must be fulfilled by separate physical devices. For example, a container requests two network interfaces that must be allocated from two different physical NICs.",
+          "type": "string"
+        },
+        "matchAttribute": {
+          "description": "MatchAttribute requires that all devices in question have this attribute and that its type and value are the same across those devices.\n\nFor example, if you specified \"dra.example.com/numa\" (a hypothetical example!), then only devices in the same NUMA node will be chosen. A device which does not have that attribute will not be chosen. All devices should use a value of the same type for this attribute because that is part of its specification, but if one device doesn't, then it also will not be chosen.\n\nMust include the domain qualifier.",
+          "type": "string"
+        },
+        "requests": {
+          "description": "Requests is a list of the one or more requests in this claim which must co-satisfy this constraint. If a request is fulfilled by multiple devices, then all of the devices must satisfy the constraint. If this is not specified, this constraint applies to all requests in this claim.\n\nReferences to subrequests must include the name of the main request and may include the subrequest using the format <main request>[/<subrequest>]. If just the main request is given, the constraint applies to all subrequests.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceCounterConsumption": {
+      "description": "DeviceCounterConsumption defines a set of counters that a device will consume from a CounterSet.",
+      "properties": {
+        "counterSet": {
+          "description": "CounterSet is the name of the set from which the counters defined will be consumed.",
+          "type": "string"
+        },
+        "counters": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.Counter"
+          },
+          "description": "Counters defines the counters that will be consumed by the device.\n\nThe maximum number counters in a device is 32. In addition, the maximum number of all counters in all devices is 1024 (for example, 64 devices with 16 counters each).",
+          "type": "object"
+        }
+      },
+      "required": ["counterSet", "counters"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceRequest": {
+      "description": "DeviceRequest is a request for devices required for a claim. This is typically a request for a single resource like a device, but can also ask for several identical devices. With FirstAvailable it is also possible to provide a prioritized list of requests.",
+      "properties": {
+        "exactly": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.ExactDeviceRequest",
+          "description": "Exactly specifies the details for a single request that must be met exactly for the request to be satisfied.\n\nOne of Exactly or FirstAvailable must be set."
+        },
+        "firstAvailable": {
+          "description": "FirstAvailable contains subrequests, of which exactly one will be selected by the scheduler. It tries to satisfy them in the order in which they are listed here. So if there are two entries in the list, the scheduler will only check the second one if it determines that the first one can not be used.\n\nDRA does not yet implement scoring, so the scheduler will select the first set of devices that satisfies all the requests in the claim. And if the requirements can be satisfied on more than one node, other scheduling features will determine which node is chosen. This means that the set of devices allocated to a claim might not be the optimal set available to the cluster. Scoring will be implemented later.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceSubRequest"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "name": {
+          "description": "Name can be used to reference this request in a pod.spec.containers[].resources.claims entry and in a constraint of the claim.\n\nReferences using the name in the DeviceRequest will uniquely identify a request when the Exactly field is set. When the FirstAvailable field is set, a reference to the name of the DeviceRequest will match whatever subrequest is chosen by the scheduler.\n\nMust be a DNS label.",
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceRequestAllocationResult": {
+      "description": "DeviceRequestAllocationResult contains the allocation result for one request.",
+      "properties": {
+        "adminAccess": {
+          "description": "AdminAccess indicates that this device was allocated for administrative access. See the corresponding request field for a definition of mode.\n\nThis is an alpha field and requires enabling the DRAAdminAccess feature gate. Admin access is disabled if this field is unset or set to false, otherwise it is enabled.",
+          "type": "boolean"
+        },
+        "bindingConditions": {
+          "description": "BindingConditions contains a copy of the BindingConditions from the corresponding ResourceSlice at the time of allocation.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bindingFailureConditions": {
+          "description": "BindingFailureConditions contains a copy of the BindingFailureConditions from the corresponding ResourceSlice at the time of allocation.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "consumedCapacity": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request. The consumed amount may differ from the requested amount: it is rounded up to the nearest valid value based on the device\u2019s requestPolicy if applicable (i.e., may not be less than the requested amount).\n\nThe total consumed capacity for each device must not exceed the DeviceCapacity's Value.\n\nThis field is populated only for devices that allow multiple allocations. All capacity entries are included, even if the consumed amount is zero.",
+          "type": "object"
+        },
+        "device": {
+          "description": "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
+          "type": "string"
+        },
+        "driver": {
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
+          "type": "string"
+        },
+        "pool": {
+          "description": "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
+          "type": "string"
+        },
+        "request": {
+          "description": "Request is the name of the request in the claim which caused this device to be allocated. If it references a subrequest in the firstAvailable list on a DeviceRequest, this field must include both the name of the main request and the subrequest using the format <main request>/<subrequest>.\n\nMultiple devices may have been allocated per request.",
+          "type": "string"
+        },
+        "shareID": {
+          "description": "ShareID uniquely identifies an individual allocation share of the device, used when the device supports multiple simultaneous allocations. It serves as an additional map key to differentiate concurrent shares of the same device.",
+          "type": "string"
+        },
+        "tolerations": {
+          "description": "A copy of all tolerations specified in the request at the time when the device got allocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceToleration"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": ["request", "driver", "pool", "device"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceSelector": {
+      "description": "DeviceSelector must have exactly one field set.",
+      "properties": {
+        "cel": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.CELDeviceSelector",
+          "description": "CEL contains a CEL expression for selecting a device."
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceSubRequest": {
+      "description": "DeviceSubRequest describes a request for device provided in the claim.spec.devices.requests[].firstAvailable array. Each is typically a request for a single resource like a device, but can also ask for several identical devices.\n\nDeviceSubRequest is similar to ExactDeviceRequest, but doesn't expose the AdminAccess field as that one is only supported when requesting a specific device.",
+      "properties": {
+        "allocationMode": {
+          "description": "AllocationMode and its related fields define how devices are allocated to satisfy this subrequest. Supported values are:\n\n- ExactCount: This request is for a specific number of devices.\n  This is the default. The exact number is provided in the\n  count field.\n\n- All: This subrequest is for all of the matching devices in a pool.\n  Allocation will fail if some devices are already allocated,\n  unless adminAccess is requested.\n\nIf AllocationMode is not specified, the default mode is ExactCount. If the mode is ExactCount and count is not specified, the default count is one. Any other subrequests must specify this field.\n\nMore modes may get added in the future. Clients must refuse to handle requests with unknown modes.",
+          "type": "string"
+        },
+        "capacity": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.CapacityRequirements",
+          "description": "Capacity define resource requirements against each capacity.\n\nIf this field is unset and the device supports multiple allocations, the default value will be applied to each capacity according to requestPolicy. For the capacity that has no requestPolicy, default is the full capacity value.\n\nApplies to each device allocation. If Count > 1, the request fails if there aren't enough devices that meet the requirements. If AllocationMode is set to All, the request fails if there are devices that otherwise match the request, and have this capacity, with a value >= the requested amount, but which cannot be allocated to this request."
+        },
+        "count": {
+          "description": "Count is used only when the count mode is \"ExactCount\". Must be greater than zero. If AllocationMode is ExactCount and this field is not specified, the default is one.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "deviceClassName": {
+          "description": "DeviceClassName references a specific DeviceClass, which can define additional configuration and selectors to be inherited by this subrequest.\n\nA class is required. Which classes are available depends on the cluster.\n\nAdministrators may use this to restrict which devices may get requested by only installing classes with selectors for permitted devices. If users are free to request anything without restrictions, then administrators can create an empty DeviceClass for users to reference.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name can be used to reference this subrequest in the list of constraints or the list of configurations for the claim. References must use the format <main request>/<subrequest>.\n\nMust be a DNS label.",
+          "type": "string"
+        },
+        "selectors": {
+          "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this subrequest. All selectors must be satisfied for a device to be considered.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceSelector"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "tolerations": {
+          "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceToleration"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": ["name", "deviceClassName"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceTaint": {
+      "description": "The device this taint is attached to has the \"effect\" on any claim which does not tolerate the taint and, through the claim, to pods using the claim.",
+      "properties": {
+        "effect": {
+          "description": "The effect of the taint on claims that do not tolerate the taint and through such claims on the pods using them. Valid effects are NoSchedule and NoExecute. PreferNoSchedule as used for nodes is not valid here.",
+          "type": "string"
+        },
+        "key": {
+          "description": "The taint key to be applied to a device. Must be a label name.",
+          "type": "string"
+        },
+        "timeAdded": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "TimeAdded represents the time at which the taint was added. Added automatically during create or update if not set."
+        },
+        "value": {
+          "description": "The taint value corresponding to the taint key. Must be a label value.",
+          "type": "string"
+        }
+      },
+      "required": ["key", "effect"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.DeviceToleration": {
+      "description": "The ResourceClaim this DeviceToleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+      "properties": {
+        "effect": {
+          "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule and NoExecute.",
+          "type": "string"
+        },
+        "key": {
+          "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys. Must be a label name.",
+          "type": "string"
+        },
+        "operator": {
+          "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a ResourceClaim can tolerate all taints of a particular category.",
+          "type": "string"
+        },
+        "tolerationSeconds": {
+          "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system. If larger than zero, the time when the pod needs to be evicted is calculated as <time when taint was adedd> + <toleration seconds>.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "value": {
+          "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value must be empty, otherwise just a regular string. Must be a label value.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ExactDeviceRequest": {
+      "description": "ExactDeviceRequest is a request for one or more identical devices.",
+      "properties": {
+        "adminAccess": {
+          "description": "AdminAccess indicates that this is a claim for administrative access to the device(s). Claims with AdminAccess are expected to be used for monitoring or other management services for a device.  They ignore all ordinary claims to the device with respect to access modes and any resource allocations.\n\nThis is an alpha field and requires enabling the DRAAdminAccess feature gate. Admin access is disabled if this field is unset or set to false, otherwise it is enabled.",
+          "type": "boolean"
+        },
+        "allocationMode": {
+          "description": "AllocationMode and its related fields define how devices are allocated to satisfy this request. Supported values are:\n\n- ExactCount: This request is for a specific number of devices.\n  This is the default. The exact number is provided in the\n  count field.\n\n- All: This request is for all of the matching devices in a pool.\n  At least one device must exist on the node for the allocation to succeed.\n  Allocation will fail if some devices are already allocated,\n  unless adminAccess is requested.\n\nIf AllocationMode is not specified, the default mode is ExactCount. If the mode is ExactCount and count is not specified, the default count is one. Any other requests must specify this field.\n\nMore modes may get added in the future. Clients must refuse to handle requests with unknown modes.",
+          "type": "string"
+        },
+        "capacity": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.CapacityRequirements",
+          "description": "Capacity define resource requirements against each capacity.\n\nIf this field is unset and the device supports multiple allocations, the default value will be applied to each capacity according to requestPolicy. For the capacity that has no requestPolicy, default is the full capacity value.\n\nApplies to each device allocation. If Count > 1, the request fails if there aren't enough devices that meet the requirements. If AllocationMode is set to All, the request fails if there are devices that otherwise match the request, and have this capacity, with a value >= the requested amount, but which cannot be allocated to this request."
+        },
+        "count": {
+          "description": "Count is used only when the count mode is \"ExactCount\". Must be greater than zero. If AllocationMode is ExactCount and this field is not specified, the default is one.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "deviceClassName": {
+          "description": "DeviceClassName references a specific DeviceClass, which can define additional configuration and selectors to be inherited by this request.\n\nA DeviceClassName is required.\n\nAdministrators may use this to restrict which devices may get requested by only installing classes with selectors for permitted devices. If users are free to request anything without restrictions, then administrators can create an empty DeviceClass for users to reference.",
+          "type": "string"
+        },
+        "selectors": {
+          "description": "Selectors define criteria which must be satisfied by a specific device in order for that device to be considered for this request. All selectors must be satisfied for a device to be considered.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceSelector"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "tolerations": {
+          "description": "If specified, the request's tolerations.\n\nTolerations for NoSchedule are required to allocate a device which has a taint with that effect. The same applies to NoExecute.\n\nIn addition, should any of the allocated devices get tainted with NoExecute after allocation and that effect is not tolerated, then all pods consuming the ResourceClaim get deleted to evict them. The scheduler will not let new pods reserve the claim while it has these tainted devices. Once all pods are evicted, the claim will get deallocated.\n\nThe maximum number of tolerations is 16.\n\nThis is an alpha field and requires enabling the DRADeviceTaints feature gate.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceToleration"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": ["deviceClassName"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.NetworkDeviceData": {
+      "description": "NetworkDeviceData provides network-related details for the allocated device. This information may be filled by drivers or other components to configure or identify the device within a network context.",
+      "properties": {
+        "hardwareAddress": {
+          "description": "HardwareAddress represents the hardware address (e.g. MAC Address) of the device's network interface.\n\nMust not be longer than 128 characters.",
+          "type": "string"
+        },
+        "interfaceName": {
+          "description": "InterfaceName specifies the name of the network interface associated with the allocated device. This might be the name of a physical or virtual network interface being configured in the pod.\n\nMust not be longer than 256 characters.",
+          "type": "string"
+        },
+        "ips": {
+          "description": "IPs lists the network addresses assigned to the device's network interface. This can include both IPv4 and IPv6 addresses. The IPs are in the CIDR notation, which includes both the address and the associated subnet mask. e.g.: \"192.0.2.5/24\" for IPv4 and \"2001:db8::5/64\" for IPv6.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.OpaqueDeviceConfiguration": {
+      "description": "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
+      "properties": {
+        "driver": {
+          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension",
+          "description": "Parameters can contain arbitrary data. It is the responsibility of the driver developer to handle validation and versioning. Typically this includes self-identification and a version (\"kind\" + \"apiVersion\" for Kubernetes types), with conversion between different versions.\n\nThe length of the raw data must be smaller or equal to 10 Ki."
+        }
+      },
+      "required": ["driver", "parameters"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceClaim": {
+      "description": "ResourceClaim describes a request for access to resources in the cluster, for use by workloads. For example, if a workload needs an accelerator device with specific properties, this is how that request is expressed. The status stanza tracks whether this claim has been satisfied and what specific resources have been allocated.\n\nThis is an alpha type and requires enabling the DynamicResourceAllocation feature gate.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["ResourceClaim"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.ResourceClaimSpec",
+          "description": "Spec describes what is being requested and how to configure it. The spec is immutable."
+        },
+        "status": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.ResourceClaimStatus",
+          "description": "Status describes whether the claim is ready to use and what has been allocated."
+        }
+      },
+      "required": ["spec"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaim",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceClaimConsumerReference": {
+      "description": "ResourceClaimConsumerReference contains enough information to let you locate the consumer of a ResourceClaim. The user must be a resource in the same namespace as the ResourceClaim.",
+      "properties": {
+        "apiGroup": {
+          "description": "APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name is the name of resource being referenced.",
+          "type": "string"
+        },
+        "resource": {
+          "description": "Resource is the type of resource being referenced, for example \"pods\".",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID identifies exactly one incarnation of the resource.",
+          "type": "string"
+        }
+      },
+      "required": ["resource", "name", "uid"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceClaimList": {
+      "description": "ResourceClaimList is a collection of claims.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of resource claims.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.ResourceClaim"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["ResourceClaimList"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata"
+        }
+      },
+      "required": ["items"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimList",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceClaimSpec": {
+      "description": "ResourceClaimSpec defines what is being requested in a ResourceClaim and how to configure it.",
+      "properties": {
+        "devices": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceClaim",
+          "description": "Devices defines how to request devices."
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceClaimStatus": {
+      "description": "ResourceClaimStatus tracks whether the resource has been allocated and what the result of that was.",
+      "properties": {
+        "allocation": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.AllocationResult",
+          "description": "Allocation is set once the claim has been allocated successfully."
+        },
+        "devices": {
+          "description": "Devices contains the status of each device allocated for this claim, as reported by the driver. This can include driver-specific information. Entries are owned by their respective drivers.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.AllocatedDeviceStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["driver", "device", "pool", "shareID"],
+          "x-kubernetes-list-type": "map"
+        },
+        "reservedFor": {
+          "description": "ReservedFor indicates which entities are currently allowed to use the claim. A Pod which references a ResourceClaim which is not reserved for that Pod will not be started. A claim that is in use or might be in use because it has been reserved must not get deallocated.\n\nIn a cluster with multiple scheduler instances, two pods might get scheduled concurrently by different schedulers. When they reference the same ResourceClaim which already has reached its maximum number of consumers, only one pod can be scheduled.\n\nBoth schedulers try to add their pod to the claim.status.reservedFor field, but only the update that reaches the API server first gets stored. The other one fails with an error and the scheduler which issued it knows that it must put the pod back into the queue, waiting for the ResourceClaim to become usable again.\n\nThere can be at most 256 such reservations. This may get increased in the future, but not reduced.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.ResourceClaimConsumerReference"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["uid"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceClaimTemplate": {
+      "description": "ResourceClaimTemplate is used to produce ResourceClaim objects.\n\nThis is an alpha type and requires enabling the DynamicResourceAllocation feature gate.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["ResourceClaimTemplate"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.ResourceClaimTemplateSpec",
+          "description": "Describes the ResourceClaim that is to be generated.\n\nThis field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore."
+        }
+      },
+      "required": ["spec"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplate",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceClaimTemplateList": {
+      "description": "ResourceClaimTemplateList is a collection of claim templates.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of resource claim templates.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.ResourceClaimTemplate"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["ResourceClaimTemplateList"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata"
+        }
+      },
+      "required": ["items"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "resource.k8s.io",
+          "kind": "ResourceClaimTemplateList",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceClaimTemplateSpec": {
+      "description": "ResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "ObjectMeta may contain labels and annotations that will be copied into the ResourceClaim when creating it. No other fields are allowed and will be rejected during validation."
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.ResourceClaimSpec",
+          "description": "Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here."
+        }
+      },
+      "required": ["spec"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourcePool": {
+      "description": "ResourcePool describes the pool that ResourceSlices belong to.",
+      "properties": {
+        "generation": {
+          "description": "Generation tracks the change in a pool over time. Whenever a driver changes something about one or more of the resources in a pool, it must change the generation in all ResourceSlices which are part of that pool. Consumers of ResourceSlices should only consider resources from the pool with the highest generation number. The generation may be reset by drivers, which should be fine for consumers, assuming that all ResourceSlices in a pool are updated to match or deleted.\n\nCombined with ResourceSliceCount, this mechanism enables consumers to detect pools which are comprised of multiple ResourceSlices and are in an incomplete state.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "name": {
+          "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+          "type": "string"
+        },
+        "resourceSliceCount": {
+          "description": "ResourceSliceCount is the total number of ResourceSlices in the pool at this generation number. Must be greater than zero.\n\nConsumers can use this to check whether they have seen all ResourceSlices belonging to the same pool.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": ["name", "generation", "resourceSliceCount"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceSlice": {
+      "description": "ResourceSlice represents one or more resources in a pool of similar resources, managed by a common driver. A pool may span more than one ResourceSlice, and exactly how many ResourceSlices comprise a pool is determined by the driver.\n\nAt the moment, the only supported resources are devices with attributes and capacities. Each device in a given pool, regardless of how many ResourceSlices, must have a unique name. The ResourceSlice in which a device gets published may change over time. The unique identifier for a device is the tuple <driver name>, <pool name>, <device name>.\n\nWhenever a driver needs to update a pool, it increments the pool.Spec.Pool.Generation number and updates all ResourceSlices with that new number and new resource definitions. A consumer must only use ResourceSlices with the highest generation number and ignore all others.\n\nWhen allocating all resources in a pool matching certain criteria or when looking for the best solution among several different alternatives, a consumer should check the number of ResourceSlices in a pool (included in each ResourceSlice) to determine whether its view of a pool is complete and if not, should wait until the driver has completed updating the pool.\n\nFor resources that are not local to a node, the node name is not set. Instead, the driver may use a node selector to specify where the devices are available.\n\nThis is an alpha type and requires enabling the DynamicResourceAllocation feature gate.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["ResourceSlice"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.ResourceSliceSpec",
+          "description": "Contains the information published by the driver.\n\nChanging the spec automatically increments the metadata.generation number."
+        }
+      },
+      "required": ["spec"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSlice",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceSliceList": {
+      "description": "ResourceSliceList is a collection of ResourceSlices.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "Items is the list of resource ResourceSlices.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.ResourceSlice"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["ResourceSliceList"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata"
+        }
+      },
+      "required": ["items"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "resource.k8s.io",
+          "kind": "ResourceSliceList",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1.ResourceSliceSpec": {
+      "description": "ResourceSliceSpec contains the information published by the driver in one ResourceSlice.",
+      "properties": {
+        "allNodes": {
+          "description": "AllNodes indicates that all nodes have access to the resources in the pool.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
+          "type": "boolean"
+        },
+        "devices": {
+          "description": "Devices lists some or all of the devices in this pool.\n\nMust not have more than 128 entries.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.Device"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "driver": {
+          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
+          "type": "string"
+        },
+        "nodeName": {
+          "description": "NodeName identifies the node which provides the resources in this pool. A field selector can be used to list only ResourceSlice objects belonging to a certain node.\n\nThis field can be used to limit access from nodes to ResourceSlices with the same node name. It also indicates to autoscalers that adding new nodes of the same type as some old node might also make new resources available.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set. This field is immutable.",
+          "type": "string"
+        },
+        "nodeSelector": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
+          "description": "NodeSelector defines which nodes have access to the resources in the pool, when that pool is not limited to a single node.\n\nMust use exactly one term.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set."
+        },
+        "perDeviceNodeSelection": {
+          "description": "PerDeviceNodeSelection defines whether the access from nodes to resources in the pool is set on the ResourceSlice level or on each device. If it is set to true, every device defined the ResourceSlice must specify this individually.\n\nExactly one of NodeName, NodeSelector, AllNodes, and PerDeviceNodeSelection must be set.",
+          "type": "boolean"
+        },
+        "pool": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1.ResourcePool",
+          "description": "Pool describes the pool that this ResourceSlice belongs to."
+        },
+        "sharedCounters": {
+          "description": "SharedCounters defines a list of counter sets, each of which has a name and a list of counters available.\n\nThe names of the SharedCounters must be unique in the ResourceSlice.\n\nThe maximum number of counters in all sets is 32.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.resource.v1.CounterSet"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": ["driver", "pool"],
+      "type": "object",
+      "additionalProperties": false
+    },
     "io.k8s.api.resource.v1alpha3.CELDeviceSelector": {
       "description": "CELDeviceSelector contains a CEL expression for selecting a device.",
       "properties": {
@@ -14941,7 +16357,7 @@
       "additionalProperties": false
     },
     "io.k8s.api.resource.v1beta1.AllocatedDeviceStatus": {
-      "description": "AllocatedDeviceStatus contains the status of an allocated device, if the driver chooses to report it. This may include driver-specific information.",
+      "description": "AllocatedDeviceStatus contains the status of an allocated device, if the driver chooses to report it. This may include driver-specific information.\n\nThe combination of Driver, Pool, Device, and ShareID must match the corresponding key in Status.Allocation.Devices.",
       "properties": {
         "conditions": {
           "description": "Conditions contains the latest observation of the device's state. If the device has been configured according to the class and claim config references, the `Ready` condition should be True.\n\nMust not contain more than 8 entries.",
@@ -14961,7 +16377,7 @@
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "networkData": {
@@ -14970,6 +16386,10 @@
         },
         "pool": {
           "description": "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
+          "type": "string"
+        },
+        "shareID": {
+          "description": "ShareID uniquely identifies an individual allocation share of the device.",
           "type": "string"
         }
       },
@@ -14980,6 +16400,10 @@
     "io.k8s.api.resource.v1beta1.AllocationResult": {
       "description": "AllocationResult contains attributes of an allocated resource.",
       "properties": {
+        "allocationTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "AllocationTimestamp stores the time when the resources were allocated. This field is not guaranteed to be set, in which case that time is unknown.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gate."
+        },
         "devices": {
           "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceAllocationResult",
           "description": "Devices is the result of allocating devices."
@@ -14999,12 +16423,36 @@
           "description": "AllNodes indicates that all nodes have access to the device.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
           "type": "boolean"
         },
+        "allowMultipleAllocations": {
+          "description": "AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.\n\nIf AllowMultipleAllocations is set to true, the device can be allocated more than once, and all of its capacity is consumable, regardless of whether the requestPolicy is defined or not.",
+          "type": "boolean"
+        },
         "attributes": {
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceAttribute"
           },
           "description": "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
           "type": "object"
+        },
+        "bindingConditions": {
+          "description": "BindingConditions defines the conditions for proceeding with binding. All of these conditions must be set in the per-device status conditions with a value of True to proceed with binding the pod to the node while scheduling the pod.\n\nThe maximum number of binding conditions is 4.\n\nThe conditions must be a valid condition type string.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bindingFailureConditions": {
+          "description": "BindingFailureConditions defines the conditions for binding failure. They may be set in the per-device status conditions. If any is true, a binding failure occurred.\n\nThe maximum number of binding failure conditions is 4.\n\nThe conditions must be a valid condition type string.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bindsToNode": {
+          "description": "BindsToNode indicates if the usage of an allocation involving this device has to be limited to exactly the node that was chosen when allocating the claim. If set to true, the scheduler will set the ResourceClaim.Status.Allocation.NodeSelector to match the node where the allocation was made.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "type": "boolean"
         },
         "capacity": {
           "additionalProperties": {
@@ -15045,11 +16493,68 @@
       "description": "CELDeviceSelector contains a CEL expression for selecting a device.",
       "properties": {
         "expression": {
-          "description": "Expression is a CEL expression which evaluates a single device. It must evaluate to true when the device under consideration satisfies the desired criteria, and false when it does not. Any other result is an error and causes allocation of devices to abort.\n\nThe expression's input is an object named \"device\", which carries the following properties:\n - driver (string): the name of the driver which defines this device.\n - attributes (map[string]object): the device's attributes, grouped by prefix\n   (e.g. device.attributes[\"dra.example.com\"] evaluates to an object with all\n   of the attributes which were prefixed by \"dra.example.com\".\n - capacity (map[string]object): the device's capacities, grouped by prefix.\n\nExample: Consider a device with driver=\"dra.example.com\", which exposes two attributes named \"model\" and \"ext.example.com/family\" and which exposes one capacity named \"modules\". This input to this expression would have the following fields:\n\n    device.driver\n    device.attributes[\"dra.example.com\"].model\n    device.attributes[\"ext.example.com\"].family\n    device.capacity[\"dra.example.com\"].modules\n\nThe device.driver field can be used to check for a specific driver, either as a high-level precondition (i.e. you only want to consider devices from this driver) or as part of a multi-clause expression that is meant to consider devices from different drivers.\n\nThe value type of each attribute is defined by the device definition, and users who write these expressions must consult the documentation for their specific drivers. The value type of each capacity is Quantity.\n\nIf an unknown prefix is used as a lookup in either device.attributes or device.capacity, an empty map will be returned. Any reference to an unknown field will cause an evaluation error and allocation to abort.\n\nA robust expression should check for the existence of attributes before referencing them.\n\nFor ease of use, the cel.bind() function is enabled, and can be used to simplify expressions that access multiple attributes with the same domain. For example:\n\n    cel.bind(dra, device.attributes[\"dra.example.com\"], dra.someBool && dra.anotherBool)\n\nThe length of the expression must be smaller or equal to 10 Ki. The cost of evaluating it is also limited based on the estimated number of logical steps.",
+          "description": "Expression is a CEL expression which evaluates a single device. It must evaluate to true when the device under consideration satisfies the desired criteria, and false when it does not. Any other result is an error and causes allocation of devices to abort.\n\nThe expression's input is an object named \"device\", which carries the following properties:\n - driver (string): the name of the driver which defines this device.\n - attributes (map[string]object): the device's attributes, grouped by prefix\n   (e.g. device.attributes[\"dra.example.com\"] evaluates to an object with all\n   of the attributes which were prefixed by \"dra.example.com\".\n - capacity (map[string]object): the device's capacities, grouped by prefix.\n - allowMultipleAllocations (bool): the allowMultipleAllocations property of the device\n   (v1.34+ with the DRAConsumableCapacity feature enabled).\n\nExample: Consider a device with driver=\"dra.example.com\", which exposes two attributes named \"model\" and \"ext.example.com/family\" and which exposes one capacity named \"modules\". This input to this expression would have the following fields:\n\n    device.driver\n    device.attributes[\"dra.example.com\"].model\n    device.attributes[\"ext.example.com\"].family\n    device.capacity[\"dra.example.com\"].modules\n\nThe device.driver field can be used to check for a specific driver, either as a high-level precondition (i.e. you only want to consider devices from this driver) or as part of a multi-clause expression that is meant to consider devices from different drivers.\n\nThe value type of each attribute is defined by the device definition, and users who write these expressions must consult the documentation for their specific drivers. The value type of each capacity is Quantity.\n\nIf an unknown prefix is used as a lookup in either device.attributes or device.capacity, an empty map will be returned. Any reference to an unknown field will cause an evaluation error and allocation to abort.\n\nA robust expression should check for the existence of attributes before referencing them.\n\nFor ease of use, the cel.bind() function is enabled, and can be used to simplify expressions that access multiple attributes with the same domain. For example:\n\n    cel.bind(dra, device.attributes[\"dra.example.com\"], dra.someBool && dra.anotherBool)\n\nThe length of the expression must be smaller or equal to 10 Ki. The cost of evaluating it is also limited based on the estimated number of logical steps.",
           "type": "string"
         }
       },
       "required": ["expression"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1beta1.CapacityRequestPolicy": {
+      "description": "CapacityRequestPolicy defines how requests consume device capacity.\n\nMust not set more than one ValidRequestValues.",
+      "properties": {
+        "default": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Default specifies how much of this capacity is consumed by a request that does not contain an entry for it in DeviceRequest's Capacity."
+        },
+        "validRange": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.CapacityRequestPolicyRange",
+          "description": "ValidRange defines an acceptable quantity value range in consuming requests.\n\nIf this field is set, Default must be defined and it must fall within the defined ValidRange.\n\nIf the requested amount does not fall within the defined range, the request violates the policy, and this device cannot be allocated.\n\nIf the request doesn't contain this capacity entry, Default value is used."
+        },
+        "validValues": {
+          "description": "ValidValues defines a set of acceptable quantity values in consuming requests.\n\nMust not contain more than 10 entries. Must be sorted in ascending order.\n\nIf this field is set, Default must be defined and it must be included in ValidValues list.\n\nIf the requested amount does not match any valid value but smaller than some valid values, the scheduler calculates the smallest valid value that is greater than or equal to the request. That is: min(ceil(requestedValue) \u2208 validValues), where requestedValue \u2264 max(validValues).\n\nIf the requested amount exceeds all valid values, the request violates the policy, and this device cannot be allocated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1beta1.CapacityRequestPolicyRange": {
+      "description": "CapacityRequestPolicyRange defines a valid range for consumable capacity values.\n\n  - If the requested amount is less than Min, it is rounded up to the Min value.\n  - If Step is set and the requested amount is between Min and Max but not aligned with Step,\n    it will be rounded up to the next value equal to Min + (n * Step).\n  - If Step is not set, the requested amount is used as-is if it falls within the range Min to Max (if set).\n  - If the requested or rounded amount exceeds Max (if set), the request does not satisfy the policy,\n    and the device cannot be allocated.",
+      "properties": {
+        "max": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Max defines the upper limit for capacity that can be requested.\n\nMax must be less than or equal to the capacity value. Min and requestPolicy.default must be less than or equal to the maximum."
+        },
+        "min": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Min specifies the minimum capacity allowed for a consumption request.\n\nMin must be greater than or equal to zero, and less than or equal to the capacity value. requestPolicy.default must be more than or equal to the minimum."
+        },
+        "step": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Step defines the step size between valid capacity amounts within the range.\n\nMax (if set) and requestPolicy.default must be a multiple of Step. Min + Step must be less than or equal to the capacity value."
+        }
+      },
+      "required": ["min"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1beta1.CapacityRequirements": {
+      "description": "CapacityRequirements defines the capacity requirements for a specific device request.",
+      "properties": {
+        "requests": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Requests represent individual device resource requests for distinct resources, all of which must be provided by the device.\n\nThis value is used as an additional filtering condition against the available capacity on the device. This is semantically equivalent to a CEL selector with `device.capacity[<domain>].<name>.compareTo(quantity(<request quantity>)) >= 0`. For example, device.capacity['test-driver.cdi.k8s.io'].counters.compareTo(quantity('2')) >= 0.\n\nWhen a requestPolicy is defined, the requested amount is adjusted upward to the nearest valid value based on the policy. If the requested amount cannot be adjusted to a valid value\u2014because it exceeds what the requestPolicy allows\u2014 the device is considered ineligible for allocation.\n\nFor any capacity that is not explicitly requested: - If no requestPolicy is set, the default consumed capacity is equal to the full device capacity\n  (i.e., the whole device is claimed).\n- If a requestPolicy is set, the default consumed capacity is determined according to that policy.\n\nIf the device allows multiple allocation, the aggregated amount across all requests must not exceed the capacity value. The consumed capacity, which may be adjusted based on the requestPolicy if defined, is recorded in the resource claim\u2019s status.devices[*].consumedCapacity field.",
+          "type": "object"
+        }
+      },
       "type": "object",
       "additionalProperties": false
     },
@@ -15174,9 +16679,13 @@
     "io.k8s.api.resource.v1beta1.DeviceCapacity": {
       "description": "DeviceCapacity describes a quantity associated with a device.",
       "properties": {
+        "requestPolicy": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.CapacityRequestPolicy",
+          "description": "RequestPolicy defines how this DeviceCapacity must be consumed when the device is allowed to be shared by multiple allocations.\n\nThe Device must have allowMultipleAllocations set to true in order to set a requestPolicy.\n\nIf unset, capacity requests are unconstrained: requests can consume any amount of capacity, as long as the total consumed across all allocations does not exceed the device's defined capacity. If request is also unset, default is the full capacity value."
+        },
         "value": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
-          "description": "Value defines how much of a certain device capacity is available."
+          "description": "Value defines how much of a certain capacity that device has.\n\nThis field reflects the fixed total capacity and does not change. The consumed amount is tracked separately by scheduler and does not affect this value."
         }
       },
       "required": ["value"],
@@ -15322,6 +16831,10 @@
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
+        "extendedResourceName": {
+          "description": "ExtendedResourceName is the extended resource name for the devices of this class. The devices of this class can be used to satisfy a pod's extended resource requests. It has the same format as the name of a pod's extended resource. It should be unique among all the device classes in a cluster. If two device classes have the same name, then the class created later is picked to satisfy a pod's extended resource requests. If two classes are created at the same time, then the name of the class lexicographically sorted first is picked.\n\nThis is an alpha field.",
+          "type": "string"
+        },
         "selectors": {
           "description": "Each selector must be satisfied by a device which is claimed via this class.",
           "items": {
@@ -15337,6 +16850,10 @@
     "io.k8s.api.resource.v1beta1.DeviceConstraint": {
       "description": "DeviceConstraint must have exactly one field set besides Requests.",
       "properties": {
+        "distinctAttribute": {
+          "description": "DistinctAttribute requires that all devices in question have this attribute and that its type and value are unique across those devices.\n\nThis acts as the inverse of MatchAttribute.\n\nThis constraint is used to avoid allocating multiple requests to the same device by ensuring attribute-level differentiation.\n\nThis is useful for scenarios where resource requests must be fulfilled by separate physical devices. For example, a container requests two network interfaces that must be allocated from two different physical NICs.",
+          "type": "string"
+        },
         "matchAttribute": {
           "description": "MatchAttribute requires that all devices in question have this attribute and that its type and value are the same across those devices.\n\nFor example, if you specified \"dra.example.com/numa\" (a hypothetical example!), then only devices in the same NUMA node will be chosen. A device which does not have that attribute will not be chosen. All devices should use a value of the same type for this attribute because that is part of its specification, but if one device doesn't, then it also will not be chosen.\n\nMust include the domain qualifier.",
           "type": "string"
@@ -15382,6 +16899,10 @@
         "allocationMode": {
           "description": "AllocationMode and its related fields define how devices are allocated to satisfy this request. Supported values are:\n\n- ExactCount: This request is for a specific number of devices.\n  This is the default. The exact number is provided in the\n  count field.\n\n- All: This request is for all of the matching devices in a pool.\n  At least one device must exist on the node for the allocation to succeed.\n  Allocation will fail if some devices are already allocated,\n  unless adminAccess is requested.\n\nIf AllocationMode is not specified, the default mode is ExactCount. If the mode is ExactCount and count is not specified, the default count is one. Any other requests must specify this field.\n\nThis field can only be set when deviceClassName is set and no subrequests are specified in the firstAvailable list.\n\nMore modes may get added in the future. Clients must refuse to handle requests with unknown modes.",
           "type": "string"
+        },
+        "capacity": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.CapacityRequirements",
+          "description": "Capacity define resource requirements against each capacity.\n\nIf this field is unset and the device supports multiple allocations, the default value will be applied to each capacity according to requestPolicy. For the capacity that has no requestPolicy, default is the full capacity value.\n\nApplies to each device allocation. If Count > 1, the request fails if there aren't enough devices that meet the requirements. If AllocationMode is set to All, the request fails if there are devices that otherwise match the request, and have this capacity, with a value >= the requested amount, but which cannot be allocated to this request."
         },
         "count": {
           "description": "Count is used only when the count mode is \"ExactCount\". Must be greater than zero. If AllocationMode is ExactCount and this field is not specified, the default is one.\n\nThis field can only be set when deviceClassName is set and no subrequests are specified in the firstAvailable list.",
@@ -15432,12 +16953,35 @@
           "description": "AdminAccess indicates that this device was allocated for administrative access. See the corresponding request field for a definition of mode.\n\nThis is an alpha field and requires enabling the DRAAdminAccess feature gate. Admin access is disabled if this field is unset or set to false, otherwise it is enabled.",
           "type": "boolean"
         },
+        "bindingConditions": {
+          "description": "BindingConditions contains a copy of the BindingConditions from the corresponding ResourceSlice at the time of allocation.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bindingFailureConditions": {
+          "description": "BindingFailureConditions contains a copy of the BindingFailureConditions from the corresponding ResourceSlice at the time of allocation.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "consumedCapacity": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request. The consumed amount may differ from the requested amount: it is rounded up to the nearest valid value based on the device\u2019s requestPolicy if applicable (i.e., may not be less than the requested amount).\n\nThe total consumed capacity for each device must not exceed the DeviceCapacity's Value.\n\nThis field is populated only for devices that allow multiple allocations. All capacity entries are included, even if the consumed amount is zero.",
+          "type": "object"
+        },
         "device": {
           "description": "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "pool": {
@@ -15446,6 +16990,10 @@
         },
         "request": {
           "description": "Request is the name of the request in the claim which caused this device to be allocated. If it references a subrequest in the firstAvailable list on a DeviceRequest, this field must include both the name of the main request and the subrequest using the format <main request>/<subrequest>.\n\nMultiple devices may have been allocated per request.",
+          "type": "string"
+        },
+        "shareID": {
+          "description": "ShareID uniquely identifies an individual allocation share of the device, used when the device supports multiple simultaneous allocations. It serves as an additional map key to differentiate concurrent shares of the same device.",
           "type": "string"
         },
         "tolerations": {
@@ -15478,6 +17026,10 @@
         "allocationMode": {
           "description": "AllocationMode and its related fields define how devices are allocated to satisfy this subrequest. Supported values are:\n\n- ExactCount: This request is for a specific number of devices.\n  This is the default. The exact number is provided in the\n  count field.\n\n- All: This subrequest is for all of the matching devices in a pool.\n  Allocation will fail if some devices are already allocated,\n  unless adminAccess is requested.\n\nIf AllocationMode is not specified, the default mode is ExactCount. If the mode is ExactCount and count is not specified, the default count is one. Any other subrequests must specify this field.\n\nMore modes may get added in the future. Clients must refuse to handle requests with unknown modes.",
           "type": "string"
+        },
+        "capacity": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta1.CapacityRequirements",
+          "description": "Capacity define resource requirements against each capacity.\n\nIf this field is unset and the device supports multiple allocations, the default value will be applied to each capacity according to requestPolicy. For the capacity that has no requestPolicy, default is the full capacity value.\n\nApplies to each device allocation. If Count > 1, the request fails if there aren't enough devices that meet the requirements. If AllocationMode is set to All, the request fails if there are devices that otherwise match the request, and have this capacity, with a value >= the requested amount, but which cannot be allocated to this request."
         },
         "count": {
           "description": "Count is used only when the count mode is \"ExactCount\". Must be greater than zero. If AllocationMode is ExactCount and this field is not specified, the default is one.",
@@ -15592,7 +17144,7 @@
       "description": "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
       "properties": {
         "driver": {
-          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "parameters": {
@@ -15723,7 +17275,7 @@
             "$ref": "#/definitions/io.k8s.api.resource.v1beta1.AllocatedDeviceStatus"
           },
           "type": "array",
-          "x-kubernetes-list-map-keys": ["driver", "device", "pool"],
+          "x-kubernetes-list-map-keys": ["driver", "device", "pool", "shareID"],
           "x-kubernetes-list-type": "map"
         },
         "reservedFor": {
@@ -15929,7 +17481,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "driver": {
-          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
           "type": "string"
         },
         "nodeName": {
@@ -15962,7 +17514,7 @@
       "additionalProperties": false
     },
     "io.k8s.api.resource.v1beta2.AllocatedDeviceStatus": {
-      "description": "AllocatedDeviceStatus contains the status of an allocated device, if the driver chooses to report it. This may include driver-specific information.",
+      "description": "AllocatedDeviceStatus contains the status of an allocated device, if the driver chooses to report it. This may include driver-specific information.\n\nThe combination of Driver, Pool, Device, and ShareID must match the corresponding key in Status.Allocation.Devices.",
       "properties": {
         "conditions": {
           "description": "Conditions contains the latest observation of the device's state. If the device has been configured according to the class and claim config references, the `Ready` condition should be True.\n\nMust not contain more than 8 entries.",
@@ -15982,7 +17534,7 @@
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "networkData": {
@@ -15991,6 +17543,10 @@
         },
         "pool": {
           "description": "This name together with the driver name and the device name field identify which device was allocated (`<driver name>/<pool name>/<device name>`).\n\nMust not be longer than 253 characters and may contain one or more DNS sub-domains separated by slashes.",
+          "type": "string"
+        },
+        "shareID": {
+          "description": "ShareID uniquely identifies an individual allocation share of the device.",
           "type": "string"
         }
       },
@@ -16001,6 +17557,10 @@
     "io.k8s.api.resource.v1beta2.AllocationResult": {
       "description": "AllocationResult contains attributes of an allocated resource.",
       "properties": {
+        "allocationTimestamp": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+          "description": "AllocationTimestamp stores the time when the resources were allocated. This field is not guaranteed to be set, in which case that time is unknown.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gate."
+        },
         "devices": {
           "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceAllocationResult",
           "description": "Devices is the result of allocating devices."
@@ -16017,11 +17577,68 @@
       "description": "CELDeviceSelector contains a CEL expression for selecting a device.",
       "properties": {
         "expression": {
-          "description": "Expression is a CEL expression which evaluates a single device. It must evaluate to true when the device under consideration satisfies the desired criteria, and false when it does not. Any other result is an error and causes allocation of devices to abort.\n\nThe expression's input is an object named \"device\", which carries the following properties:\n - driver (string): the name of the driver which defines this device.\n - attributes (map[string]object): the device's attributes, grouped by prefix\n   (e.g. device.attributes[\"dra.example.com\"] evaluates to an object with all\n   of the attributes which were prefixed by \"dra.example.com\".\n - capacity (map[string]object): the device's capacities, grouped by prefix.\n\nExample: Consider a device with driver=\"dra.example.com\", which exposes two attributes named \"model\" and \"ext.example.com/family\" and which exposes one capacity named \"modules\". This input to this expression would have the following fields:\n\n    device.driver\n    device.attributes[\"dra.example.com\"].model\n    device.attributes[\"ext.example.com\"].family\n    device.capacity[\"dra.example.com\"].modules\n\nThe device.driver field can be used to check for a specific driver, either as a high-level precondition (i.e. you only want to consider devices from this driver) or as part of a multi-clause expression that is meant to consider devices from different drivers.\n\nThe value type of each attribute is defined by the device definition, and users who write these expressions must consult the documentation for their specific drivers. The value type of each capacity is Quantity.\n\nIf an unknown prefix is used as a lookup in either device.attributes or device.capacity, an empty map will be returned. Any reference to an unknown field will cause an evaluation error and allocation to abort.\n\nA robust expression should check for the existence of attributes before referencing them.\n\nFor ease of use, the cel.bind() function is enabled, and can be used to simplify expressions that access multiple attributes with the same domain. For example:\n\n    cel.bind(dra, device.attributes[\"dra.example.com\"], dra.someBool && dra.anotherBool)\n\nThe length of the expression must be smaller or equal to 10 Ki. The cost of evaluating it is also limited based on the estimated number of logical steps.",
+          "description": "Expression is a CEL expression which evaluates a single device. It must evaluate to true when the device under consideration satisfies the desired criteria, and false when it does not. Any other result is an error and causes allocation of devices to abort.\n\nThe expression's input is an object named \"device\", which carries the following properties:\n - driver (string): the name of the driver which defines this device.\n - attributes (map[string]object): the device's attributes, grouped by prefix\n   (e.g. device.attributes[\"dra.example.com\"] evaluates to an object with all\n   of the attributes which were prefixed by \"dra.example.com\".\n - capacity (map[string]object): the device's capacities, grouped by prefix.\n - allowMultipleAllocations (bool): the allowMultipleAllocations property of the device\n   (v1.34+ with the DRAConsumableCapacity feature enabled).\n\nExample: Consider a device with driver=\"dra.example.com\", which exposes two attributes named \"model\" and \"ext.example.com/family\" and which exposes one capacity named \"modules\". This input to this expression would have the following fields:\n\n    device.driver\n    device.attributes[\"dra.example.com\"].model\n    device.attributes[\"ext.example.com\"].family\n    device.capacity[\"dra.example.com\"].modules\n\nThe device.driver field can be used to check for a specific driver, either as a high-level precondition (i.e. you only want to consider devices from this driver) or as part of a multi-clause expression that is meant to consider devices from different drivers.\n\nThe value type of each attribute is defined by the device definition, and users who write these expressions must consult the documentation for their specific drivers. The value type of each capacity is Quantity.\n\nIf an unknown prefix is used as a lookup in either device.attributes or device.capacity, an empty map will be returned. Any reference to an unknown field will cause an evaluation error and allocation to abort.\n\nA robust expression should check for the existence of attributes before referencing them.\n\nFor ease of use, the cel.bind() function is enabled, and can be used to simplify expressions that access multiple attributes with the same domain. For example:\n\n    cel.bind(dra, device.attributes[\"dra.example.com\"], dra.someBool && dra.anotherBool)\n\nThe length of the expression must be smaller or equal to 10 Ki. The cost of evaluating it is also limited based on the estimated number of logical steps.",
           "type": "string"
         }
       },
       "required": ["expression"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1beta2.CapacityRequestPolicy": {
+      "description": "CapacityRequestPolicy defines how requests consume device capacity.\n\nMust not set more than one ValidRequestValues.",
+      "properties": {
+        "default": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Default specifies how much of this capacity is consumed by a request that does not contain an entry for it in DeviceRequest's Capacity."
+        },
+        "validRange": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.CapacityRequestPolicyRange",
+          "description": "ValidRange defines an acceptable quantity value range in consuming requests.\n\nIf this field is set, Default must be defined and it must fall within the defined ValidRange.\n\nIf the requested amount does not fall within the defined range, the request violates the policy, and this device cannot be allocated.\n\nIf the request doesn't contain this capacity entry, Default value is used."
+        },
+        "validValues": {
+          "description": "ValidValues defines a set of acceptable quantity values in consuming requests.\n\nMust not contain more than 10 entries. Must be sorted in ascending order.\n\nIf this field is set, Default must be defined and it must be included in ValidValues list.\n\nIf the requested amount does not match any valid value but smaller than some valid values, the scheduler calculates the smallest valid value that is greater than or equal to the request. That is: min(ceil(requestedValue) \u2208 validValues), where requestedValue \u2264 max(validValues).\n\nIf the requested amount exceeds all valid values, the request violates the policy, and this device cannot be allocated.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1beta2.CapacityRequestPolicyRange": {
+      "description": "CapacityRequestPolicyRange defines a valid range for consumable capacity values.\n\n  - If the requested amount is less than Min, it is rounded up to the Min value.\n  - If Step is set and the requested amount is between Min and Max but not aligned with Step,\n    it will be rounded up to the next value equal to Min + (n * Step).\n  - If Step is not set, the requested amount is used as-is if it falls within the range Min to Max (if set).\n  - If the requested or rounded amount exceeds Max (if set), the request does not satisfy the policy,\n    and the device cannot be allocated.",
+      "properties": {
+        "max": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Max defines the upper limit for capacity that can be requested.\n\nMax must be less than or equal to the capacity value. Min and requestPolicy.default must be less than or equal to the maximum."
+        },
+        "min": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Min specifies the minimum capacity allowed for a consumption request.\n\nMin must be greater than or equal to zero, and less than or equal to the capacity value. requestPolicy.default must be more than or equal to the minimum."
+        },
+        "step": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+          "description": "Step defines the step size between valid capacity amounts within the range.\n\nMax (if set) and requestPolicy.default must be a multiple of Step. Min + Step must be less than or equal to the capacity value."
+        }
+      },
+      "required": ["min"],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "io.k8s.api.resource.v1beta2.CapacityRequirements": {
+      "description": "CapacityRequirements defines the capacity requirements for a specific device request.",
+      "properties": {
+        "requests": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "Requests represent individual device resource requests for distinct resources, all of which must be provided by the device.\n\nThis value is used as an additional filtering condition against the available capacity on the device. This is semantically equivalent to a CEL selector with `device.capacity[<domain>].<name>.compareTo(quantity(<request quantity>)) >= 0`. For example, device.capacity['test-driver.cdi.k8s.io'].counters.compareTo(quantity('2')) >= 0.\n\nWhen a requestPolicy is defined, the requested amount is adjusted upward to the nearest valid value based on the policy. If the requested amount cannot be adjusted to a valid value\u2014because it exceeds what the requestPolicy allows\u2014 the device is considered ineligible for allocation.\n\nFor any capacity that is not explicitly requested: - If no requestPolicy is set, the default consumed capacity is equal to the full device capacity\n  (i.e., the whole device is claimed).\n- If a requestPolicy is set, the default consumed capacity is determined according to that policy.\n\nIf the device allows multiple allocation, the aggregated amount across all requests must not exceed the capacity value. The consumed capacity, which may be adjusted based on the requestPolicy if defined, is recorded in the resource claim\u2019s status.devices[*].consumedCapacity field.",
+          "type": "object"
+        }
+      },
       "type": "object",
       "additionalProperties": false
     },
@@ -16063,12 +17680,36 @@
           "description": "AllNodes indicates that all nodes have access to the device.\n\nMust only be set if Spec.PerDeviceNodeSelection is set to true. At most one of NodeName, NodeSelector and AllNodes can be set.",
           "type": "boolean"
         },
+        "allowMultipleAllocations": {
+          "description": "AllowMultipleAllocations marks whether the device is allowed to be allocated to multiple DeviceRequests.\n\nIf AllowMultipleAllocations is set to true, the device can be allocated more than once, and all of its capacity is consumable, regardless of whether the requestPolicy is defined or not.",
+          "type": "boolean"
+        },
         "attributes": {
           "additionalProperties": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceAttribute"
           },
           "description": "Attributes defines the set of attributes for this device. The name of each attribute must be unique in that set.\n\nThe maximum number of attributes and capacities combined is 32.",
           "type": "object"
+        },
+        "bindingConditions": {
+          "description": "BindingConditions defines the conditions for proceeding with binding. All of these conditions must be set in the per-device status conditions with a value of True to proceed with binding the pod to the node while scheduling the pod.\n\nThe maximum number of binding conditions is 4.\n\nThe conditions must be a valid condition type string.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bindingFailureConditions": {
+          "description": "BindingFailureConditions defines the conditions for binding failure. They may be set in the per-device status conditions. If any is set to \"True\", a binding failure occurred.\n\nThe maximum number of binding failure conditions is 4.\n\nThe conditions must be a valid condition type string.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bindsToNode": {
+          "description": "BindsToNode indicates if the usage of an allocation involving this device has to be limited to exactly the node that was chosen when allocating the claim. If set to true, the scheduler will set the ResourceClaim.Status.Allocation.NodeSelector to match the node where the allocation was made.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "type": "boolean"
         },
         "capacity": {
           "additionalProperties": {
@@ -16184,9 +17825,13 @@
     "io.k8s.api.resource.v1beta2.DeviceCapacity": {
       "description": "DeviceCapacity describes a quantity associated with a device.",
       "properties": {
+        "requestPolicy": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.CapacityRequestPolicy",
+          "description": "RequestPolicy defines how this DeviceCapacity must be consumed when the device is allowed to be shared by multiple allocations.\n\nThe Device must have allowMultipleAllocations set to true in order to set a requestPolicy.\n\nIf unset, capacity requests are unconstrained: requests can consume any amount of capacity, as long as the total consumed across all allocations does not exceed the device's defined capacity. If request is also unset, default is the full capacity value."
+        },
         "value": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
-          "description": "Value defines how much of a certain device capacity is available."
+          "description": "Value defines how much of a certain capacity that device has.\n\nThis field reflects the fixed total capacity and does not change. The consumed amount is tracked separately by scheduler and does not affect this value."
         }
       },
       "required": ["value"],
@@ -16332,6 +17977,10 @@
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
+        "extendedResourceName": {
+          "description": "ExtendedResourceName is the extended resource name for the devices of this class. The devices of this class can be used to satisfy a pod's extended resource requests. It has the same format as the name of a pod's extended resource. It should be unique among all the device classes in a cluster. If two device classes have the same name, then the class created later is picked to satisfy a pod's extended resource requests. If two classes are created at the same time, then the name of the class lexicographically sorted first is picked.\n\nThis is an alpha field.",
+          "type": "string"
+        },
         "selectors": {
           "description": "Each selector must be satisfied by a device which is claimed via this class.",
           "items": {
@@ -16347,6 +17996,10 @@
     "io.k8s.api.resource.v1beta2.DeviceConstraint": {
       "description": "DeviceConstraint must have exactly one field set besides Requests.",
       "properties": {
+        "distinctAttribute": {
+          "description": "DistinctAttribute requires that all devices in question have this attribute and that its type and value are unique across those devices.\n\nThis acts as the inverse of MatchAttribute.\n\nThis constraint is used to avoid allocating multiple requests to the same device by ensuring attribute-level differentiation.\n\nThis is useful for scenarios where resource requests must be fulfilled by separate physical devices. For example, a container requests two network interfaces that must be allocated from two different physical NICs.",
+          "type": "string"
+        },
         "matchAttribute": {
           "description": "MatchAttribute requires that all devices in question have this attribute and that its type and value are the same across those devices.\n\nFor example, if you specified \"dra.example.com/numa\" (a hypothetical example!), then only devices in the same NUMA node will be chosen. A device which does not have that attribute will not be chosen. All devices should use a value of the same type for this attribute because that is part of its specification, but if one device doesn't, then it also will not be chosen.\n\nMust include the domain qualifier.",
           "type": "string"
@@ -16413,12 +18066,35 @@
           "description": "AdminAccess indicates that this device was allocated for administrative access. See the corresponding request field for a definition of mode.\n\nThis is an alpha field and requires enabling the DRAAdminAccess feature gate. Admin access is disabled if this field is unset or set to false, otherwise it is enabled.",
           "type": "boolean"
         },
+        "bindingConditions": {
+          "description": "BindingConditions contains a copy of the BindingConditions from the corresponding ResourceSlice at the time of allocation.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "bindingFailureConditions": {
+          "description": "BindingFailureConditions contains a copy of the BindingFailureConditions from the corresponding ResourceSlice at the time of allocation.\n\nThis is an alpha field and requires enabling the DRADeviceBindingConditions and DRAResourceClaimDeviceStatus feature gates.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "consumedCapacity": {
+          "additionalProperties": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "description": "ConsumedCapacity tracks the amount of capacity consumed per device as part of the claim request. The consumed amount may differ from the requested amount: it is rounded up to the nearest valid value based on the device\u2019s requestPolicy if applicable (i.e., may not be less than the requested amount).\n\nThe total consumed capacity for each device must not exceed the DeviceCapacity's Value.\n\nThis field is populated only for devices that allow multiple allocations. All capacity entries are included, even if the consumed amount is zero.",
+          "type": "object"
+        },
         "device": {
           "description": "Device references one device instance via its name in the driver's resource pool. It must be a DNS label.",
           "type": "string"
         },
         "driver": {
-          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver specifies the name of the DRA driver whose kubelet plugin should be invoked to process the allocation once the claim is needed on a node.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "pool": {
@@ -16427,6 +18103,10 @@
         },
         "request": {
           "description": "Request is the name of the request in the claim which caused this device to be allocated. If it references a subrequest in the firstAvailable list on a DeviceRequest, this field must include both the name of the main request and the subrequest using the format <main request>/<subrequest>.\n\nMultiple devices may have been allocated per request.",
+          "type": "string"
+        },
+        "shareID": {
+          "description": "ShareID uniquely identifies an individual allocation share of the device, used when the device supports multiple simultaneous allocations. It serves as an additional map key to differentiate concurrent shares of the same device.",
           "type": "string"
         },
         "tolerations": {
@@ -16459,6 +18139,10 @@
         "allocationMode": {
           "description": "AllocationMode and its related fields define how devices are allocated to satisfy this subrequest. Supported values are:\n\n- ExactCount: This request is for a specific number of devices.\n  This is the default. The exact number is provided in the\n  count field.\n\n- All: This subrequest is for all of the matching devices in a pool.\n  Allocation will fail if some devices are already allocated,\n  unless adminAccess is requested.\n\nIf AllocationMode is not specified, the default mode is ExactCount. If the mode is ExactCount and count is not specified, the default count is one. Any other subrequests must specify this field.\n\nMore modes may get added in the future. Clients must refuse to handle requests with unknown modes.",
           "type": "string"
+        },
+        "capacity": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.CapacityRequirements",
+          "description": "Capacity define resource requirements against each capacity.\n\nIf this field is unset and the device supports multiple allocations, the default value will be applied to each capacity according to requestPolicy. For the capacity that has no requestPolicy, default is the full capacity value.\n\nApplies to each device allocation. If Count > 1, the request fails if there aren't enough devices that meet the requirements. If AllocationMode is set to All, the request fails if there are devices that otherwise match the request, and have this capacity, with a value >= the requested amount, but which cannot be allocated to this request."
         },
         "count": {
           "description": "Count is used only when the count mode is \"ExactCount\". Must be greater than zero. If AllocationMode is ExactCount and this field is not specified, the default is one.",
@@ -16557,6 +18241,10 @@
           "description": "AllocationMode and its related fields define how devices are allocated to satisfy this request. Supported values are:\n\n- ExactCount: This request is for a specific number of devices.\n  This is the default. The exact number is provided in the\n  count field.\n\n- All: This request is for all of the matching devices in a pool.\n  At least one device must exist on the node for the allocation to succeed.\n  Allocation will fail if some devices are already allocated,\n  unless adminAccess is requested.\n\nIf AllocationMode is not specified, the default mode is ExactCount. If the mode is ExactCount and count is not specified, the default count is one. Any other requests must specify this field.\n\nMore modes may get added in the future. Clients must refuse to handle requests with unknown modes.",
           "type": "string"
         },
+        "capacity": {
+          "$ref": "#/definitions/io.k8s.api.resource.v1beta2.CapacityRequirements",
+          "description": "Capacity define resource requirements against each capacity.\n\nIf this field is unset and the device supports multiple allocations, the default value will be applied to each capacity according to requestPolicy. For the capacity that has no requestPolicy, default is the full capacity value.\n\nApplies to each device allocation. If Count > 1, the request fails if there aren't enough devices that meet the requirements. If AllocationMode is set to All, the request fails if there are devices that otherwise match the request, and have this capacity, with a value >= the requested amount, but which cannot be allocated to this request."
+        },
         "count": {
           "description": "Count is used only when the count mode is \"ExactCount\". Must be greater than zero. If AllocationMode is ExactCount and this field is not specified, the default is one.",
           "format": "int64",
@@ -16614,7 +18302,7 @@
       "description": "OpaqueDeviceConfiguration contains configuration parameters for a driver in a format defined by the driver vendor.",
       "properties": {
         "driver": {
-          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver.",
+          "description": "Driver is used to determine which kubelet plugin needs to be passed these configuration parameters.\n\nAn admission policy provided by the driver developer could use this to decide whether it needs to validate them.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters.",
           "type": "string"
         },
         "parameters": {
@@ -16745,7 +18433,7 @@
             "$ref": "#/definitions/io.k8s.api.resource.v1beta2.AllocatedDeviceStatus"
           },
           "type": "array",
-          "x-kubernetes-list-map-keys": ["driver", "device", "pool"],
+          "x-kubernetes-list-map-keys": ["driver", "device", "pool", "shareID"],
           "x-kubernetes-list-type": "map"
         },
         "reservedFor": {
@@ -16951,7 +18639,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "driver": {
-          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. This field is immutable.",
+          "description": "Driver identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.\n\nMust be a DNS subdomain and should end with a DNS domain owned by the vendor of the driver. It should use only lower case characters. This field is immutable.",
           "type": "string"
         },
         "nodeName": {
@@ -17142,7 +18830,7 @@
           "type": "string"
         },
         "nodeAllocatableUpdatePeriodSeconds": {
-          "description": "nodeAllocatableUpdatePeriodSeconds specifies the interval between periodic updates of the CSINode allocatable capacity for this driver. When set, both periodic updates and updates triggered by capacity-related failures are enabled. If not set, no updates occur (neither periodic nor upon detecting capacity-related failures), and the allocatable.count remains static. The minimum allowed value for this field is 10 seconds.\n\nThis is an alpha feature and requires the MutableCSINodeAllocatableCount feature gate to be enabled.\n\nThis field is mutable.",
+          "description": "nodeAllocatableUpdatePeriodSeconds specifies the interval between periodic updates of the CSINode allocatable capacity for this driver. When set, both periodic updates and updates triggered by capacity-related failures are enabled. If not set, no updates occur (neither periodic nor upon detecting capacity-related failures), and the allocatable.count remains static. The minimum allowed value for this field is 10 seconds.\n\nThis is a beta feature and requires the MutableCSINodeAllocatableCount feature gate to be enabled.\n\nThis field is mutable.",
           "format": "int64",
           "type": "integer"
         },
@@ -17627,11 +19315,85 @@
       "type": "object",
       "additionalProperties": false
     },
+    "io.k8s.api.storage.v1.VolumeAttributesClass": {
+      "description": "VolumeAttributesClass represents a specification of mutable volume attributes defined by the CSI driver. The class can be specified during dynamic provisioning of PersistentVolumeClaims, and changed in the PersistentVolumeClaim spec after provisioning.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "driverName": {
+          "description": "Name of the CSI driver This field is immutable.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["VolumeAttributesClass"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        },
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "parameters hold volume attributes defined by the CSI driver. These values are opaque to the Kubernetes and are passed directly to the CSI driver. The underlying storage provider supports changing these attributes on an existing volume, however the parameters field itself is immutable. To invoke a volume update, a new VolumeAttributesClass should be created with new parameters, and the PersistentVolumeClaim should be updated to reference the new VolumeAttributesClass.\n\nThis field is required and must contain at least one key/value pair. The keys cannot be empty, and the maximum number of parameters is 512, with a cumulative max size of 256K. If the CSI driver rejects invalid parameters, the target PersistentVolumeClaim will be set to an \"Infeasible\" state in the modifyVolumeStatus field.",
+          "type": "object"
+        }
+      },
+      "required": ["driverName"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "VolumeAttributesClass",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "io.k8s.api.storage.v1.VolumeAttributesClassList": {
+      "description": "VolumeAttributesClassList is a collection of VolumeAttributesClass objects.",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+        },
+        "items": {
+          "description": "items is the list of VolumeAttributesClass objects.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.storage.v1.VolumeAttributesClass"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string",
+          "enum": ["VolumeAttributesClassList"]
+        },
+        "metadata": {
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+          "description": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+        }
+      },
+      "required": ["items"],
+      "type": "object",
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "storage.k8s.io",
+          "kind": "VolumeAttributesClassList",
+          "version": "v1"
+        }
+      ],
+      "additionalProperties": false
+    },
     "io.k8s.api.storage.v1.VolumeError": {
       "description": "VolumeError captures an error encountered during a volume operation.",
       "properties": {
         "errorCode": {
-          "description": "errorCode is a numeric gRPC code representing the error encountered during Attach or Detach operations.\n\nThis is an optional, alpha field that requires the MutableCSINodeAllocatableCount feature gate being enabled to be set.",
+          "description": "errorCode is a numeric gRPC code representing the error encountered during Attach or Detach operations.\n\nThis is an optional, beta field that requires the MutableCSINodeAllocatableCount feature gate being enabled to be set.",
           "format": "int32",
           "type": "integer"
         },
@@ -19214,6 +20976,11 @@
         {
           "group": "resource.k8s.io",
           "kind": "DeleteOptions",
+          "version": "v1"
+        },
+        {
+          "group": "resource.k8s.io",
+          "kind": "DeleteOptions",
           "version": "v1alpha3"
         },
         {
@@ -19592,8 +21359,7 @@
         },
         "details": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails",
-          "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
-          "x-kubernetes-list-type": "atomic"
+          "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
         },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
@@ -19955,6 +21721,11 @@
           "group": "rbac.authorization.k8s.io",
           "kind": "WatchEvent",
           "version": "v1beta1"
+        },
+        {
+          "group": "resource.k8s.io",
+          "kind": "WatchEvent",
+          "version": "v1"
         },
         {
           "group": "resource.k8s.io",

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -296,6 +296,25 @@
       "required": ["schedule", "jobTemplate"],
       "type": "object"
     },
+    "io.k8s.api.batch.v1.CronJobStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "active": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "lastScheduleTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "lastSuccessfulTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        }
+      },
+      "type": "object"
+    },
     "io.k8s.api.batch.v1.Job": {
       "additionalProperties": false,
       "properties": {
@@ -324,6 +343,31 @@
           "version": "v1"
         }
       ]
+    },
+    "io.k8s.api.batch.v1.JobCondition": {
+      "additionalProperties": false,
+      "properties": {
+        "lastProbeTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "lastTransitionTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "message": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "status"],
+      "type": "object"
     },
     "io.k8s.api.batch.v1.JobSpec": {
       "additionalProperties": false,
@@ -387,6 +431,56 @@
       "required": ["template"],
       "type": "object"
     },
+    "io.k8s.api.batch.v1.JobStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "active": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "completedIndexes": {
+          "type": "string"
+        },
+        "completionTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "conditions": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.batch.v1.JobCondition"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "failed": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "failedIndexes": {
+          "type": "string"
+        },
+        "ready": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "startTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "succeeded": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "terminating": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "uncountedTerminatedPods": {
+          "$ref": "#/$defs/io.k8s.api.batch.v1.UncountedTerminatedPods"
+        }
+      },
+      "type": "object"
+    },
     "io.k8s.api.batch.v1.JobTemplateSpec": {
       "additionalProperties": false,
       "properties": {
@@ -444,7 +538,7 @@
           "type": "string"
         }
       },
-      "required": ["type", "status"],
+      "required": ["type"],
       "type": "object"
     },
     "io.k8s.api.batch.v1.PodFailurePolicyRule": {
@@ -490,6 +584,26 @@
         },
         "succeededIndexes": {
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.batch.v1.UncountedTerminatedPods": {
+      "additionalProperties": false,
+      "properties": {
+        "failed": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        },
+        "succeeded": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
         }
       },
       "type": "object"
@@ -550,6 +664,19 @@
         }
       ]
     },
+    "io.k8s.api.core.v1.AttachedVolume": {
+      "additionalProperties": false,
+      "properties": {
+        "devicePath": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "devicePath"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.AzureDiskVolumeSource": {
       "additionalProperties": false,
       "properties": {
@@ -575,6 +702,25 @@
       "required": ["diskName", "diskURI"],
       "type": "object"
     },
+    "io.k8s.api.core.v1.AzureFilePersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "readOnly": {
+          "type": "boolean"
+        },
+        "secretName": {
+          "type": "string"
+        },
+        "secretNamespace": {
+          "type": "string"
+        },
+        "shareName": {
+          "type": "string"
+        }
+      },
+      "required": ["secretName", "shareName"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.AzureFileVolumeSource": {
       "additionalProperties": false,
       "properties": {
@@ -589,6 +735,46 @@
         }
       },
       "required": ["secretName", "shareName"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.CSIPersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "controllerExpandSecretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "controllerPublishSecretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "driver": {
+          "type": "string"
+        },
+        "fsType": {
+          "type": "string"
+        },
+        "nodeExpandSecretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "nodePublishSecretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "nodeStageSecretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "volumeAttributes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "volumeHandle": {
+          "type": "string"
+        }
+      },
+      "required": ["driver", "volumeHandle"],
       "type": "object"
     },
     "io.k8s.api.core.v1.CSIVolumeSource": {
@@ -636,6 +822,35 @@
       },
       "type": "object"
     },
+    "io.k8s.api.core.v1.CephFSPersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "monitors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "path": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "secretFile": {
+          "type": "string"
+        },
+        "secretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "user": {
+          "type": "string"
+        }
+      },
+      "required": ["monitors"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.CephFSVolumeSource": {
       "additionalProperties": false,
       "properties": {
@@ -665,6 +880,25 @@
       "required": ["monitors"],
       "type": "object"
     },
+    "io.k8s.api.core.v1.CinderPersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "fsType": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "volumeID": {
+          "type": "string"
+        }
+      },
+      "required": ["volumeID"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.CinderVolumeSource": {
       "additionalProperties": false,
       "properties": {
@@ -682,6 +916,16 @@
         }
       },
       "required": ["volumeID"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ClientIPConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "timeoutSeconds": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
       "type": "object"
     },
     "io.k8s.api.core.v1.ClusterTrustBundleProjection": {
@@ -773,6 +1017,28 @@
       "required": ["key"],
       "type": "object",
       "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.ConfigMapNodeConfigSource": {
+      "additionalProperties": false,
+      "properties": {
+        "kubeletConfigKey": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "resourceVersion": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        }
+      },
+      "required": ["namespace", "name", "kubeletConfigKey"],
+      "type": "object"
     },
     "io.k8s.api.core.v1.ConfigMapProjection": {
       "additionalProperties": false,
@@ -891,6 +1157,13 @@
         "restartPolicy": {
           "type": "string"
         },
+        "restartPolicyRules": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerRestartRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
         "securityContext": {
           "$ref": "#/$defs/io.k8s.api.core.v1.SecurityContext"
         },
@@ -939,6 +1212,39 @@
       "required": ["name"],
       "type": "object"
     },
+    "io.k8s.api.core.v1.ContainerExtendedResourceRequest": {
+      "additionalProperties": false,
+      "properties": {
+        "containerName": {
+          "type": "string"
+        },
+        "requestName": {
+          "type": "string"
+        },
+        "resourceName": {
+          "type": "string"
+        }
+      },
+      "required": ["containerName", "resourceName", "requestName"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerImage": {
+      "additionalProperties": false,
+      "properties": {
+        "names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "sizeBytes": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "io.k8s.api.core.v1.ContainerPort": {
       "additionalProperties": false,
       "properties": {
@@ -974,6 +1280,193 @@
         }
       },
       "required": ["resourceName", "restartPolicy"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerRestartRule": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "type": "string"
+        },
+        "exitCodes": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes"
+        }
+      },
+      "required": ["action"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerRestartRuleOnExitCodes": {
+      "additionalProperties": false,
+      "properties": {
+        "operator": {
+          "type": "string"
+        },
+        "values": {
+          "items": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set"
+        }
+      },
+      "required": ["operator"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerState": {
+      "additionalProperties": false,
+      "properties": {
+        "running": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStateRunning"
+        },
+        "terminated": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStateTerminated"
+        },
+        "waiting": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStateWaiting"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStateRunning": {
+      "additionalProperties": false,
+      "properties": {
+        "startedAt": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStateTerminated": {
+      "additionalProperties": false,
+      "properties": {
+        "containerID": {
+          "type": "string"
+        },
+        "exitCode": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "finishedAt": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "message": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "signal": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "startedAt": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        }
+      },
+      "required": ["exitCode"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStateWaiting": {
+      "additionalProperties": false,
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "allocatedResources": {
+          "additionalProperties": {
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "type": "object"
+        },
+        "allocatedResourcesStatus": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ResourceStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["name"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "containerID": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "imageID": {
+          "type": "string"
+        },
+        "lastState": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerState"
+        },
+        "name": {
+          "type": "string"
+        },
+        "ready": {
+          "type": "boolean"
+        },
+        "resources": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+        },
+        "restartCount": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "started": {
+          "type": "boolean"
+        },
+        "state": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerState"
+        },
+        "stopSignal": {
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ContainerUser"
+        },
+        "volumeMounts": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.VolumeMountStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["mountPath"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "mountPath",
+          "x-kubernetes-patch-strategy": "merge"
+        }
+      },
+      "required": ["name", "ready", "restartCount", "image", "imageID"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ContainerUser": {
+      "additionalProperties": false,
+      "properties": {
+        "linux": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.LinuxContainerUser"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.DaemonEndpoint": {
+      "additionalProperties": false,
+      "properties": {
+        "Port": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": ["Port"],
       "type": "object"
     },
     "io.k8s.api.core.v1.DownwardAPIProjection": {
@@ -1078,6 +1571,9 @@
         "fieldRef": {
           "$ref": "#/$defs/io.k8s.api.core.v1.ObjectFieldSelector"
         },
+        "fileKeyRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.FileKeySelector"
+        },
         "resourceFieldRef": {
           "$ref": "#/$defs/io.k8s.api.core.v1.ResourceFieldSelector"
         },
@@ -1161,6 +1657,13 @@
         },
         "restartPolicy": {
           "type": "string"
+        },
+        "restartPolicyRules": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerRestartRule"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
         },
         "securityContext": {
           "$ref": "#/$defs/io.k8s.api.core.v1.SecurityContext"
@@ -1265,6 +1768,51 @@
       },
       "type": "object"
     },
+    "io.k8s.api.core.v1.FileKeySelector": {
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "volumeName": {
+          "type": "string"
+        }
+      },
+      "required": ["volumeName", "path", "key"],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.FlexPersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "driver": {
+          "type": "string"
+        },
+        "fsType": {
+          "type": "string"
+        },
+        "options": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        }
+      },
+      "required": ["driver"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.FlexVolumeSource": {
       "additionalProperties": false,
       "properties": {
@@ -1352,6 +1900,25 @@
       "required": ["repository"],
       "type": "object"
     },
+    "io.k8s.api.core.v1.GlusterfsPersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "endpoints": {
+          "type": "string"
+        },
+        "endpointsNamespace": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        }
+      },
+      "required": ["endpoints", "path"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.GlusterfsVolumeSource": {
       "additionalProperties": false,
       "properties": {
@@ -1424,6 +1991,16 @@
       "required": ["ip"],
       "type": "object"
     },
+    "io.k8s.api.core.v1.HostIP": {
+      "additionalProperties": false,
+      "properties": {
+        "ip": {
+          "type": "string"
+        }
+      },
+      "required": ["ip"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.HostPathVolumeSource": {
       "additionalProperties": false,
       "properties": {
@@ -1435,6 +2012,51 @@
         }
       },
       "required": ["path"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ISCSIPersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "chapAuthDiscovery": {
+          "type": "boolean"
+        },
+        "chapAuthSession": {
+          "type": "boolean"
+        },
+        "fsType": {
+          "type": "string"
+        },
+        "initiatorName": {
+          "type": "string"
+        },
+        "iqn": {
+          "type": "string"
+        },
+        "iscsiInterface": {
+          "type": "string"
+        },
+        "lun": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "portals": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "targetPortal": {
+          "type": "string"
+        }
+      },
+      "required": ["targetPortal", "iqn", "lun"],
       "type": "object"
     },
     "io.k8s.api.core.v1.ISCSIVolumeSource": {
@@ -1544,6 +2166,64 @@
       },
       "type": "object"
     },
+    "io.k8s.api.core.v1.LinuxContainerUser": {
+      "additionalProperties": false,
+      "properties": {
+        "gid": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "supplementalGroups": {
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "uid": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": ["uid", "gid"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LoadBalancerIngress": {
+      "additionalProperties": false,
+      "properties": {
+        "hostname": {
+          "type": "string"
+        },
+        "ip": {
+          "type": "string"
+        },
+        "ipMode": {
+          "type": "string"
+        },
+        "ports": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.PortStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.LoadBalancerStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "ingress": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.LoadBalancerIngress"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
     "io.k8s.api.core.v1.LocalObjectReference": {
       "additionalProperties": false,
       "properties": {
@@ -1553,6 +2233,32 @@
       },
       "type": "object",
       "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.LocalVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "fsType": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": ["path"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ModifyVolumeStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string"
+        },
+        "targetVolumeAttributesClassName": {
+          "type": "string"
+        }
+      },
+      "required": ["status"],
+      "type": "object"
     },
     "io.k8s.api.core.v1.NFSVolumeSource": {
       "additionalProperties": false,
@@ -1599,6 +2305,19 @@
         }
       ]
     },
+    "io.k8s.api.core.v1.NodeAddress": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "address"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.NodeAffinity": {
       "additionalProperties": false,
       "properties": {
@@ -1611,6 +2330,100 @@
         },
         "requiredDuringSchedulingIgnoredDuringExecution": {
           "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeCondition": {
+      "additionalProperties": false,
+      "properties": {
+        "lastHeartbeatTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "lastTransitionTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "message": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "status"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeConfigSource": {
+      "additionalProperties": false,
+      "properties": {
+        "configMap": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ConfigMapNodeConfigSource"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeConfigStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "active": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigSource"
+        },
+        "assigned": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigSource"
+        },
+        "error": {
+          "type": "string"
+        },
+        "lastKnownGood": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigSource"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeDaemonEndpoints": {
+      "additionalProperties": false,
+      "properties": {
+        "kubeletEndpoint": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.DaemonEndpoint"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeFeatures": {
+      "additionalProperties": false,
+      "properties": {
+        "supplementalGroupsPolicy": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeRuntimeHandler": {
+      "additionalProperties": false,
+      "properties": {
+        "features": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeRuntimeHandlerFeatures"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeRuntimeHandlerFeatures": {
+      "additionalProperties": false,
+      "properties": {
+        "recursiveReadOnlyMounts": {
+          "type": "boolean"
+        },
+        "userNamespaces": {
+          "type": "boolean"
         }
       },
       "type": "object"
@@ -1671,6 +2484,184 @@
       "type": "object",
       "x-kubernetes-map-type": "atomic"
     },
+    "io.k8s.api.core.v1.NodeSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "configSource": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigSource"
+        },
+        "externalID": {
+          "type": "string"
+        },
+        "podCIDR": {
+          "type": "string"
+        },
+        "podCIDRs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "set",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "providerID": {
+          "type": "string"
+        },
+        "taints": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.Taint"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "unschedulable": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "addresses": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.NodeAddress"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["type"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "allocatable": {
+          "additionalProperties": {
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "type": "object"
+        },
+        "capacity": {
+          "additionalProperties": {
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "type": "object"
+        },
+        "conditions": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.NodeCondition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["type"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "config": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeConfigStatus"
+        },
+        "daemonEndpoints": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeDaemonEndpoints"
+        },
+        "features": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeFeatures"
+        },
+        "images": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerImage"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "nodeInfo": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSystemInfo"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "runtimeHandlers": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.NodeRuntimeHandler"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "volumesAttached": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.AttachedVolume"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "volumesInUse": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeSwapStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "capacity": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.NodeSystemInfo": {
+      "additionalProperties": false,
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "bootID": {
+          "type": "string"
+        },
+        "containerRuntimeVersion": {
+          "type": "string"
+        },
+        "kernelVersion": {
+          "type": "string"
+        },
+        "kubeProxyVersion": {
+          "type": "string"
+        },
+        "kubeletVersion": {
+          "type": "string"
+        },
+        "machineID": {
+          "type": "string"
+        },
+        "operatingSystem": {
+          "type": "string"
+        },
+        "osImage": {
+          "type": "string"
+        },
+        "swap": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSwapStatus"
+        },
+        "systemUUID": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "machineID",
+        "systemUUID",
+        "bootID",
+        "kernelVersion",
+        "osImage",
+        "containerRuntimeVersion",
+        "kubeletVersion",
+        "kubeProxyVersion",
+        "operatingSystem",
+        "architecture"
+      ],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.ObjectFieldSelector": {
       "additionalProperties": false,
       "properties": {
@@ -1682,6 +2673,34 @@
         }
       },
       "required": ["fieldPath"],
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.api.core.v1.ObjectReference": {
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "fieldPath": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "resourceVersion": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        }
+      },
       "type": "object",
       "x-kubernetes-map-type": "atomic"
     },
@@ -1743,6 +2762,31 @@
         }
       ]
     },
+    "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+      "additionalProperties": false,
+      "properties": {
+        "lastProbeTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "lastTransitionTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "message": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "status"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
       "additionalProperties": false,
       "properties": {
@@ -1780,6 +2824,57 @@
       },
       "type": "object"
     },
+    "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "accessModes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "allocatedResourceStatuses": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
+        },
+        "allocatedResources": {
+          "additionalProperties": {
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "type": "object"
+        },
+        "capacity": {
+          "additionalProperties": {
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "type": "object"
+        },
+        "conditions": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.PersistentVolumeClaimCondition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["type"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "currentVolumeAttributesClassName": {
+          "type": "string"
+        },
+        "modifyVolumeStatus": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ModifyVolumeStatus"
+        },
+        "phase": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
       "additionalProperties": false,
       "properties": {
@@ -1804,6 +2899,135 @@
         }
       },
       "required": ["claimName"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "accessModes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "awsElasticBlockStore": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource"
+        },
+        "azureDisk": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.AzureDiskVolumeSource"
+        },
+        "azureFile": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.AzureFilePersistentVolumeSource"
+        },
+        "capacity": {
+          "additionalProperties": {
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.api.resource.Quantity"
+          },
+          "type": "object"
+        },
+        "cephfs": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.CephFSPersistentVolumeSource"
+        },
+        "cinder": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.CinderPersistentVolumeSource"
+        },
+        "claimRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference",
+          "x-kubernetes-map-type": "granular"
+        },
+        "csi": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.CSIPersistentVolumeSource"
+        },
+        "fc": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.FCVolumeSource"
+        },
+        "flexVolume": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.FlexPersistentVolumeSource"
+        },
+        "flocker": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.FlockerVolumeSource"
+        },
+        "gcePersistentDisk": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource"
+        },
+        "glusterfs": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.GlusterfsPersistentVolumeSource"
+        },
+        "hostPath": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.HostPathVolumeSource"
+        },
+        "iscsi": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ISCSIPersistentVolumeSource"
+        },
+        "local": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.LocalVolumeSource"
+        },
+        "mountOptions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "nfs": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NFSVolumeSource"
+        },
+        "nodeAffinity": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.VolumeNodeAffinity"
+        },
+        "persistentVolumeReclaimPolicy": {
+          "type": "string"
+        },
+        "photonPersistentDisk": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource"
+        },
+        "portworxVolume": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.PortworxVolumeSource"
+        },
+        "quobyte": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.QuobyteVolumeSource"
+        },
+        "rbd": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.RBDPersistentVolumeSource"
+        },
+        "scaleIO": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ScaleIOPersistentVolumeSource"
+        },
+        "storageClassName": {
+          "type": "string"
+        },
+        "storageos": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.StorageOSPersistentVolumeSource"
+        },
+        "volumeAttributesClassName": {
+          "type": "string"
+        },
+        "volumeMode": {
+          "type": "string"
+        },
+        "vsphereVolume": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PersistentVolumeStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "lastPhaseTransitionTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "message": {
+          "type": "string"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource": {
@@ -1925,6 +3149,61 @@
       },
       "type": "object"
     },
+    "io.k8s.api.core.v1.PodCertificateProjection": {
+      "additionalProperties": false,
+      "properties": {
+        "certificateChainPath": {
+          "type": "string"
+        },
+        "credentialBundlePath": {
+          "type": "string"
+        },
+        "keyPath": {
+          "type": "string"
+        },
+        "keyType": {
+          "type": "string"
+        },
+        "maxExpirationSeconds": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "signerName": {
+          "type": "string"
+        }
+      },
+      "required": ["signerName", "keyType"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodCondition": {
+      "additionalProperties": false,
+      "properties": {
+        "lastProbeTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "lastTransitionTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "message": {
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "status"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.PodDNSConfig": {
       "additionalProperties": false,
       "properties": {
@@ -1964,6 +3243,33 @@
       },
       "type": "object"
     },
+    "io.k8s.api.core.v1.PodExtendedResourceClaimStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "requestMappings": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerExtendedResourceRequest"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "resourceClaimName": {
+          "type": "string"
+        }
+      },
+      "required": ["requestMappings", "resourceClaimName"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodIP": {
+      "additionalProperties": false,
+      "properties": {
+        "ip": {
+          "type": "string"
+        }
+      },
+      "required": ["ip"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.PodOS": {
       "additionalProperties": false,
       "properties": {
@@ -1994,6 +3300,19 @@
           "type": "string"
         },
         "resourceClaimTemplateName": {
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodResourceClaimStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "resourceClaimName": {
           "type": "string"
         }
       },
@@ -2132,6 +3451,9 @@
           "type": "boolean"
         },
         "hostname": {
+          "type": "string"
+        },
+        "hostnameOverride": {
           "type": "string"
         },
         "imagePullSecrets": {
@@ -2275,6 +3597,106 @@
       "required": ["containers"],
       "type": "object"
     },
+    "io.k8s.api.core.v1.PodStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "conditions": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.PodCondition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["type"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "containerStatuses": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "ephemeralContainerStatuses": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "extendedResourceClaimStatus": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.PodExtendedResourceClaimStatus"
+        },
+        "hostIP": {
+          "type": "string"
+        },
+        "hostIPs": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.HostIP"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic",
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "initContainerStatuses": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ContainerStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "message": {
+          "type": "string"
+        },
+        "nominatedNodeName": {
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "podIP": {
+          "type": "string"
+        },
+        "podIPs": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.PodIP"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["ip"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "ip",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "qosClass": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "resize": {
+          "type": "string"
+        },
+        "resourceClaimStatuses": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.PodResourceClaimStatus"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["name"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge,retainKeys"
+        },
+        "startTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        }
+      },
+      "type": "object"
+    },
     "io.k8s.api.core.v1.PodTemplate": {
       "additionalProperties": false,
       "properties": {
@@ -2311,6 +3733,23 @@
           "$ref": "#/$defs/io.k8s.api.core.v1.PodSpec"
         }
       },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PortStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "port": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "protocol": {
+          "type": "string"
+        }
+      },
+      "required": ["port", "protocol"],
       "type": "object"
     },
     "io.k8s.api.core.v1.PortworxVolumeSource": {
@@ -2427,6 +3866,41 @@
       "required": ["registry", "volume"],
       "type": "object"
     },
+    "io.k8s.api.core.v1.RBDPersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "fsType": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "keyring": {
+          "type": "string"
+        },
+        "monitors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "pool": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "user": {
+          "type": "string"
+        }
+      },
+      "required": ["monitors", "image"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.RBDVolumeSource": {
       "additionalProperties": false,
       "properties": {
@@ -2492,6 +3966,19 @@
       "type": "object",
       "x-kubernetes-map-type": "atomic"
     },
+    "io.k8s.api.core.v1.ResourceHealth": {
+      "additionalProperties": false,
+      "properties": {
+        "health": {
+          "type": "string"
+        },
+        "resourceID": {
+          "type": "string"
+        }
+      },
+      "required": ["resourceID"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.ResourceRequirements": {
       "additionalProperties": false,
       "properties": {
@@ -2518,6 +4005,24 @@
       },
       "type": "object"
     },
+    "io.k8s.api.core.v1.ResourceStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "resources": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ResourceHealth"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["resourceID"],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
     "io.k8s.api.core.v1.SELinuxOptions": {
       "additionalProperties": false,
       "properties": {
@@ -2534,6 +4039,43 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ScaleIOPersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "fsType": {
+          "type": "string"
+        },
+        "gateway": {
+          "type": "string"
+        },
+        "protectionDomain": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SecretReference"
+        },
+        "sslEnabled": {
+          "type": "boolean"
+        },
+        "storageMode": {
+          "type": "string"
+        },
+        "storagePool": {
+          "type": "string"
+        },
+        "system": {
+          "type": "string"
+        },
+        "volumeName": {
+          "type": "string"
+        }
+      },
+      "required": ["gateway", "system", "secretRef"],
       "type": "object"
     },
     "io.k8s.api.core.v1.ScaleIOVolumeSource": {
@@ -2683,6 +4225,19 @@
         }
       },
       "type": "object"
+    },
+    "io.k8s.api.core.v1.SecretReference": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.core.v1.SecretVolumeSource": {
       "additionalProperties": false,
@@ -2840,6 +4395,155 @@
       "required": ["path"],
       "type": "object"
     },
+    "io.k8s.api.core.v1.ServicePort": {
+      "additionalProperties": false,
+      "properties": {
+        "appProtocol": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "nodePort": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "port": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "protocol": {
+          "type": "string"
+        },
+        "targetPort": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.util.intstr.IntOrString"
+        }
+      },
+      "required": ["port"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ServiceSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "allocateLoadBalancerNodePorts": {
+          "type": "boolean"
+        },
+        "clusterIP": {
+          "type": "string"
+        },
+        "clusterIPs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "externalIPs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "externalName": {
+          "type": "string"
+        },
+        "externalTrafficPolicy": {
+          "type": "string"
+        },
+        "healthCheckNodePort": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "internalTrafficPolicy": {
+          "type": "string"
+        },
+        "ipFamilies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "ipFamilyPolicy": {
+          "type": "string"
+        },
+        "loadBalancerClass": {
+          "type": "string"
+        },
+        "loadBalancerIP": {
+          "type": "string"
+        },
+        "loadBalancerSourceRanges": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        },
+        "ports": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.api.core.v1.ServicePort"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["port", "protocol"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "port",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "publishNotReadyAddresses": {
+          "type": "boolean"
+        },
+        "selector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic"
+        },
+        "sessionAffinity": {
+          "type": "string"
+        },
+        "sessionAffinityConfig": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.SessionAffinityConfig"
+        },
+        "trafficDistribution": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.ServiceStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "conditions": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["type"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "loadBalancer": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.LoadBalancerStatus"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SessionAffinityConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "clientIP": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ClientIPConfig"
+        }
+      },
+      "type": "object"
+    },
     "io.k8s.api.core.v1.SleepAction": {
       "additionalProperties": false,
       "properties": {
@@ -2849,6 +4553,27 @@
         }
       },
       "required": ["seconds"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.StorageOSPersistentVolumeSource": {
+      "additionalProperties": false,
+      "properties": {
+        "fsType": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "secretRef": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.ObjectReference"
+        },
+        "volumeName": {
+          "type": "string"
+        },
+        "volumeNamespace": {
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "io.k8s.api.core.v1.StorageOSVolumeSource": {
@@ -2896,6 +4621,25 @@
         }
       },
       "required": ["port"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Taint": {
+      "additionalProperties": false,
+      "properties": {
+        "effect": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "timeAdded": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": ["key", "effect"],
       "type": "object"
     },
     "io.k8s.api.core.v1.Toleration": {
@@ -3134,6 +4878,34 @@
       "required": ["name", "mountPath"],
       "type": "object"
     },
+    "io.k8s.api.core.v1.VolumeMountStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "mountPath": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "recursiveReadOnly": {
+          "type": "string"
+        }
+      },
+      "required": ["name", "mountPath"],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.VolumeNodeAffinity": {
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.NodeSelector"
+        }
+      },
+      "type": "object"
+    },
     "io.k8s.api.core.v1.VolumeProjection": {
       "additionalProperties": false,
       "properties": {
@@ -3145,6 +4917,9 @@
         },
         "downwardAPI": {
           "$ref": "#/$defs/io.k8s.api.core.v1.DownwardAPIProjection"
+        },
+        "podCertificate": {
+          "$ref": "#/$defs/io.k8s.api.core.v1.PodCertificateProjection"
         },
         "secret": {
           "$ref": "#/$defs/io.k8s.api.core.v1.SecretProjection"
@@ -3272,6 +5047,54 @@
       },
       "type": "object"
     },
+    "io.k8s.api.policy.v1.PodDisruptionBudgetStatus": {
+      "additionalProperties": false,
+      "properties": {
+        "conditions": {
+          "items": {
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": ["type"],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "currentHealthy": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "desiredHealthy": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "disruptedPods": {
+          "additionalProperties": {
+            "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+          },
+          "type": "object"
+        },
+        "disruptionsAllowed": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "expectedPods": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "disruptionsAllowed",
+        "currentHealthy",
+        "desiredHealthy",
+        "expectedPods"
+      ],
+      "type": "object"
+    },
     "io.k8s.apimachinery.pkg.api.resource.Quantity": {
       "oneOf": [
         {
@@ -3281,6 +5104,32 @@
           "type": "number"
         }
       ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Condition": {
+      "additionalProperties": false,
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "message": {
+          "type": "string"
+        },
+        "observedGeneration": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "status", "lastTransitionTime", "reason", "message"],
+      "type": "object"
     },
     "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
       "type": "object"

--- a/scripts/merge-json-schema.jq
+++ b/scripts/merge-json-schema.jq
@@ -63,6 +63,13 @@ collect_dependencies($direct_refs; $k8s_defs) as $all_needed |
 # Merge only the needed definitions from k8s into the $defs section
 .["$defs"] = ($input["$defs"] + $needed_defs) |
 
+# Second pass: Check all definitions for missing references and add them
+# This handles cases where transitively included definitions reference other definitions
+((.["$defs"] | find_refs) - ($all_needed + ($input["$defs"] | keys))) as $missing_refs |
+(collect_dependencies($missing_refs; $k8s_defs)) as $additional_needed |
+($k8s_defs | with_entries(select(.key as $k | $additional_needed | contains([$k])))) as $additional_defs |
+.["$defs"] = (.["$defs"] + $additional_defs) |
+
 # Walk through the entire object and update any $ref paths
 #
 # The Kubernetes JSON Schema uses the obsolete `definitions` name, but we want


### PR DESCRIPTION
# Why?

While investigating automatic documentation generation from the JSON schema, discovered that the merge-json-schema.jq script had a bug where it failed to correctly handle transitive dependencies. When a K8s type (e.g., CronJob) was included as a transitive dependency, the script would add it but not its own dependencies (e.g., CronJobStatus), leaving broken `$ref` links. This blocked integration of documentation generation tools.

# What

- Fixed merge-json-schema.jq to include a second-pass dependency resolution that ensures all transitive dependencies are included
- Integrated json-schema-static-docs for automatic Helm schema documentation generation
- Added `make docs/schema` target to generate markdown documentation from values.schema.json
- Created wrapper script (scripts/generate-schema-docs.js) to configure tool for draft-2020-12 schemas with K8s extensions
- Integrated documentation generation into `make generate` workflow
- Updated helm/schema/k8s.json to latest upstream version

# How Tested

- Verified `make helm/values.schema.json` generates schema with all CronJob-related types (CronJob, CronJobSpec, CronJobStatus)
- Confirmed `make docs/schema` generates documentation successfully without errors
- Validated no broken `$ref` links in generated schema using json-schema-static-docs validation
- Tested `make generate` includes documentation generation
- Verified `make clean` removes generated docs/schema directory