### PR TITLE
CP-34764: Add HPA for Webhook Server

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -982,6 +982,29 @@ insightsController:
     # For additional information, see:
     # https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/docs/istio.md
     suppressIstioAnnotations: false
+  # Horizontal Pod Autoscaler configuration for the webhook server.
+  #
+  # EXPERIMENTAL: These settings are experimental and may move to the
+  # components.webhookServer section or change in a future release.
+  #
+  # When enabled, automatically scales the webhook server based on CPU and/or
+  # memory utilization. This is particularly useful for high-churn clusters
+  # with frequent resource creation/modification events.
+  autoscaling:
+    # Whether to enable horizontal pod autoscaling for the webhook server.
+    enabled: false
+    # Additional annotations to add to the HPA resource.
+    annotations: {}
+    # Minimum number of webhook server replicas.
+    minReplicas: 2
+    # Maximum number of webhook server replicas.
+    maxReplicas: 10
+    # Target CPU utilization percentage for autoscaling.
+    # Set to null to disable CPU-based scaling.
+    targetCPUUtilizationPercentage: 80
+    # Target memory utilization percentage for autoscaling.
+    # Set to null to disable memory-based scaling.
+    targetMemoryUtilizationPercentage: 80
   # Additional volume mounts to add to the insights controller pods.
   volumeMounts: []
   # Additional volumes to add to the insights controller pods.

--- a/helm/templates/webhook-hpa.yaml
+++ b/helm/templates/webhook-hpa.yaml
@@ -1,0 +1,70 @@
+{{- if and .Values.insightsController.enabled .Values.insightsController.autoscaling.enabled }}
+{{- /*
+Horizontal Pod Autoscaler for CloudZero Webhook Server
+
+This HPA applies when the webhook server (insights controller) is enabled
+(insightsController.enabled=true) and autoscaling is enabled
+(insightsController.autoscaling.enabled=true)
+
+The HPA scales the webhook server deployment based on CPU and/or memory utilization,
+allowing the system to automatically adjust to varying admission webhook load.
+This is particularly useful for high-churn clusters with frequent resource
+creation/modification events.
+*/ -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cloudzero-agent.insightsController.deploymentName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateAnnotations" (merge
+      (deepCopy .Values.defaults.annotations)
+      .Values.insightsController.autoscaling.annotations
+    ) | nindent 2 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cloudzero-agent.insightsController.deploymentName" . }}
+  minReplicas: {{ .Values.insightsController.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.insightsController.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.insightsController.autoscaling.targetCPUUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.insightsController.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.insightsController.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.insightsController.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+      selectPolicy: Min
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 30
+      - type: Pods
+        value: 4
+        periodSeconds: 30
+      selectPolicy: Max
+{{- end }}

--- a/helm/tests/webhook_hpa_test.yaml
+++ b/helm/tests/webhook_hpa_test.yaml
@@ -1,0 +1,245 @@
+suite: test Webhook Server HPA configuration
+templates:
+  - templates/webhook-hpa.yaml
+tests:
+  # Test that HPA is not created when webhook is disabled
+  - it: should not create HPA when webhook is disabled
+    set:
+      insightsController.enabled: false
+      insightsController.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Test that HPA is not created when autoscaling is disabled
+  - it: should not create HPA when autoscaling is disabled
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Test that HPA is created when both webhook and autoscaling are enabled
+  - it: should create HPA when webhook and autoscaling are enabled
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2
+
+  # Test HPA target reference
+  - it: should target the correct deployment
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.apiVersion
+          value: apps/v1
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: RELEASE-NAME-cz-webhook
+
+  # Test replica configuration
+  - it: should use configured min and max replicas
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling:
+        enabled: true
+        minReplicas: 3
+        maxReplicas: 15
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 3
+      - equal:
+          path: spec.maxReplicas
+          value: 15
+
+  # Test default replica values
+  - it: should use default replica values
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  # Test CPU metric configuration
+  - it: should configure CPU metric when targetCPUUtilizationPercentage is set
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling:
+        enabled: true
+        targetCPUUtilizationPercentage: 75
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  # Test memory metric configuration
+  - it: should configure memory metric when targetMemoryUtilizationPercentage is set
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling:
+        enabled: true
+        targetMemoryUtilizationPercentage: 85
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 85
+
+  # Test default includes both CPU and memory metrics
+  - it: should configure both CPU and memory metrics by default
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 80
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 80
+
+  # Test both metrics
+  - it: should configure both CPU and memory metrics
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling:
+        enabled: true
+        targetCPUUtilizationPercentage: 70
+        targetMemoryUtilizationPercentage: 80
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 70
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 80
+
+  # Test no metrics when both are null
+  - it: should not configure metrics when both CPU and memory are null
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling:
+        enabled: true
+        targetCPUUtilizationPercentage: null
+        targetMemoryUtilizationPercentage: null
+    asserts:
+      - lengthEqual:
+          path: spec.metrics
+          count: 0
+
+  # Test scaling behavior
+  - it: should configure scale-down behavior
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+      - lengthEqual:
+          path: spec.behavior.scaleDown.policies
+          count: 2
+      - equal:
+          path: spec.behavior.scaleDown.selectPolicy
+          value: Min
+
+  # Test scale-up behavior
+  - it: should configure scale-up behavior
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling.enabled: true
+    asserts:
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 0
+      - lengthEqual:
+          path: spec.behavior.scaleUp.policies
+          count: 2
+      - equal:
+          path: spec.behavior.scaleUp.selectPolicy
+          value: Max
+
+  # Test HPA labels
+  - it: should have correct labels including component label
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling.enabled: true
+    asserts:
+      - isNotEmpty:
+          path: metadata.labels
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: webhook-server
+
+  # Test HPA annotations
+  - it: should include custom annotations when provided
+    set:
+      insightsController.enabled: true
+      insightsController.autoscaling:
+        enabled: true
+        annotations:
+          custom.annotation: "test-value"
+    asserts:
+      - equal:
+          path: metadata.annotations["custom.annotation"]
+          value: "test-value"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -6091,6 +6091,41 @@
           },
           "type": "object"
         },
+        "autoscaling": {
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            },
+            "enabled": {
+              "default": false,
+              "type": "boolean"
+            },
+            "maxReplicas": {
+              "default": 10,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "minReplicas": {
+              "default": 2,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "targetCPUUtilizationPercentage": {
+              "default": 80,
+              "maximum": 100,
+              "minimum": 1,
+              "type": ["integer", "null"]
+            },
+            "targetMemoryUtilizationPercentage": {
+              "default": 80,
+              "maximum": 100,
+              "minimum": 1,
+              "type": ["integer", "null"]
+            }
+          },
+          "type": "object"
+        },
         "configurationMountPath": {
           "type": ["string", "null"]
         },

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1260,6 +1260,53 @@ properties:
                   Whether to collect annotations from StatefulSets.
                 type: boolean
                 default: false
+      autoscaling:
+        description: |
+          Horizontal Pod Autoscaler configuration for the webhook server.
+
+          When enabled, automatically scales the webhook server based on CPU and/or
+          memory utilization. This is particularly useful for high-churn clusters
+          with frequent resource creation/modification events.
+        type: object
+        additionalProperties: false
+        properties:
+          enabled:
+            description: |
+              Whether to enable horizontal pod autoscaling for the webhook server.
+            type: boolean
+            default: false
+          annotations:
+            description: |
+              Additional annotations to add to the HPA resource.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+          minReplicas:
+            description: |
+              Minimum number of webhook server replicas.
+            type: integer
+            minimum: 1
+            default: 2
+          maxReplicas:
+            description: |
+              Maximum number of webhook server replicas.
+            type: integer
+            minimum: 1
+            default: 10
+          targetCPUUtilizationPercentage:
+            description: |
+              Target CPU utilization percentage for autoscaling.
+              Set to null to disable CPU-based scaling.
+            type: [integer, "null"]
+            minimum: 1
+            maximum: 100
+            default: 80
+          targetMemoryUtilizationPercentage:
+            description: |
+              Target memory utilization percentage for autoscaling.
+              Set to null to disable memory-based scaling.
+            type: [integer, "null"]
+            minimum: 1
+            maximum: 100
+            default: 80
       tls:
         description: |
           Configuration for TLS certificates used by the insights controller.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -982,6 +982,29 @@ insightsController:
     # For additional information, see:
     # https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/docs/istio.md
     suppressIstioAnnotations: false
+  # Horizontal Pod Autoscaler configuration for the webhook server.
+  #
+  # EXPERIMENTAL: These settings are experimental and may move to the
+  # components.webhookServer section or change in a future release.
+  #
+  # When enabled, automatically scales the webhook server based on CPU and/or
+  # memory utilization. This is particularly useful for high-churn clusters
+  # with frequent resource creation/modification events.
+  autoscaling:
+    # Whether to enable horizontal pod autoscaling for the webhook server.
+    enabled: false
+    # Additional annotations to add to the HPA resource.
+    annotations: {}
+    # Minimum number of webhook server replicas.
+    minReplicas: 2
+    # Maximum number of webhook server replicas.
+    maxReplicas: 10
+    # Target CPU utilization percentage for autoscaling.
+    # Set to null to disable CPU-based scaling.
+    targetCPUUtilizationPercentage: 80
+    # Target memory utilization percentage for autoscaling.
+    # Set to null to disable memory-based scaling.
+    targetMemoryUtilizationPercentage: 80
   # Additional volume mounts to add to the insights controller pods.
   volumeMounts: []
   # Additional volumes to add to the insights controller pods.

--- a/tests/helm/schema/webhook.autoscaling.both-metrics.pass.yaml
+++ b/tests/helm/schema/webhook.autoscaling.both-metrics.pass.yaml
@@ -1,0 +1,11 @@
+# Valid: Both CPU and memory targets configured
+apiKey: "test-key-123"
+existingSecretName: null
+insightsController:
+  enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 15
+    targetCPUUtilizationPercentage: 75
+    targetMemoryUtilizationPercentage: 80

--- a/tests/helm/schema/webhook.autoscaling.enabled.pass.yaml
+++ b/tests/helm/schema/webhook.autoscaling.enabled.pass.yaml
@@ -1,0 +1,10 @@
+# Valid: Autoscaling enabled with webhook server
+apiKey: "test-key-123"
+existingSecretName: null
+insightsController:
+  enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70

--- a/tests/helm/schema/webhook.autoscaling.memory-only.pass.yaml
+++ b/tests/helm/schema/webhook.autoscaling.memory-only.pass.yaml
@@ -1,0 +1,11 @@
+# Valid: Memory target only (CPU explicitly null)
+apiKey: "test-key-123"
+existingSecretName: null
+insightsController:
+  enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: null
+    targetMemoryUtilizationPercentage: 85

--- a/tests/helm/schema/webhook.autoscaling.minReplicas-invalid.fail.yaml
+++ b/tests/helm/schema/webhook.autoscaling.minReplicas-invalid.fail.yaml
@@ -1,0 +1,9 @@
+# Invalid: minReplicas must be >= 1
+apiKey: "test-key-123"
+existingSecretName: null
+insightsController:
+  enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 0
+    maxReplicas: 10

--- a/tests/helm/schema/webhook.autoscaling.targetCPU-boundary.pass.yaml
+++ b/tests/helm/schema/webhook.autoscaling.targetCPU-boundary.pass.yaml
@@ -1,0 +1,10 @@
+# Valid: CPU target at boundary (1%)
+apiKey: "test-key-123"
+existingSecretName: null
+insightsController:
+  enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 1

--- a/tests/helm/schema/webhook.autoscaling.targetCPU-invalid.fail.yaml
+++ b/tests/helm/schema/webhook.autoscaling.targetCPU-invalid.fail.yaml
@@ -1,0 +1,10 @@
+# Invalid: CPU target must be <= 100
+apiKey: "test-key-123"
+existingSecretName: null
+insightsController:
+  enabled: true
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 101

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -1013,6 +1013,13 @@ data:
           nodes: false
           pods: true
           statefulsets: false
+      autoscaling:
+        annotations: {}
+        enabled: false
+        maxReplicas: 10
+        minReplicas: 2
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
       configurationMountPath: null
       enabled: true
       labels:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -1082,6 +1082,13 @@ data:
           nodes: false
           pods: true
           statefulsets: false
+      autoscaling:
+        annotations: {}
+        enabled: false
+        maxReplicas: 10
+        minReplicas: 2
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
       configurationMountPath: null
       enabled: true
       labels:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1029,6 +1029,13 @@ data:
           nodes: false
           pods: true
           statefulsets: false
+      autoscaling:
+        annotations: {}
+        enabled: false
+        maxReplicas: 10
+        minReplicas: 2
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
       configurationMountPath: null
       enabled: true
       labels:


### PR DESCRIPTION
This change adds Horizontal Pod Autoscaler (HPA) support for the webhook server to enable automatic scaling based on workload. This addresses requests for better handling of varying webhook admission request volumes without manual intervention.

The HPA automatically scales the webhook server between configurable min/max replicas (default 2-10) based on CPU and memory utilization (default 80% targets). This allows the webhook server to adapt to any cluster size and activity level without manual tuning.

The implementation uses standard Kubernetes resource metrics (CPU/memory) rather than custom metrics, making it straightforward to deploy and operate. Autoscaling is disabled by default and can be enabled via `insightsController.autoscaling.enabled=true`.

The autoscaling settings are placed in the `insightsController` section rather than `components.webhookServer` because they are considered experimental and may move or change in a future release.

Testing:
- All Helm unittest tests pass (209 tests including 18 new HPA-specific tests)
- Schema validation tests pass (6 new test cases)
- Successfully deployed to test cluster and verified scaling behavior