### PR TITLE
CP-34389: exclude .global sections from checksum calculation

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -623,9 +623,22 @@ Note that jobConfigID *only* exists so we can avoid lots of commit noise when
 regenerating the manifests in tests/helm/template. It should never be set in
 production, as it will break important functionality to automatically reload
 things when a ConfigMap changes.
+
+When used as a subchart, .global values from the parent chart are excluded
+from the checksum.
 */}}
 {{- define "cloudzero-agent.configurationChecksum" -}}
-{{ .Values.jobConfigID | default (. | toYaml | sha256sum) }}
+{{- if .Values.jobConfigID -}}
+{{ .Values.jobConfigID }}
+{{- else -}}
+{{- $cleanValues := omit .Values "global" -}}
+{{- if $cleanValues.kubeStateMetrics -}}
+  {{- $cleanKSM := omit $cleanValues.kubeStateMetrics "global" -}}
+  {{- $_ := set $cleanValues "kubeStateMetrics" $cleanKSM -}}
+{{- end -}}
+{{- $context := dict "Chart" .Chart "Release" .Release "Values" $cleanValues "Capabilities" .Capabilities -}}
+{{ $context | toYaml | sha256sum }}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
When the CloudZero Agent chart is used as a subchart, changes to the parent chart's global values were causing the checksum to change due to .Values.global and .Values.kubeStateMetrics.global potentially changing.

Global values are explicitly outside the scope of the CloudZero Agent's configuration and should not trigger resource recreation. This change excludes both .Values.global (parent chart globals) and .Values.kubeStateMetrics.global (subchart globals inherited from parent) from the checksum calculation.

The fix ensures that only actual CloudZero Agent configuration changes trigger new backfill jobs, preventing unnecessary disruption to customer deployments when parent chart values are updated.

Unfortunately we don't currently have a great way to test this right now, but the manual test procedure was basically to just create two different charts, both using cloudzero-agent as a subchart, with slightly different globals (which don't impact the Agent chart), then diffing the output of `helm template` for each. I was able to reproduce the issue by doing this, and the diff disappeart after the fix was in place.
