### PR TITLE
CP-34359: remove empty caBundle when using cert-manager

### DIFF
--- a/helm/templates/webhook-validating-config.yaml
+++ b/helm/templates/webhook-validating-config.yaml
@@ -82,8 +82,6 @@ webhooks:
         port: {{ $.Values.insightsController.service.port }}
       {{- if (gt (len $.Values.insightsController.tls.caBundle) 1 ) }}
       caBundle: {{ $.Values.insightsController.tls.caBundle | quote }}
-      {{- else if $.Values.insightsController.tls.useCertManager }}
-      caBundle: ''
       {{- end }}
     admissionReviewVersions: ["v1"]
     sideEffects: None

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -3177,7 +3177,6 @@ webhooks:
         name: cz-agent-cloudzero-agent-webhook-server-svc
         path: /validate
         port: 443
-      caBundle: ''
     admissionReviewVersions: ["v1"]
     sideEffects: None
     timeoutSeconds: 1


### PR DESCRIPTION
When `useCertManager` is enabled, do not render the `caBundle` key at all in the ValidatingWebhookConfiguration. Previously, the template set `caBundle: ''` (empty string) when cert-manager was enabled, which causes
ArgoCD reconciliation failures.

Cert-manager injects the CA bundle automatically via the `cert-manager.io/inject-ca-from` annotation, so the key should not be present in the template. This change removes the `else if` branch that was rendering the empty caBundle key

Behavior after this change:
- With cert-manager: No caBundle key (cert-manager injects via annotation)
- With explicit caBundle: Key appears with provided value
- Neither: No caBundle key (uses K8s default behavior)

Testing:
- Deployed to EKS test cluster with cert-manager enabled
- Verified cert-manager successfully injected CA bundle via annotation
- Confirmed webhook configuration has no empty caBundle key
- Validated all agent deployments reached ready state