### PR TITLE
Change deployment strategy for agent when persistent volume is enabled

### DIFF
--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -12,6 +12,10 @@ spec:
     matchLabels:
       {{- include "cloudzero-agent.server.matchLabels" . | nindent 6 }}
   replicas: 1
+  {{- if .Values.server.persistentVolume }}
+  strategy:
+    type: Recreate
+  {{- end }}
   template:
     metadata:
       {{- include "cloudzero-agent.generateAnnotations" .Values.server.podAnnotations | nindent 8 }}


### PR DESCRIPTION
# Why?
When the PVC feature is enabled you will run into the following issue when upgrading the chart:

```
Multi-Attach error for volume "pvc-401c5500-a013-4853-815d-0bfd7c43ad1e" Volume is already used by pod(s) cloudzero-agent-server-7f8cdfbb85-wjkdn
```

This is because the PVC claim is already being mounted by the previous version of the pod, while the new version of the pod is waiting for the claim to get released!

# What

A quick fix for this is to change the [rollout strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) for the deployment to `Recreate`. This will terminate the previously running pod and free up the PVC claim mount for use in the new pod.


# How Tested

1. Enable PVC feature
2. Upgrade the helm chart
3. New agent-server container will work 
4. Upgrade helm chart again (e.g. add label change)
5. New agent-server container will be blocked until previous container is deleted