### PR TITLE
CP-34358: Use cluster.local DNS suffix in cAdvisor Prometheus config

### DIFF
--- a/app/config/validator/testdata/prometheus.yml
+++ b/app/config/validator/testdata/prometheus.yml
@@ -108,7 +108,7 @@ scrape_configs:
       - separator: ;
         regex: (.*)
         target_label: __address__
-        replacement: kubernetes.default.svc:443
+        replacement: kubernetes.default.svc.cluster.local:443
         action: replace
       - source_labels: [__meta_kubernetes_node_name]
         separator: ;

--- a/app/functions/agent-validator/config/internal/scrape_config.tmpl
+++ b/app/functions/agent-validator/config/internal/scrape_config.tmpl
@@ -35,7 +35,7 @@ scrape_configs:
   - separator: ;
     regex: (.*)
     target_label: __address__
-    replacement: kubernetes.default.svc:443
+    replacement: kubernetes.default.svc.cluster.local:443
     action: replace
   - source_labels: [__meta_kubernetes_node_name]
     separator: ;

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -557,9 +557,9 @@ and optimization recommendations across Kubernetes workloads.
   # Scrape metrics from cAdvisor.
   relabel_configs:
 
-    # Replace the value of __address__ labels with "kubernetes.default.svc:443"
+    # Replace the value of __address__ labels with "kubernetes.default.svc.cluster.local:443"
     - target_label: __address__
-      replacement: kubernetes.default.svc:443
+      replacement: kubernetes.default.svc.cluster.local:443
 
     # Replace the value of __metrics_path__ in __meta_kubernetes_node_name with
     # "/api/v1/nodes/$1/proxy/metrics/cadvisor"

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -265,9 +265,9 @@ data:
         # Scrape metrics from cAdvisor.
         relabel_configs:
       
-          # Replace the value of __address__ labels with "kubernetes.default.svc:443"
+          # Replace the value of __address__ labels with "kubernetes.default.svc.cluster.local:443"
           - target_label: __address__
-            replacement: kubernetes.default.svc:443
+            replacement: kubernetes.default.svc.cluster.local:443
       
           # Replace the value of __metrics_path__ in __meta_kubernetes_node_name with
           # "/api/v1/nodes/$1/proxy/metrics/cadvisor"

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -281,9 +281,9 @@ data:
         # Scrape metrics from cAdvisor.
         relabel_configs:
       
-          # Replace the value of __address__ labels with "kubernetes.default.svc:443"
+          # Replace the value of __address__ labels with "kubernetes.default.svc.cluster.local:443"
           - target_label: __address__
-            replacement: kubernetes.default.svc:443
+            replacement: kubernetes.default.svc.cluster.local:443
       
           # Replace the value of __metrics_path__ in __meta_kubernetes_node_name with
           # "/api/v1/nodes/$1/proxy/metrics/cadvisor"


### PR DESCRIPTION
Update the cAdvisor DNS configuration in Prometheus scrape configs to use the fully qualified domain name `kubernetes.default.svc.cluster.local:443` instead of `kubernetes.default.svc:443`.

Using the FQDN with the `.cluster.local` suffix is more explicit and can prevent DNS resolution issues in some cluster configurations.

Changes:
- helm/templates/_cm_helpers.tpl: Update cAdvisor __address__ replacement
- app/functions/agent-validator/config/internal/scrape_config.tmpl: Update validator template
- app/config/validator/testdata/prometheus.yml: Update test data