### PR TITLE
CP-34948: implement cohesive system to manage replicas

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -173,6 +173,9 @@ defaults:
   # Note that if you set this, you'll likely also want to set
   # kubeStateMetrics.priorityClassName.
   priorityClassName:
+  # Default number of replicas to use for components which support multiple
+  # replicas. This can be overridden by component-specific replica settings.
+  replicas: 3
   # Default security context for all pods. Component-specific security contexts
   # will be merged with these defaults, with component settings taking precedence.
   #
@@ -385,7 +388,7 @@ components:
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
   # after some processing.
   aggregator:
-    replicas: 3
+    replicas: null
     podDisruptionBudget:
       # enabled:
       # minAvailable:
@@ -431,7 +434,7 @@ components:
 
   # Settings for the webhook server.
   webhookServer:
-    replicas: 3
+    replicas: null
     podDisruptionBudget:
       # enabled:
       # minAvailable:

--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -11,7 +11,11 @@ spec:
   selector:
     matchLabels:
       {{- include "cloudzero-agent.server.matchLabels" . | nindent 6 }}
+  {{- if eq (include "cloudzero-agent.Values.components.agent.mode" .) "clustered" }}
+  replicas: {{ .Values.components.agent.replicas | default .Values.defaults.replicas }}
+  {{- else }}
   replicas: 1
+  {{- end }}
   template:
     metadata:
       {{- include "cloudzero-agent.generateAnnotations" .Values.server.podAnnotations | nindent 8 }}

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -41,7 +41,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cloudzero-agent.aggregator.matchLabels" . | nindent 6 }}
-  replicas: {{ .Values.components.aggregator.replicas }}
+  replicas: {{ .Values.components.aggregator.replicas | default .Values.defaults.replicas }}
   template:
     metadata:
       {{- include "cloudzero-agent.generateAnnotations" (merge

--- a/helm/templates/webhook-deploy.yaml
+++ b/helm/templates/webhook-deploy.yaml
@@ -36,7 +36,7 @@ metadata:
   # Supports monitoring, backup policies, and operational tooling integration
   {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.insightsController.server.deploymentAnnotations) | nindent 2 }}
 spec:
-  replicas: {{ .Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas }}
+  replicas: {{ .Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas | default .Values.defaults.replicas }}
   selector:
     matchLabels:
       {{- include "cloudzero-agent.insightsController.server.matchLabels" . | nindent 6 }}

--- a/helm/templates/webhook-pdb.yaml
+++ b/helm/templates/webhook-pdb.yaml
@@ -3,6 +3,6 @@
     "componentName" .Values.insightsController.server.name
     "name" (include "cloudzero-agent.insightsController.deploymentName" .)
     "matchLabels" (include "cloudzero-agent.insightsController.server.matchLabels" .)
-    "replicas" (.Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas)
+    "replicas" (.Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas | default .Values.defaults.replicas)
     "root" .
   ) }}

--- a/helm/tests/agent_replicas_validation_test.yaml
+++ b/helm/tests/agent_replicas_validation_test.yaml
@@ -1,0 +1,204 @@
+suite: test agent replicas validation
+templates:
+  - templates/agent-deploy.yaml
+  - templates/agent-daemonset.yaml
+tests:
+  # Test that null replicas defaults to 1 for non-clustered modes
+  - it: should default to replicas=1 when replicas is null and mode is null
+    set:
+      components.agent.mode: null
+      components.agent.replicas: null
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: templates/agent-deploy.yaml
+
+  # Test that replicas=1 is used in deployment for non-clustered modes
+  - it: should use replicas=1 in deployment when mode is null
+    set:
+      components.agent.mode: null
+      components.agent.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: templates/agent-deploy.yaml
+
+  # Test that replicas=1 is used in deployment for agent mode
+  - it: should use replicas=1 in deployment when mode is agent
+    set:
+      components.agent.mode: agent
+      components.agent.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: templates/agent-deploy.yaml
+
+  # Test that replicas=1 is used in deployment for server mode
+  - it: should use replicas=1 in deployment when mode is server
+    set:
+      components.agent.mode: server
+      components.agent.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: templates/agent-deploy.yaml
+
+  # Test that replicas=1 is used in deployment for federated mode
+  - it: should use replicas=1 in deployment when mode is federated
+    set:
+      components.agent.mode: federated
+      components.agent.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: templates/agent-deploy.yaml
+
+  # Test that replicas=3 is used in deployment when mode is clustered
+  - it: should use replicas=3 in deployment when mode is clustered
+    set:
+      components.agent.mode: clustered
+      components.agent.replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 3
+        template: templates/agent-deploy.yaml
+
+  # Test that replicas=5 is used in deployment when mode is clustered
+  - it: should use replicas=5 in deployment when mode is clustered
+    set:
+      components.agent.mode: clustered
+      components.agent.replicas: 5
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 5
+        template: templates/agent-deploy.yaml
+
+  # Test that replicas=1 is used in deployment when mode is clustered
+  - it: should use replicas=1 in deployment when mode is clustered
+    set:
+      components.agent.mode: clustered
+      components.agent.replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: templates/agent-deploy.yaml
+
+  # Test that replicas defaults to defaults.replicas (3) when null in clustered mode
+  - it: should default to defaults.replicas (3) when replicas is null in clustered mode
+    set:
+      components.agent.mode: clustered
+      components.agent.replicas: null
+      defaults.replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 3
+        template: templates/agent-deploy.yaml
+
+  # Test that replicas uses defaults.replicas when explicitly set to different value
+  - it: should use defaults.replicas when components.agent.replicas is null and defaults.replicas is set
+    set:
+      components.agent.mode: clustered
+      components.agent.replicas: null
+      defaults.replicas: 5
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 5
+        template: templates/agent-deploy.yaml
+
+  # Test that components.agent.replicas takes precedence over defaults.replicas
+  - it: should use components.agent.replicas when set, ignoring defaults.replicas
+    set:
+      components.agent.mode: clustered
+      components.agent.replicas: 7
+      defaults.replicas: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 7
+        template: templates/agent-deploy.yaml
+
+  # Test that null replicas defaults to 1 for agent mode
+  - it: should default to replicas=1 when replicas is null and mode is agent
+    set:
+      components.agent.mode: agent
+      components.agent.replicas: null
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: templates/agent-deploy.yaml
+
+  # Test that null replicas defaults to 1 for server mode
+  - it: should default to replicas=1 when replicas is null and mode is server
+    set:
+      components.agent.mode: server
+      components.agent.replicas: null
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-deploy.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: templates/agent-deploy.yaml
+
+  # Test that null replicas is allowed for federated mode
+  - it: should allow null replicas when mode is federated
+    set:
+      components.agent.mode: federated
+      components.agent.replicas: null
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/agent-daemonset.yaml
+
+  # Note: Schema validation failures (e.g., replicas=2 with mode=null) are tested
+  # in tests/helm/schema/components.agent.replicas.*.fail.yaml files.
+  # Helm unittest cannot test schema validation failures as they occur before
+  # template rendering.

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -5578,6 +5578,44 @@
       "properties": {
         "agent": {
           "additionalProperties": false,
+          "allOf": [
+            {
+              "if": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "mode": {
+                        "type": "null"
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "mode": {
+                        "enum": ["federated", "agent", "server"]
+                      }
+                    }
+                  }
+                ]
+              },
+              "then": {
+                "if": {
+                  "properties": {
+                    "replicas": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "replicas": {
+                      "const": 1
+                    }
+                  }
+                }
+              }
+            }
+          ],
           "properties": {
             "federatedNode": {
               "additionalProperties": false,
@@ -5628,7 +5666,14 @@
               "type": "object"
             },
             "replicas": {
-              "type": "integer"
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "resources": {
               "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
@@ -5914,6 +5959,10 @@
         },
         "priorityClassName": {
           "type": ["string", "null"]
+        },
+        "replicas": {
+          "default": 3,
+          "type": "integer"
         },
         "securityContext": {
           "$ref": "#/$defs/io.k8s.api.core.v1.PodSecurityContext"

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -272,6 +272,13 @@ properties:
         type:
           - string
           - "null"
+      replicas:
+        description: |
+          Default number of replicas to use across components which support
+          multiple replicas. This can be overridden by component-specific
+          replica settings.
+        type: integer
+        default: 3
       securityContext:
         description: |
           Default security context for all pods. Component-specific security contexts
@@ -342,7 +349,13 @@ properties:
           replicas:
             description: |
               Number of replicas to deploy.
-            type: integer
+
+              For modes other than "clustered", if set, this must be 1, or left
+              unset. For "clustered" mode, this can be any integer value. If
+              null, falls back to defaults.replicas.
+            oneOf:
+              - type: integer
+              - type: "null"
           tolerations:
             description: |
               Tolerations configuration for the agent pods.
@@ -404,6 +417,24 @@ properties:
                   For details, see the Kubernetes documentation on resource management:
                   https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                 $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+        allOf:
+          - if:
+              anyOf:
+                - properties:
+                    mode:
+                      type: "null"
+                - properties:
+                    mode:
+                      enum: ["federated", "agent", "server"]
+            then:
+              if:
+                properties:
+                  replicas:
+                    type: integer
+              then:
+                properties:
+                  replicas:
+                    const: 1
 
       validator:
         description: |
@@ -579,7 +610,8 @@ properties:
               - type: "null"
           replicas:
             description: |
-              Number of replicas to deploy.
+              Number of replicas to deploy. If null, falls back to
+              defaults.replicas.
             additionalProperties: false
             type:
               - integer
@@ -657,7 +689,8 @@ properties:
               - type: "null"
           replicas:
             description: |
-              Number of replicas to deploy.
+              Number of replicas to deploy. If null, falls back to
+              defaults.replicas.
             additionalProperties: false
             type:
               - integer

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -173,6 +173,9 @@ defaults:
   # Note that if you set this, you'll likely also want to set
   # kubeStateMetrics.priorityClassName.
   priorityClassName:
+  # Default number of replicas to use for components which support multiple
+  # replicas. This can be overridden by component-specific replica settings.
+  replicas: 3
   # Default security context for all pods. Component-specific security contexts
   # will be merged with these defaults, with component settings taking precedence.
   #
@@ -385,7 +388,7 @@ components:
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
   # after some processing.
   aggregator:
-    replicas: 3
+    replicas: null
     podDisruptionBudget:
       # enabled:
       # minAvailable:
@@ -431,7 +434,7 @@ components:
 
   # Settings for the webhook server.
   webhookServer:
-    replicas: 3
+    replicas: null
     podDisruptionBudget:
       # enabled:
       # minAvailable:

--- a/tests/helm/schema/components.agent.replicas.agent-mode-invalid.fail.yaml
+++ b/tests/helm/schema/components.agent.replicas.agent-mode-invalid.fail.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    mode: agent
+    replicas: 2

--- a/tests/helm/schema/components.agent.replicas.clustered-null.pass.yaml
+++ b/tests/helm/schema/components.agent.replicas.clustered-null.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    mode: clustered
+    replicas: null

--- a/tests/helm/schema/components.agent.replicas.clustered-valid.pass.yaml
+++ b/tests/helm/schema/components.agent.replicas.clustered-valid.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    mode: clustered
+    replicas: 3

--- a/tests/helm/schema/components.agent.replicas.invalid-nonclustered.fail.yaml
+++ b/tests/helm/schema/components.agent.replicas.invalid-nonclustered.fail.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    mode: null
+    replicas: 2

--- a/tests/helm/schema/components.agent.replicas.invalid-type.fail.yaml
+++ b/tests/helm/schema/components.agent.replicas.invalid-type.fail.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    mode: null
+    replicas: "not-a-number"

--- a/tests/helm/schema/components.agent.replicas.null.pass.yaml
+++ b/tests/helm/schema/components.agent.replicas.null.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    mode: null
+    replicas: null

--- a/tests/helm/schema/components.agent.replicas.omitted.pass.yaml
+++ b/tests/helm/schema/components.agent.replicas.omitted.pass.yaml
@@ -1,0 +1,4 @@
+components:
+  agent:
+    mode: null
+    # replicas is omitted

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -884,7 +884,7 @@ data:
               memory: 64Mi
           securityContext: {}
         podDisruptionBudget: null
-        replicas: 3
+        replicas: null
         securityContext: {}
         shipper:
           resources:
@@ -956,7 +956,7 @@ data:
           schedule: 0 */12 * * *
           securityContext: {}
         podDisruptionBudget: null
-        replicas: 3
+        replicas: null
         resources:
           limits:
             cpu: 500m
@@ -995,6 +995,7 @@ data:
         enabled: true
         minAvailable: 1
       priorityClassName: null
+      replicas: 3
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534
@@ -2247,7 +2248,7 @@ spec:
       app.kubernetes.io/component: server
       app.kubernetes.io/name: cloudzero-agent
       app.kubernetes.io/instance: cz-agent
-  replicas: 1
+  replicas: 2
   template:
     metadata:
         

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -844,7 +844,7 @@ data:
               memory: 64Mi
           securityContext: {}
         podDisruptionBudget: null
-        replicas: 3
+        replicas: null
         securityContext: {}
         shipper:
           resources:
@@ -916,7 +916,7 @@ data:
           schedule: 0 */12 * * *
           securityContext: {}
         podDisruptionBudget: null
-        replicas: 3
+        replicas: null
         resources:
           limits:
             cpu: 500m
@@ -955,6 +955,7 @@ data:
         enabled: true
         minAvailable: 1
       priorityClassName: null
+      replicas: 3
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -913,7 +913,7 @@ data:
               memory: 64Mi
           securityContext: {}
         podDisruptionBudget: null
-        replicas: 3
+        replicas: null
         securityContext: {}
         shipper:
           resources:
@@ -985,7 +985,7 @@ data:
           schedule: 0 */12 * * *
           securityContext: {}
         podDisruptionBudget: null
-        replicas: 3
+        replicas: null
         resources:
           limits:
             cpu: 500m
@@ -1024,6 +1024,7 @@ data:
         enabled: true
         minAvailable: 1
       priorityClassName: null
+      replicas: 3
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -860,7 +860,7 @@ data:
               memory: 64Mi
           securityContext: {}
         podDisruptionBudget: null
-        replicas: 3
+        replicas: null
         securityContext: {}
         shipper:
           resources:
@@ -932,7 +932,7 @@ data:
           schedule: 0 */12 * * *
           securityContext: {}
         podDisruptionBudget: null
-        replicas: 3
+        replicas: null
         resources:
           limits:
             cpu: 500m
@@ -971,6 +971,7 @@ data:
         enabled: true
         minAvailable: 1
       priorityClassName: null
+      replicas: 3
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534


### PR DESCRIPTION
Implements a comprehensive replicas configuration system that provides default values and enforces mode-specific constraints for the agent component.

The agent component needs different replica count behaviors depending on the deployment mode:
- Non-clustered modes (agent, server, federated) must use exactly 1 replica for proper operation
- Clustered mode (Alloy) supports horizontal scaling and should allow multiple replicas
- Components should have a sensible default replica count that can be overridden per-component

- Added `defaults.replicas` property with default value of 3
  - Provides a global default for all components that support multiple replicas
  - Can be overridden by component-specific settings

- Updated `components.agent.replicas` to allow null values
  - Changed from `type: integer` to `oneOf: [integer, null]`
  - Allows omitting the value to use defaults

- Added conditional validation for agent replicas
  - If mode is not "clustered" (null, federated, agent, or server) AND replicas is explicitly set to an integer, it must equal 1
  - If mode is "clustered", any integer value is allowed
  - Null values are always allowed (will use defaults)

- Updated `global` schema to allow null
  - Prevents validation errors when global is not set

- **agent-deploy.yaml**: Conditional replica count logic
  - Clustered mode: Uses `components.agent.replicas` with fallback to `defaults.replicas`
  - Non-clustered modes: Always uses 1 (enforced by schema validation)

- **aggregator-deploy.yaml**: Added fallback to `defaults.replicas`
  - Falls back to `defaults.replicas` when `components.aggregator.replicas` is null

- **webhook-deploy.yaml**: Added fallback to `defaults.replicas`
  - Extended existing fallback chain: `insightsController.server.replicaCount` → `components.webhookServer.replicas` → `defaults.replicas`

- **webhook-pdb.yaml**: Updated PodDisruptionBudget replica calculation
  - Uses same fallback chain as webhook deployment for consistency

- Created comprehensive unittest suite (`agent_replicas_validation_test.yaml`)
  - Tests all valid combinations of mode and replicas values
  - Verifies fallback behavior to `defaults.replicas`
  - Validates that explicit values take precedence over defaults

- Created schema validation test files
  - `components.agent.replicas.null.pass.yaml`: Null replicas allowed
  - `components.agent.replicas.clustered-valid.pass.yaml`: Clustered mode allows any integer
  - `components.agent.replicas.clustered-null.pass.yaml`: Null allowed in clustered mode
  - `components.agent.replicas.invalid-nonclustered.fail.yaml`: Non-clustered modes reject values other than 1
  - `components.agent.replicas.agent-mode-invalid.fail.yaml`: Agent mode rejects values other than 1
  - `components.agent.replicas.invalid-type.fail.yaml`: Type validation rejects non-integer values
  - `components.agent.replicas.omitted.pass.yaml`: Omitted property allowed
