### PR TITLE
CP-34949: move Alloy configuration to components.agent

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -176,6 +176,25 @@ defaults:
   # Default number of replicas to use for components which support multiple
   # replicas. This can be overridden by component-specific replica settings.
   replicas: 3
+  # Default Horizontal Pod Autoscaler configuration to use across components
+  # which support autoscaling. Component-specific autoscaling settings will
+  # fall back to these defaults when not explicitly set.
+  #
+  # For details, see the Kubernetes documentation on HPA:
+  # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  autoscaling:
+    # Whether to enable horizontal pod autoscaling.
+    enabled: false
+    # Minimum number of replicas.
+    minReplicas: 1
+    # Maximum number of replicas.
+    maxReplicas: 10
+    # Target CPU utilization percentage for autoscaling.
+    # Set to null to disable CPU-based scaling.
+    targetCPUUtilizationPercentage: 80
+    # Target memory utilization percentage for autoscaling.
+    # Set to null to disable memory-based scaling.
+    targetMemoryUtilizationPercentage: 80
   # Default security context for all pods. Component-specific security contexts
   # will be merged with these defaults, with component settings taking precedence.
   #
@@ -204,21 +223,33 @@ components:
     # Valid values:
     #
     # - "agent": Deploys Prometheus in agent mode. This is optimized for remote write
-    #   scenarios and uses fewer resources. Equivalent to server.agentMode=true.
+    #   scenarios and uses fewer resources.
     #
     # - "server": Deploys Prometheus in server mode. This is the traditional Prometheus
-    #   deployment with full storage and query capabilities. Equivalent to
-    #   server.agentMode=false.
+    #   deployment with full storage and query capabilities.
     #
     # - "federated": Deploys the agent in federated mode as a DaemonSet with one pod
     #   per node. This is equivalent to setting defaults.federation.enabled to true.
     #   Uses Prometheus in server mode for metrics collection.
     #
-    # - "clustered": Uses Grafana Alloy instead of Prometheus for metrics collection.
-    #   Alloy provides better performance and native horizontal scalability.
+    # - "clustered": EXPERIMENTAL. Uses Grafana Alloy instead of Prometheus for
+    #   metrics collection. Alloy provides better performance and native
+    #   horizontal scalability.
     #
-    # - null means automatic mode (use legacy properties with default to agent).
+    # - null means automatic mode (currently defaults to "agent").
     mode: null
+
+    # Horizontal Pod Autoscaler configuration for the agent.
+    # Only applies when components.agent.mode is set to "clustered".
+    #
+    # HPA enables automatic scaling based on resource utilization,
+    # allowing the deployment to handle varying load efficiently.
+    #
+    # If null, falls back to defaults.autoscaling.
+    #
+    # For details, see the Kubernetes documentation on HPA:
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    autoscaling: null
 
     podDisruptionBudget:
       # enabled:
@@ -259,6 +290,31 @@ components:
         limits:
           memory: "1024Mi"
           cpu: "1000m"
+
+    # The agent clustered node component configuration.
+    # Only applies when components.agent.mode is set to "clustered".
+    clusteredNode:
+      # Container image configuration for Grafana Alloy.
+      image:
+        repository: docker.io/grafana/alloy
+        tag: v1.11.3
+
+      # Resource requirements and limits for the container.
+      #
+      # Alloy has different performance characteristics than Prometheus and
+      # typically requires less resources for the same workload due to its more
+      # efficient design.
+      #
+      # For details, see the Kubernetes documentation on resource management:
+      # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "50m"
+        limits:
+          memory: "512Mi"
+          cpu: "100m"
+
     # The agent configmap reloader component watches for configuration changes.
     reloader:
       # Security context for the agent configmap reloader container.
@@ -435,6 +491,15 @@ components:
   # Settings for the webhook server.
   webhookServer:
     replicas: null
+    # Horizontal Pod Autoscaler configuration for the webhook server.
+    #
+    # When enabled, automatically scales the webhook server based on CPU and/or
+    # memory utilization. This is particularly useful for high-churn clusters
+    # with frequent resource creation/modification events.
+    #
+    # For details, see the Kubernetes documentation on HPA:
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    autoscaling: null
     podDisruptionBudget:
       # enabled:
       # minAvailable:
@@ -581,52 +646,6 @@ prometheusConfig:
       scrapeInterval: 30s
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
-
-# EXPERIMENTAL Grafana Alloy configuration settings. This section contains all
-# Alloy-specific configuration isolated from the main agent configuration during
-# the experimental phase.
-alloy:
-  # Container image configuration for Grafana Alloy.
-  image:
-    repository: docker.io/grafana/alloy
-    tag: v1.11.3
-    # registry: docker.io
-    # pullPolicy: IfNotPresent
-
-  # Horizontal Pod Autoscaler configuration for Alloy.
-  # Only applies when alloy.enabled=true in non-federated mode.
-  #
-  # HPA enables automatic scaling based on resource utilization,
-  # allowing the deployment to handle varying load efficiently.
-  #
-  # For details, see the Kubernetes documentation on HPA:
-  # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
-  autoscaling:
-    # Whether to enable horizontal pod autoscaling.
-    enabled: true
-    # Minimum number of replicas.
-    minReplicas: 1
-    # Maximum number of replicas.
-    maxReplicas: 10
-    # Target CPU utilization percentage for autoscaling.
-    targetCPUUtilizationPercentage: 80
-    # Target memory utilization percentage for autoscaling (optional).
-    targetMemoryUtilizationPercentage: 80
-
-  # Resource requirements and limits for the Alloy container.
-  #
-  # Alloy has different performance characteristics than Prometheus and typically
-  # requires less resources for the same workload due to its more efficient design.
-  #
-  # For details, see the Kubernetes documentation on resource management:
-  # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "50m"
-    limits:
-      memory: "512Mi"
-      cpu: "100m"
 
 # General server settings that apply to both the prometheus agent server and the webhook server
 serverConfig:
@@ -1050,29 +1069,6 @@ insightsController:
     # For additional information, see:
     # https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/docs/istio.md
     suppressIstioAnnotations: false
-  # Horizontal Pod Autoscaler configuration for the webhook server.
-  #
-  # EXPERIMENTAL: These settings are experimental and may move to the
-  # components.webhookServer section or change in a future release.
-  #
-  # When enabled, automatically scales the webhook server based on CPU and/or
-  # memory utilization. This is particularly useful for high-churn clusters
-  # with frequent resource creation/modification events.
-  autoscaling:
-    # Whether to enable horizontal pod autoscaling for the webhook server.
-    enabled: false
-    # Additional annotations to add to the HPA resource.
-    annotations: {}
-    # Minimum number of webhook server replicas.
-    minReplicas: 2
-    # Maximum number of webhook server replicas.
-    maxReplicas: 10
-    # Target CPU utilization percentage for autoscaling.
-    # Set to null to disable CPU-based scaling.
-    targetCPUUtilizationPercentage: 80
-    # Target memory utilization percentage for autoscaling.
-    # Set to null to disable memory-based scaling.
-    targetMemoryUtilizationPercentage: 80
   # Additional volume mounts to add to the insights controller pods.
   volumeMounts: []
   # Additional volumes to add to the insights controller pods.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1222,7 +1222,7 @@ Usage in templates: {{ eq (include "cloudzero-agent.Values.components.agent.mode
 Get the metrics collector image configuration
 
 Returns the appropriate image configuration based on which collector is active:
-- For Alloy: Uses alloy.image
+- For Alloy: Uses components.agent.clusteredNode.image
 - For Prometheus: Uses components.prometheus.image
 
 Usage: {{ include "cloudzero-agent.agentCollectorImage" . }}
@@ -1230,9 +1230,34 @@ Returns: Image object with repository, tag, registry, pullPolicy
 */}}
 {{- define "cloudzero-agent.agentCollectorImage" -}}
 {{- if eq (include "cloudzero-agent.Values.components.agent.mode" .) "clustered" -}}
-  {{- toYaml .Values.alloy.image -}}
+  {{- toYaml .Values.components.agent.clusteredNode.image -}}
 {{- else -}}
   {{- toYaml .Values.components.prometheus.image -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get autoscaling configuration with fallback to defaults
+
+Returns the autoscaling configuration, falling back to defaults.autoscaling
+when the component-specific autoscaling is null or when individual properties
+are not set.
+
+Usage: {{ include "cloudzero-agent.getAutoscaling" (dict "component" .Values.components.agent.autoscaling "defaults" .Values.defaults.autoscaling) }}
+Returns: Autoscaling configuration object
+*/}}
+{{- define "cloudzero-agent.getAutoscaling" -}}
+{{- if .component -}}
+  {{- $result := dict
+        "enabled" (hasKey .component "enabled" | ternary .component.enabled .defaults.enabled)
+        "minReplicas" (.component.minReplicas | default .defaults.minReplicas)
+        "maxReplicas" (.component.maxReplicas | default .defaults.maxReplicas)
+        "targetCPUUtilizationPercentage" (.component.targetCPUUtilizationPercentage | default .defaults.targetCPUUtilizationPercentage)
+        "targetMemoryUtilizationPercentage" (.component.targetMemoryUtilizationPercentage | default .defaults.targetMemoryUtilizationPercentage)
+  -}}
+  {{- toYaml $result -}}
+{{- else -}}
+  {{- toYaml .defaults -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -255,7 +255,7 @@ spec:
             timeoutSeconds: 1
             failureThreshold: 3
             successThreshold: 1
-          {{- include "cloudzero-agent.generateResources" (.Values.alloy.resources | default (dict)) | nindent 10 }}
+          {{- include "cloudzero-agent.generateResources" (.Values.components.agent.clusteredNode.resources | default (dict)) | nindent 10 }}
           {{- include "cloudzero-agent.generateContainerSecurityContext" (mergeOverwrite
               (.Values.defaults.securityContext | default (dict))
               (.Values.components.agent.securityContext | default (dict))

--- a/helm/templates/agent-hpa.yaml
+++ b/helm/templates/agent-hpa.yaml
@@ -1,10 +1,12 @@
-{{- if and (eq (include "cloudzero-agent.Values.components.agent.mode" .) "clustered") .Values.alloy.autoscaling.enabled }}
+{{- $autoscaling := include "cloudzero-agent.getAutoscaling" (dict "component" .Values.components.agent.autoscaling "defaults" .Values.defaults.autoscaling) | fromYaml -}}
+{{- if and (eq (include "cloudzero-agent.Values.components.agent.mode" .) "clustered") $autoscaling.enabled }}
 {{- /*
 Horizontal Pod Autoscaler for Grafana Alloy
 
 This HPA only applies when using Alloy as the metrics collector
-(components.agent.mode="clustered") and autoscaling is enabled
-(alloy.autoscaling.enabled=true)
+(components.agent.mode="clustered") and autoscaling is enabled.
+Autoscaling configuration falls back to defaults.autoscaling when
+components.agent.autoscaling is null or when individual properties are not set.
 
 The HPA scales the Alloy deployment based on CPU and/or memory utilization,
 allowing the system to automatically adjust to varying metric collection load.
@@ -22,24 +24,24 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ template "cloudzero-agent.server.fullname" . }}
-  minReplicas: {{ .Values.alloy.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.alloy.autoscaling.maxReplicas }}
+  minReplicas: {{ $autoscaling.minReplicas }}
+  maxReplicas: {{ $autoscaling.maxReplicas }}
   metrics:
-  {{- if .Values.alloy.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if $autoscaling.targetCPUUtilizationPercentage }}
   - type: Resource
     resource:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.alloy.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ $autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
-  {{- if .Values.alloy.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- if $autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: {{ .Values.alloy.autoscaling.targetMemoryUtilizationPercentage }}
+        averageUtilization: {{ $autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
   behavior:
     scaleDown:

--- a/helm/templates/webhook-hpa.yaml
+++ b/helm/templates/webhook-hpa.yaml
@@ -1,10 +1,12 @@
-{{- if and .Values.insightsController.enabled .Values.insightsController.autoscaling.enabled }}
+{{- $autoscaling := include "cloudzero-agent.getAutoscaling" (dict "component" .Values.components.webhookServer.autoscaling "defaults" .Values.defaults.autoscaling) | fromYaml -}}
+{{- if and .Values.insightsController.enabled $autoscaling.enabled }}
 {{- /*
 Horizontal Pod Autoscaler for CloudZero Webhook Server
 
 This HPA applies when the webhook server (insights controller) is enabled
-(insightsController.enabled=true) and autoscaling is enabled
-(insightsController.autoscaling.enabled=true)
+(insightsController.enabled=true) and autoscaling is enabled.
+Autoscaling configuration falls back to defaults.autoscaling when
+components.webhookServer.autoscaling is null or when individual properties are not set.
 
 The HPA scales the webhook server deployment based on CPU and/or memory utilization,
 allowing the system to automatically adjust to varying admission webhook load.
@@ -20,31 +22,31 @@ metadata:
     {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
   {{- include "cloudzero-agent.generateAnnotations" (merge
       (deepCopy .Values.defaults.annotations)
-      .Values.insightsController.autoscaling.annotations
+      (.Values.insightsController.server.podAnnotations | default (dict))
     ) | nindent 2 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "cloudzero-agent.insightsController.deploymentName" . }}
-  minReplicas: {{ .Values.insightsController.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.insightsController.autoscaling.maxReplicas }}
+  minReplicas: {{ $autoscaling.minReplicas }}
+  maxReplicas: {{ $autoscaling.maxReplicas }}
   metrics:
-  {{- if .Values.insightsController.autoscaling.targetCPUUtilizationPercentage }}
+  {{- if $autoscaling.targetCPUUtilizationPercentage }}
   - type: Resource
     resource:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: {{ .Values.insightsController.autoscaling.targetCPUUtilizationPercentage }}
+        averageUtilization: {{ $autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
-  {{- if .Values.insightsController.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- if $autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: {{ .Values.insightsController.autoscaling.targetMemoryUtilizationPercentage }}
+        averageUtilization: {{ $autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
   behavior:
     scaleDown:

--- a/helm/tests/agent_mode_derivation_test.yaml
+++ b/helm/tests/agent_mode_derivation_test.yaml
@@ -5,9 +5,12 @@ templates:
   - templates/agent-cm.yaml
 tests:
   # Test that components.agent.mode takes precedence when set
+  # Note: When defaults.federation.enabled is true, components.agent.mode cannot be
+  # "clustered", "agent", or "server" - it must be null or "federated". So we test
+  # with defaults.federation.enabled set to false to verify mode takes precedence.
   - it: should use components.agent.mode when explicitly set, ignoring legacy properties
     set:
-      defaults.federation.enabled: true
+      defaults.federation.enabled: false
       server.agentMode: false
       components.agent.mode: clustered
     asserts:

--- a/helm/tests/alloy_hpa_test.yaml
+++ b/helm/tests/alloy_hpa_test.yaml
@@ -6,7 +6,8 @@ tests:
   - it: should not create HPA when using Prometheus
     set:
       components.agent.mode: agent
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling:
+        enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -15,7 +16,7 @@ tests:
   - it: should not create HPA when autoscaling is disabled
     set:
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: false
+      components.agent.autoscaling.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -24,7 +25,8 @@ tests:
   - it: should not create HPA when federation is enabled
     set:
       components.agent.mode: federated
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling:
+        enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -33,7 +35,7 @@ tests:
   - it: should create HPA when Alloy is enabled with autoscaling
     set:
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -47,7 +49,7 @@ tests:
   - it: should target the correct deployment
     set:
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling.enabled: true
     asserts:
       - equal:
           path: spec.scaleTargetRef.apiVersion
@@ -63,7 +65,7 @@ tests:
   - it: should use configured min and max replicas
     set:
       components.agent.mode: clustered
-      alloy.autoscaling:
+      components.agent.autoscaling:
         enabled: true
         minReplicas: 3
         maxReplicas: 20
@@ -79,7 +81,7 @@ tests:
   - it: should configure CPU metric when targetCPUUtilizationPercentage is set
     set:
       components.agent.mode: clustered
-      alloy.autoscaling:
+      components.agent.autoscaling:
         enabled: true
         targetCPUUtilizationPercentage: 75
     asserts:
@@ -97,7 +99,7 @@ tests:
   - it: should configure memory metric when targetMemoryUtilizationPercentage is set
     set:
       components.agent.mode: clustered
-      alloy.autoscaling:
+      components.agent.autoscaling:
         enabled: true
         targetMemoryUtilizationPercentage: 85
     asserts:
@@ -115,7 +117,7 @@ tests:
   - it: should configure both CPU and memory metrics
     set:
       components.agent.mode: clustered
-      alloy.autoscaling:
+      components.agent.autoscaling:
         enabled: true
         targetCPUUtilizationPercentage: 70
         targetMemoryUtilizationPercentage: 80
@@ -146,7 +148,7 @@ tests:
   - it: should configure scale-down behavior
     set:
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling.enabled: true
     asserts:
       - equal:
           path: spec.behavior.scaleDown.stabilizationWindowSeconds
@@ -162,7 +164,7 @@ tests:
   - it: should configure scale-up behavior
     set:
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling.enabled: true
     asserts:
       - equal:
           path: spec.behavior.scaleUp.stabilizationWindowSeconds
@@ -178,7 +180,7 @@ tests:
   - it: should have correct labels including component label
     set:
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling.enabled: true
     asserts:
       - isNotEmpty:
           path: metadata.labels
@@ -196,7 +198,7 @@ tests:
       apiKey: "test-key"
       existingSecretName: null
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling.enabled: true
     asserts:
       # Verify HPA name matches expected deployment name (both use same helper)
       - equal:

--- a/helm/tests/alloy_image_configuration_test.yaml
+++ b/helm/tests/alloy_image_configuration_test.yaml
@@ -3,7 +3,7 @@ templates:
   - templates/agent-deploy.yaml
 tests:
   # Test default Alloy image
-  - it: should use default Alloy image from alloy.image
+  - it: should use default Alloy image from components.agent.clusteredNode.image
     set:
       components.agent.mode: clustered
     asserts:
@@ -15,7 +15,7 @@ tests:
   - it: should use custom Alloy image when specified
     set:
       components.agent.mode: clustered
-      alloy.image:
+      components.agent.clusteredNode.image:
         repository: custom.registry.io/custom/alloy
         tag: v2.0.0
     asserts:
@@ -27,7 +27,9 @@ tests:
   - it: should not affect Prometheus image
     set:
       components.agent.mode: agent
-      alloy.image:
+      components.agent.autoscaling:
+        enabled: false
+      components.agent.clusteredNode.image:
         repository: custom.registry.io/custom/alloy
         tag: v2.0.0
     asserts:
@@ -38,11 +40,11 @@ tests:
           path: spec.template.spec.containers[1].image
           pattern: alloy
 
-  # Test image pull policy from alloy.image
-  - it: should respect pullPolicy from alloy.image
+  # Test image pull policy from components.agent.clusteredNode.image
+  - it: should respect pullPolicy from components.agent.clusteredNode.image
     set:
       components.agent.mode: clustered
-      alloy.image:
+      components.agent.clusteredNode.image:
         pullPolicy: Always
     asserts:
       - equal:

--- a/helm/tests/alloy_name_matching_test.yaml
+++ b/helm/tests/alloy_name_matching_test.yaml
@@ -13,7 +13,7 @@ tests:
       apiKey: "test-key"
       existingSecretName: null
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling.enabled: true
       serviceAccount.create: true
     asserts:
       # Verify HPA name matches expected deployment name (both use same helper)

--- a/helm/tests/alloy_resources_test.yaml
+++ b/helm/tests/alloy_resources_test.yaml
@@ -2,11 +2,11 @@ suite: test Alloy resources configuration
 templates:
   - templates/agent-deploy.yaml
 tests:
-  # Test that Alloy uses alloy.resources when set
-  - it: should use alloy.resources for Alloy container
+  # Test that Alloy uses components.agent.clusteredNode.resources when set
+  - it: should use components.agent.clusteredNode.resources for Alloy container
     set:
       components.agent.mode: clustered
-      alloy.resources:
+      components.agent.clusteredNode.resources:
         requests:
           memory: "256Mi"
           cpu: "100m"
@@ -31,7 +31,7 @@ tests:
           value: "500m"
 
   # Test that Alloy uses default values from values.yaml
-  - it: should use default alloy.resources from values.yaml
+  - it: should use default components.agent.clusteredNode.resources from values.yaml
     set:
       components.agent.mode: clustered
     asserts:
@@ -55,6 +55,8 @@ tests:
   - it: should use components.agent.resources for Prometheus container
     set:
       components.agent.mode: agent
+      components.agent.autoscaling:
+        enabled: false
       components.agent.resources:
         requests:
           memory: "512Mi"
@@ -79,11 +81,11 @@ tests:
           path: spec.template.spec.containers[1].resources.limits.cpu
           value: "1000m"
 
-  # Test that custom alloy.resources override defaults
-  - it: should override default alloy.resources with custom values
+  # Test that custom components.agent.clusteredNode.resources override defaults
+  - it: should override default components.agent.clusteredNode.resources with custom values
     set:
       components.agent.mode: clustered
-      alloy.resources:
+      components.agent.clusteredNode.resources:
         requests:
           memory: "128Mi"
           cpu: "50m"
@@ -108,10 +110,12 @@ tests:
           value: "250m"
 
   # Test that Alloy and Prometheus have independent resource configurations
-  - it: should not affect Prometheus resources when alloy.resources is set
+  - it: should not affect Prometheus resources when components.agent.clusteredNode.resources is set
     set:
       components.agent.mode: agent
-      alloy.resources:
+      components.agent.autoscaling:
+        enabled: false
+      components.agent.clusteredNode.resources:
         requests:
           memory: "128Mi"
           cpu: "50m"

--- a/helm/tests/autoscaling_fallback_test.yaml
+++ b/helm/tests/autoscaling_fallback_test.yaml
@@ -1,0 +1,115 @@
+suite: test autoscaling fallback to defaults
+templates:
+  - agent-hpa.yaml
+tests:
+  - it: should use defaults.autoscaling when components.agent.autoscaling is null
+    set:
+      components.agent.mode: clustered
+      components.agent.autoscaling: null
+      defaults.autoscaling:
+        enabled: true
+        minReplicas: 2
+        maxReplicas: 15
+        targetCPUUtilizationPercentage: 75
+        targetMemoryUtilizationPercentage: 85
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 15
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 75
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 85
+
+  - it: should use component values when set, falling back to defaults for missing properties
+    set:
+      components.agent.mode: clustered
+      components.agent.autoscaling:
+        enabled: true
+        minReplicas: 5
+        # maxReplicas, targetCPUUtilizationPercentage, targetMemoryUtilizationPercentage
+        # should fall back to defaults
+      defaults.autoscaling:
+        enabled: false
+        minReplicas: 2
+        maxReplicas: 20
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 90
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 5
+      - equal:
+          path: spec.maxReplicas
+          value: 20
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 80
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 90
+
+  - it: should handle null targetCPUUtilizationPercentage in defaults
+    set:
+      components.agent.mode: clustered
+      components.agent.autoscaling:
+        enabled: true
+        minReplicas: 2
+        maxReplicas: 10
+        # targetCPUUtilizationPercentage should fall back to null from defaults
+      defaults.autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetCPUUtilizationPercentage: null
+        targetMemoryUtilizationPercentage: 80
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - lengthEqual:
+          path: spec.metrics
+          count: 1
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: memory
+
+  - it: should handle null targetMemoryUtilizationPercentage in defaults
+    set:
+      components.agent.mode: clustered
+      components.agent.autoscaling:
+        enabled: true
+        minReplicas: 2
+        maxReplicas: 10
+        # targetMemoryUtilizationPercentage should fall back to null from defaults
+      defaults.autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 10
+        targetCPUUtilizationPercentage: 75
+        targetMemoryUtilizationPercentage: null
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - lengthEqual:
+          path: spec.metrics
+          count: 1
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu

--- a/helm/tests/server_deployment_name_independence_test.yaml
+++ b/helm/tests/server_deployment_name_independence_test.yaml
@@ -14,7 +14,7 @@ tests:
       apiKey: "test-key"
       existingSecretName: null
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling.enabled: true
     asserts:
       # Verify HPA scaleTargetRef.name matches the actual deployment name
       - equal:
@@ -26,7 +26,7 @@ tests:
       apiKey: "test-key"
       existingSecretName: null
       components.agent.mode: clustered
-      alloy.autoscaling.enabled: true
+      components.agent.autoscaling.enabled: true
     asserts:
       # Verify deployment name matches what HPA references
       - equal:

--- a/helm/tests/webhook_autoscaling_fallback_test.yaml
+++ b/helm/tests/webhook_autoscaling_fallback_test.yaml
@@ -1,0 +1,67 @@
+suite: test webhook autoscaling fallback to defaults
+templates:
+  - webhook-hpa.yaml
+tests:
+  - it: should use defaults.autoscaling for webhook when components.webhookServer.autoscaling is null
+    set:
+      components.agent.autoscaling:
+        enabled: false
+      insightsController.enabled: true
+      components.webhookServer.autoscaling: null
+      defaults.autoscaling:
+        enabled: true
+        minReplicas: 3
+        maxReplicas: 12
+        targetCPUUtilizationPercentage: 70
+        targetMemoryUtilizationPercentage: 80
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 3
+      - equal:
+          path: spec.maxReplicas
+          value: 12
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 70
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 80
+
+  - it: should use webhook component values when set, falling back to defaults for missing properties
+    set:
+      components.agent.autoscaling:
+        enabled: false
+      insightsController.enabled: true
+      components.webhookServer.autoscaling:
+        enabled: true
+        minReplicas: 4
+        # maxReplicas, targetCPUUtilizationPercentage, targetMemoryUtilizationPercentage
+        # should fall back to defaults
+      defaults.autoscaling:
+        enabled: false
+        minReplicas: 2
+        maxReplicas: 10
+        targetCPUUtilizationPercentage: 85
+        targetMemoryUtilizationPercentage: 95
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 4
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 85
+      - equal:
+          path: spec.metrics[1].resource.target.averageUtilization
+          value: 95

--- a/helm/tests/webhook_hpa_test.yaml
+++ b/helm/tests/webhook_hpa_test.yaml
@@ -5,8 +5,10 @@ tests:
   # Test that HPA is not created when webhook is disabled
   - it: should not create HPA when webhook is disabled
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: false
-      insightsController.autoscaling.enabled: true
+      components.webhookServer.autoscaling.enabled: true
     asserts:
       - hasDocuments:
           count: 0
@@ -14,8 +16,10 @@ tests:
   # Test that HPA is not created when autoscaling is disabled
   - it: should not create HPA when autoscaling is disabled
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling.enabled: false
+      components.webhookServer.autoscaling.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -23,8 +27,10 @@ tests:
   # Test that HPA is created when both webhook and autoscaling are enabled
   - it: should create HPA when webhook and autoscaling are enabled
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling.enabled: true
+      components.webhookServer.autoscaling.enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -37,8 +43,10 @@ tests:
   # Test HPA target reference
   - it: should target the correct deployment
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling.enabled: true
+      components.webhookServer.autoscaling.enabled: true
     asserts:
       - equal:
           path: spec.scaleTargetRef.apiVersion
@@ -53,8 +61,10 @@ tests:
   # Test replica configuration
   - it: should use configured min and max replicas
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling:
+      components.webhookServer.autoscaling:
         enabled: true
         minReplicas: 3
         maxReplicas: 15
@@ -66,11 +76,16 @@ tests:
           path: spec.maxReplicas
           value: 15
 
-  # Test default replica values
-  - it: should use default replica values
+  # Test default replica values (from defaults.autoscaling)
+  - it: should use default replica values from defaults.autoscaling
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling.enabled: true
+      components.webhookServer.autoscaling.enabled: true
+      defaults.autoscaling:
+        minReplicas: 2
+        maxReplicas: 10
     asserts:
       - equal:
           path: spec.minReplicas
@@ -82,8 +97,10 @@ tests:
   # Test CPU metric configuration
   - it: should configure CPU metric when targetCPUUtilizationPercentage is set
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling:
+      components.webhookServer.autoscaling:
         enabled: true
         targetCPUUtilizationPercentage: 75
     asserts:
@@ -100,8 +117,10 @@ tests:
   # Test memory metric configuration
   - it: should configure memory metric when targetMemoryUtilizationPercentage is set
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling:
+      components.webhookServer.autoscaling:
         enabled: true
         targetMemoryUtilizationPercentage: 85
     asserts:
@@ -118,8 +137,10 @@ tests:
   # Test default includes both CPU and memory metrics
   - it: should configure both CPU and memory metrics by default
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling.enabled: true
+      components.webhookServer.autoscaling.enabled: true
     asserts:
       - lengthEqual:
           path: spec.metrics
@@ -146,8 +167,10 @@ tests:
   # Test both metrics
   - it: should configure both CPU and memory metrics
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling:
+      components.webhookServer.autoscaling:
         enabled: true
         targetCPUUtilizationPercentage: 70
         targetMemoryUtilizationPercentage: 80
@@ -177,8 +200,13 @@ tests:
   # Test no metrics when both are null
   - it: should not configure metrics when both CPU and memory are null
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling:
+      defaults.autoscaling:
+        targetCPUUtilizationPercentage: null
+        targetMemoryUtilizationPercentage: null
+      components.webhookServer.autoscaling:
         enabled: true
         targetCPUUtilizationPercentage: null
         targetMemoryUtilizationPercentage: null
@@ -190,8 +218,10 @@ tests:
   # Test scaling behavior
   - it: should configure scale-down behavior
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling.enabled: true
+      components.webhookServer.autoscaling.enabled: true
     asserts:
       - equal:
           path: spec.behavior.scaleDown.stabilizationWindowSeconds
@@ -206,8 +236,10 @@ tests:
   # Test scale-up behavior
   - it: should configure scale-up behavior
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling.enabled: true
+      components.webhookServer.autoscaling.enabled: true
     asserts:
       - equal:
           path: spec.behavior.scaleUp.stabilizationWindowSeconds
@@ -222,24 +254,13 @@ tests:
   # Test HPA labels
   - it: should have correct labels including component label
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.enabled: true
-      insightsController.autoscaling.enabled: true
+      components.webhookServer.autoscaling.enabled: true
     asserts:
       - isNotEmpty:
           path: metadata.labels
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
           value: webhook-server
-
-  # Test HPA annotations
-  - it: should include custom annotations when provided
-    set:
-      insightsController.enabled: true
-      insightsController.autoscaling:
-        enabled: true
-        annotations:
-          custom.annotation: "test-value"
-    asserts:
-      - equal:
-          path: metadata.annotations["custom.annotation"]
-          value: "test-value"

--- a/helm/tests/webhook_resources_fallback_test.yaml
+++ b/helm/tests/webhook_resources_fallback_test.yaml
@@ -5,6 +5,8 @@ tests:
   # Test that insightsController.resources takes precedence over components.webhookServer.resources
   - it: should use insightsController.resources when both are set
     set:
+      components.agent.autoscaling:
+        enabled: false
       components.webhookServer:
         resources:
           requests:
@@ -37,6 +39,8 @@ tests:
   # Test that insightsController.resources is used when components.webhookServer.resources is not set
   - it: should use insightsController.resources when components.webhookServer.resources is not set
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.resources:
         requests:
           memory: "128Mi"
@@ -61,6 +65,8 @@ tests:
   # Test that components.webhookServer.resources is used when insightsController.resources is not set
   - it: should use components.webhookServer.resources when insightsController.resources is not set
     set:
+      components.agent.autoscaling:
+        enabled: false
       components.webhookServer:
         resources:
           requests:
@@ -93,6 +99,8 @@ tests:
   # Test that default resources are used when both components and legacy resources are null
   - it: should use default resources when both components and legacy resources are null
     set:
+      components.agent.autoscaling:
+        enabled: false
       insightsController.resources:
         requests:
           memory: ""

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1,5 +1,46 @@
 {
   "$defs": {
+    "com.cloudzero.agent.AutoscalingSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "maxReplicas": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "minReplicas": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "targetCPUUtilizationPercentage": {
+          "oneOf": [
+            {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "targetMemoryUtilizationPercentage": {
+          "oneOf": [
+            {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
     "com.cloudzero.agent.PodDisruptionBudgetSpec": {
       "additionalProperties": false,
       "properties": {
@@ -5320,6 +5361,57 @@
   "$id": "https://raw.githubusercontent.com/Cloudzero/cloudzero-agent/refs/heads/develop/helm/values.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "allOf": [
+          {
+            "properties": {
+              "defaults": {
+                "properties": {
+                  "federation": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    },
+                    "required": ["enabled"],
+                    "type": "object"
+                  }
+                },
+                "required": ["federation"],
+                "type": "object"
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "components": {
+            "properties": {
+              "agent": {
+                "properties": {
+                  "mode": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "const": "federated"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        }
+      }
+    }
+  ],
   "anyOf": [
     {
       "required": ["apiKey"]
@@ -5496,60 +5588,6 @@
       },
       "type": "object"
     },
-    "alloy": {
-      "additionalProperties": false,
-      "properties": {
-        "autoscaling": {
-          "oneOf": [
-            {
-              "additionalProperties": false,
-              "properties": {
-                "enabled": {
-                  "type": "boolean"
-                },
-                "maxReplicas": {
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "minReplicas": {
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "targetCPUUtilizationPercentage": {
-                  "maximum": 100,
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "targetMemoryUtilizationPercentage": {
-                  "maximum": 100,
-                  "minimum": 1,
-                  "type": "integer"
-                }
-              },
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "config": {
-          "additionalProperties": true,
-          "type": "object"
-        },
-        "enabled": {
-          "default": false,
-          "type": "boolean"
-        },
-        "image": {
-          "$ref": "#/$defs/com.cloudzero.agent.image"
-        },
-        "resources": {
-          "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
-        }
-      },
-      "type": "object"
-    },
     "apiKey": {
       "type": ["string", "null"]
     },
@@ -5614,9 +5652,102 @@
                   }
                 }
               }
+            },
+            {
+              "if": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "mode": {
+                        "type": "null"
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "mode": {
+                        "enum": ["federated", "agent", "server"]
+                      }
+                    }
+                  }
+                ]
+              },
+              "then": {
+                "properties": {
+                  "autoscaling": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "allOf": [
+                          {
+                            "$ref": "#/$defs/com.cloudzero.agent.AutoscalingSpec"
+                          },
+                          {
+                            "properties": {
+                              "enabled": {
+                                "const": false
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "mode": {
+                    "const": "clustered"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "autoscaling": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "$ref": "#/$defs/com.cloudzero.agent.AutoscalingSpec"
+                      }
+                    ]
+                  }
+                }
+              }
             }
           ],
           "properties": {
+            "autoscaling": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/com.cloudzero.agent.AutoscalingSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "clusteredNode": {
+              "additionalProperties": false,
+              "properties": {
+                "image": {
+                  "$ref": "#/$defs/com.cloudzero.agent.image"
+                },
+                "resources": {
+                  "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+                },
+                "securityContext": {
+                  "$ref": "#/$defs/io.k8s.api.core.v1.PodSecurityContext"
+                }
+              },
+              "type": "object"
+            },
             "federatedNode": {
               "additionalProperties": false,
               "properties": {
@@ -5848,6 +5979,16 @@
         "webhookServer": {
           "additionalProperties": false,
           "properties": {
+            "autoscaling": {
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/com.cloudzero.agent.AutoscalingSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "backfill": {
               "additionalProperties": false,
               "properties": {
@@ -5925,6 +6066,9 @@
         },
         "annotations": {
           "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+        },
+        "autoscaling": {
+          "$ref": "#/$defs/com.cloudzero.agent.AutoscalingSpec"
         },
         "dns": {
           "$ref": "#/$defs/com.cloudzero.agent.dns"
@@ -6201,41 +6345,6 @@
                 }
               },
               "type": "object"
-            }
-          },
-          "type": "object"
-        },
-        "autoscaling": {
-          "additionalProperties": false,
-          "properties": {
-            "annotations": {
-              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
-            },
-            "enabled": {
-              "default": false,
-              "type": "boolean"
-            },
-            "maxReplicas": {
-              "default": 10,
-              "minimum": 1,
-              "type": "integer"
-            },
-            "minReplicas": {
-              "default": 2,
-              "minimum": 1,
-              "type": "integer"
-            },
-            "targetCPUUtilizationPercentage": {
-              "default": 80,
-              "maximum": 100,
-              "minimum": 1,
-              "type": ["integer", "null"]
-            },
-            "targetMemoryUtilizationPercentage": {
-              "default": 80,
-              "maximum": 100,
-              "minimum": 1,
-              "type": ["integer", "null"]
             }
           },
           "type": "object"
@@ -6657,6 +6766,7 @@
           "$ref": "#/$defs/io.k8s.api.core.v1.Affinity"
         },
         "agentMode": {
+          "deprecated": true,
           "type": ["boolean", "null"]
         },
         "annotations": {

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -93,6 +93,53 @@ $defs:
     type: string
     pattern: '^[0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))*$'
 
+  com.cloudzero.agent.AutoscalingSpec:
+    description: |
+      Horizontal Pod Autoscaler configuration specification.
+
+      This type defines the common structure for autoscaling configuration
+      used across multiple components. Component-specific autoscaling
+      configurations should reference this type and can extend it with
+      additional properties if needed.
+
+      For details, see the Kubernetes documentation on HPA:
+      https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    type: object
+    additionalProperties: false
+    properties:
+      enabled:
+        description: |
+          Whether to enable horizontal pod autoscaling.
+        type: boolean
+      minReplicas:
+        description: |
+          Minimum number of replicas.
+        type: integer
+        minimum: 1
+      maxReplicas:
+        description: |
+          Maximum number of replicas.
+        type: integer
+        minimum: 1
+      targetCPUUtilizationPercentage:
+        description: |
+          Target CPU utilization percentage for autoscaling.
+          Set to null to disable CPU-based scaling.
+        oneOf:
+          - type: integer
+            minimum: 1
+            maximum: 100
+          - type: "null"
+      targetMemoryUtilizationPercentage:
+        description: |
+          Target memory utilization percentage for autoscaling.
+          Set to null to disable memory-based scaling.
+        oneOf:
+          - type: integer
+            minimum: 1
+            maximum: 100
+          - type: "null"
+
   com.cloudzero.agent.PodDisruptionBudgetSpec:
     description: |
       A Pod Disruption Budget.
@@ -279,6 +326,15 @@ properties:
           replica settings.
         type: integer
         default: 3
+      autoscaling:
+        description: |
+          Default Horizontal Pod Autoscaler configuration to use across
+          components which support autoscaling. Component-specific autoscaling
+          settings will fall back to these defaults when not explicitly set.
+
+          For details, see the Kubernetes documentation on HPA:
+          https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+        $ref: "#/$defs/com.cloudzero.agent.AutoscalingSpec"
       securityContext:
         description: |
           Default security context for all pods. Component-specific security contexts
@@ -319,9 +375,8 @@ properties:
               - "server": Deploys Prometheus in server mode. This is the traditional Prometheus
                 deployment with full storage and query capabilities. Equivalent to
                 server.agentMode=false.
-              - "clustered": Uses Grafana Alloy instead of Prometheus for metrics collection.
-                Alloy provides better performance and native horizontal scalability. Equivalent
-                to alloy.enabled=true.
+              - "clustered": EXPERIMENTAL. Uses Grafana Alloy instead of Prometheus for metrics
+                collection. Alloy provides better performance and native horizontal scalability.
 
               If null (automatic mode), the mode will be derived from legacy configuration:
               - defaults.federation.enabled=true -> "federated"
@@ -355,6 +410,17 @@ properties:
               null, falls back to defaults.replicas.
             oneOf:
               - type: integer
+              - type: "null"
+          autoscaling:
+            description: |
+              Horizontal Pod Autoscaler configuration for the agent.
+              Only applies when components.agent.mode is set to "clustered".
+              If null, falls back to defaults.autoscaling.
+
+              For details, see the Kubernetes documentation on HPA:
+              https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+            oneOf:
+              - $ref: "#/$defs/com.cloudzero.agent.AutoscalingSpec"
               - type: "null"
           tolerations:
             description: |
@@ -397,6 +463,34 @@ properties:
                   For details, see the Kubernetes documentation on security contexts:
                   https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                 $ref: "#/$defs/io.k8s.api.core.v1.PodSecurityContext"
+          clusteredNode:
+            description: |
+              The agent clustered node component configuration for Alloy-based metrics collection.
+              Only applies when components.agent.mode is set to "clustered".
+            additionalProperties: false
+            type: object
+            properties:
+              image:
+                description: |
+                  Container image configuration for Grafana Alloy.
+                $ref: "#/$defs/com.cloudzero.agent.image"
+              resources:
+                description: |
+                  Resource requirements and limits for the Alloy container.
+
+                  Alloy has different performance characteristics than Prometheus and typically
+                  requires less resources for the same workload due to its more efficient design.
+
+                  For details, see the Kubernetes documentation on resource management:
+                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+              securityContext:
+                description: |
+                  Security context for the Alloy pods.
+
+                  For details, see the Kubernetes documentation on security contexts:
+                  https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                $ref: "#/$defs/io.k8s.api.core.v1.PodSecurityContext"
           reloader:
             description: |
               The agent configmap reloader component watches for configuration changes.
@@ -418,6 +512,15 @@ properties:
                   https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                 $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
         allOf:
+          # Conditional: Replicas constraint for non-clustered modes
+          #
+          # If mode is null (automatic) or one of ["federated", "agent",
+          # "server"], and replicas is explicitly set to an integer, then
+          # replicas must be 1.
+          #
+          # This ensures that non-clustered modes only support single-replica
+          # deployments, which is necessary because Prometheus can't really
+          # scale horizontally automatically.
           - if:
               anyOf:
                 - properties:
@@ -435,6 +538,55 @@ properties:
                 properties:
                   replicas:
                     const: 1
+
+          # Conditional: Autoscaling constraint for non-clustered modes
+          # If mode is null (automatic) or one of ["federated", "agent",
+          #
+          # "server"], then autoscaling must be either:
+          #
+          #   - null (disabled), OR
+          #   - an object with enabled: false (explicitly disabled)
+          #
+          # This prevents enabling autoscaling in non-clustered modes, as
+          # autoscaling only works with the "clustered" mode. Error message will
+          # indicate autoscaling.enabled must be false, not that mode must be
+          # clustered.
+          - if:
+              anyOf:
+                - properties:
+                    mode:
+                      type: "null"
+                - properties:
+                    mode:
+                      enum: ["federated", "agent", "server"]
+            then:
+              properties:
+                autoscaling:
+                  oneOf:
+                    - type: "null"
+                    - allOf:
+                        - $ref: "#/$defs/com.cloudzero.agent.AutoscalingSpec"
+                        - properties:
+                            enabled:
+                              const: false
+
+          # Conditional: Autoscaling allowed for clustered mode
+          #
+          # If mode is "clustered", then autoscaling can be:
+          #   - null (will fall back to defaults.autoscaling), OR
+          #   - a valid AutoscalingSpec object (can have enabled: true or false)
+          #
+          # This allows full autoscaling configuration only in clustered mode.
+          - if:
+              properties:
+                mode:
+                  const: clustered
+            then:
+              properties:
+                autoscaling:
+                  oneOf:
+                    - type: "null"
+                    - $ref: "#/$defs/com.cloudzero.agent.AutoscalingSpec"
 
       validator:
         description: |
@@ -678,6 +830,20 @@ properties:
         additionalProperties: false
         type: object
         properties:
+          autoscaling:
+            description: |
+              Horizontal Pod Autoscaler configuration for the webhook server.
+
+              When enabled, automatically scales the webhook server based on CPU and/or
+              memory utilization. This is particularly useful for high-churn clusters
+              with frequent resource creation/modification events.
+
+              If null, falls back to defaults.autoscaling. Individual properties
+              within this object will also fall back to defaults.autoscaling if not
+              explicitly set.
+            oneOf:
+              - $ref: "#/$defs/com.cloudzero.agent.AutoscalingSpec"
+              - type: "null"
           podDisruptionBudget:
             description: |
               Pod disruption budget configuration for the webhook server.
@@ -1006,80 +1172,6 @@ properties:
             items:
               type: object
 
-  alloy:
-    description: |
-      Grafana Alloy configuration settings.
-      This section contains all Alloy-specific configuration isolated from the
-      main agent configuration during the experimental phase.
-    type: object
-    additionalProperties: false
-    properties:
-      enabled:
-        description: |
-          Whether to use Grafana Alloy instead of Prometheus as the metrics
-          collector. When enabled, Alloy replaces Prometheus for metrics collection
-          and forwarding.
-        type: boolean
-        default: false
-      image:
-        description: |
-          Container image configuration for Grafana Alloy.
-        $ref: "#/$defs/com.cloudzero.agent.image"
-      autoscaling:
-        description: |
-          Horizontal Pod Autoscaler configuration for Alloy.
-          Only applies when alloy.enabled=true in non-federated mode.
-
-          For details, see the Kubernetes documentation on HPA:
-          https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
-        oneOf:
-          - type: object
-            additionalProperties: false
-            properties:
-              enabled:
-                description: |
-                  Whether to enable horizontal pod autoscaling.
-                type: boolean
-              minReplicas:
-                description: |
-                  Minimum number of replicas.
-                type: integer
-                minimum: 1
-              maxReplicas:
-                description: |
-                  Maximum number of replicas.
-                type: integer
-                minimum: 1
-              targetCPUUtilizationPercentage:
-                description: |
-                  Target CPU utilization percentage for autoscaling.
-                type: integer
-                minimum: 1
-                maximum: 100
-              targetMemoryUtilizationPercentage:
-                description: |
-                  Target memory utilization percentage for autoscaling.
-                type: integer
-                minimum: 1
-                maximum: 100
-          - type: "null"
-      resources:
-        description: |
-          Resource requirements and limits for the Alloy container.
-
-          Alloy has different performance characteristics than Prometheus and typically
-          requires less resources for the same workload due to its more efficient design.
-
-          For details, see the Kubernetes documentation on resource management:
-          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
-      config:
-        description: |
-          Advanced River configuration options. These settings allow fine-tuning
-          of Alloy's behavior beyond the standard configuration.
-        type: object
-        additionalProperties: true
-
   commonMetaLabels:
     $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
     title: Common labels applied to all resources
@@ -1402,53 +1494,6 @@ properties:
                   Whether to collect annotations from StatefulSets.
                 type: boolean
                 default: false
-      autoscaling:
-        description: |
-          Horizontal Pod Autoscaler configuration for the webhook server.
-
-          When enabled, automatically scales the webhook server based on CPU and/or
-          memory utilization. This is particularly useful for high-churn clusters
-          with frequent resource creation/modification events.
-        type: object
-        additionalProperties: false
-        properties:
-          enabled:
-            description: |
-              Whether to enable horizontal pod autoscaling for the webhook server.
-            type: boolean
-            default: false
-          annotations:
-            description: |
-              Additional annotations to add to the HPA resource.
-            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
-          minReplicas:
-            description: |
-              Minimum number of webhook server replicas.
-            type: integer
-            minimum: 1
-            default: 2
-          maxReplicas:
-            description: |
-              Maximum number of webhook server replicas.
-            type: integer
-            minimum: 1
-            default: 10
-          targetCPUUtilizationPercentage:
-            description: |
-              Target CPU utilization percentage for autoscaling.
-              Set to null to disable CPU-based scaling.
-            type: [integer, "null"]
-            minimum: 1
-            maximum: 100
-            default: 80
-          targetMemoryUtilizationPercentage:
-            description: |
-              Target memory utilization percentage for autoscaling.
-              Set to null to disable memory-based scaling.
-            type: [integer, "null"]
-            minimum: 1
-            maximum: 100
-            default: 80
       tls:
         description: |
           Configuration for TLS certificates used by the insights controller.
@@ -1865,7 +1910,10 @@ properties:
           Annotations to add to the server pods.
         $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
       agentMode:
+        deprecated: true
         description: |
+          This field is deprecated. Please use `components.agent.mode` instead.
+
           Whether the server is running in agent mode.
           If set (true or false) and components.agent.mode is not explicitly set, this is used to derive the mode.
           null means use components.agent.mode.
@@ -2273,3 +2321,46 @@ properties:
       between parent and child charts.
 
       For more information, see: https://helm.sh/docs/chart_template_guide/subcharts_and_globals/
+
+# Root-level conditional validations that span multiple properties
+allOf:
+  # Conditional: Federation mode constraint
+  #
+  # If defaults.federation.enabled is true, then components.agent.mode must be
+  # either null (automatic, which will resolve to "federated") or explicitly
+  # set to "federated". It cannot be set to "clustered", "agent", or "server".
+  #
+  # This ensures that when federation is enabled via defaults.federation.enabled,
+  # the mode is consistent with federation settings. When mode is null and
+  # defaults.federation.enabled is true, the helper function will automatically
+  # resolve the mode to "federated" for template rendering purposes.
+  #
+  # Note: This validation only triggers when defaults.federation.enabled is
+  # explicitly set to true. If it's null or not set, this validation does not apply.
+  - if:
+      allOf:
+        - properties:
+            defaults:
+              type: object
+              required:
+                - federation
+              properties:
+                federation:
+                  type: object
+                  required:
+                    - enabled
+                  properties:
+                    enabled:
+                      const: true
+    then:
+      properties:
+        components:
+          type: object
+          properties:
+            agent:
+              type: object
+              properties:
+                mode:
+                  oneOf:
+                    - type: "null"
+                    - const: federated

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -176,6 +176,25 @@ defaults:
   # Default number of replicas to use for components which support multiple
   # replicas. This can be overridden by component-specific replica settings.
   replicas: 3
+  # Default Horizontal Pod Autoscaler configuration to use across components
+  # which support autoscaling. Component-specific autoscaling settings will
+  # fall back to these defaults when not explicitly set.
+  #
+  # For details, see the Kubernetes documentation on HPA:
+  # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  autoscaling:
+    # Whether to enable horizontal pod autoscaling.
+    enabled: false
+    # Minimum number of replicas.
+    minReplicas: 1
+    # Maximum number of replicas.
+    maxReplicas: 10
+    # Target CPU utilization percentage for autoscaling.
+    # Set to null to disable CPU-based scaling.
+    targetCPUUtilizationPercentage: 80
+    # Target memory utilization percentage for autoscaling.
+    # Set to null to disable memory-based scaling.
+    targetMemoryUtilizationPercentage: 80
   # Default security context for all pods. Component-specific security contexts
   # will be merged with these defaults, with component settings taking precedence.
   #
@@ -204,21 +223,33 @@ components:
     # Valid values:
     #
     # - "agent": Deploys Prometheus in agent mode. This is optimized for remote write
-    #   scenarios and uses fewer resources. Equivalent to server.agentMode=true.
+    #   scenarios and uses fewer resources.
     #
     # - "server": Deploys Prometheus in server mode. This is the traditional Prometheus
-    #   deployment with full storage and query capabilities. Equivalent to
-    #   server.agentMode=false.
+    #   deployment with full storage and query capabilities.
     #
     # - "federated": Deploys the agent in federated mode as a DaemonSet with one pod
     #   per node. This is equivalent to setting defaults.federation.enabled to true.
     #   Uses Prometheus in server mode for metrics collection.
     #
-    # - "clustered": Uses Grafana Alloy instead of Prometheus for metrics collection.
-    #   Alloy provides better performance and native horizontal scalability.
+    # - "clustered": EXPERIMENTAL. Uses Grafana Alloy instead of Prometheus for
+    #   metrics collection. Alloy provides better performance and native
+    #   horizontal scalability.
     #
-    # - null means automatic mode (use legacy properties with default to agent).
+    # - null means automatic mode (currently defaults to "agent").
     mode: null
+
+    # Horizontal Pod Autoscaler configuration for the agent.
+    # Only applies when components.agent.mode is set to "clustered".
+    #
+    # HPA enables automatic scaling based on resource utilization,
+    # allowing the deployment to handle varying load efficiently.
+    #
+    # If null, falls back to defaults.autoscaling.
+    #
+    # For details, see the Kubernetes documentation on HPA:
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    autoscaling: null
 
     podDisruptionBudget:
       # enabled:
@@ -259,6 +290,31 @@ components:
         limits:
           memory: "1024Mi"
           cpu: "1000m"
+
+    # The agent clustered node component configuration.
+    # Only applies when components.agent.mode is set to "clustered".
+    clusteredNode:
+      # Container image configuration for Grafana Alloy.
+      image:
+        repository: docker.io/grafana/alloy
+        tag: v1.11.3
+
+      # Resource requirements and limits for the container.
+      #
+      # Alloy has different performance characteristics than Prometheus and
+      # typically requires less resources for the same workload due to its more
+      # efficient design.
+      #
+      # For details, see the Kubernetes documentation on resource management:
+      # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "50m"
+        limits:
+          memory: "512Mi"
+          cpu: "100m"
+
     # The agent configmap reloader component watches for configuration changes.
     reloader:
       # Security context for the agent configmap reloader container.
@@ -435,6 +491,15 @@ components:
   # Settings for the webhook server.
   webhookServer:
     replicas: null
+    # Horizontal Pod Autoscaler configuration for the webhook server.
+    #
+    # When enabled, automatically scales the webhook server based on CPU and/or
+    # memory utilization. This is particularly useful for high-churn clusters
+    # with frequent resource creation/modification events.
+    #
+    # For details, see the Kubernetes documentation on HPA:
+    # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+    autoscaling: null
     podDisruptionBudget:
       # enabled:
       # minAvailable:
@@ -581,52 +646,6 @@ prometheusConfig:
       scrapeInterval: 30s
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
     additionalScrapeJobs: []
-
-# EXPERIMENTAL Grafana Alloy configuration settings. This section contains all
-# Alloy-specific configuration isolated from the main agent configuration during
-# the experimental phase.
-alloy:
-  # Container image configuration for Grafana Alloy.
-  image:
-    repository: docker.io/grafana/alloy
-    tag: v1.11.3
-    # registry: docker.io
-    # pullPolicy: IfNotPresent
-
-  # Horizontal Pod Autoscaler configuration for Alloy.
-  # Only applies when alloy.enabled=true in non-federated mode.
-  #
-  # HPA enables automatic scaling based on resource utilization,
-  # allowing the deployment to handle varying load efficiently.
-  #
-  # For details, see the Kubernetes documentation on HPA:
-  # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
-  autoscaling:
-    # Whether to enable horizontal pod autoscaling.
-    enabled: true
-    # Minimum number of replicas.
-    minReplicas: 1
-    # Maximum number of replicas.
-    maxReplicas: 10
-    # Target CPU utilization percentage for autoscaling.
-    targetCPUUtilizationPercentage: 80
-    # Target memory utilization percentage for autoscaling (optional).
-    targetMemoryUtilizationPercentage: 80
-
-  # Resource requirements and limits for the Alloy container.
-  #
-  # Alloy has different performance characteristics than Prometheus and typically
-  # requires less resources for the same workload due to its more efficient design.
-  #
-  # For details, see the Kubernetes documentation on resource management:
-  # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "50m"
-    limits:
-      memory: "512Mi"
-      cpu: "100m"
 
 # General server settings that apply to both the prometheus agent server and the webhook server
 serverConfig:
@@ -1050,29 +1069,6 @@ insightsController:
     # For additional information, see:
     # https://github.com/Cloudzero/cloudzero-charts/blob/develop/charts/cloudzero-agent/docs/istio.md
     suppressIstioAnnotations: false
-  # Horizontal Pod Autoscaler configuration for the webhook server.
-  #
-  # EXPERIMENTAL: These settings are experimental and may move to the
-  # components.webhookServer section or change in a future release.
-  #
-  # When enabled, automatically scales the webhook server based on CPU and/or
-  # memory utilization. This is particularly useful for high-churn clusters
-  # with frequent resource creation/modification events.
-  autoscaling:
-    # Whether to enable horizontal pod autoscaling for the webhook server.
-    enabled: false
-    # Additional annotations to add to the HPA resource.
-    annotations: {}
-    # Minimum number of webhook server replicas.
-    minReplicas: 2
-    # Maximum number of webhook server replicas.
-    maxReplicas: 10
-    # Target CPU utilization percentage for autoscaling.
-    # Set to null to disable CPU-based scaling.
-    targetCPUUtilizationPercentage: 80
-    # Target memory utilization percentage for autoscaling.
-    # Set to null to disable memory-based scaling.
-    targetMemoryUtilizationPercentage: 80
   # Additional volume mounts to add to the insights controller pods.
   volumeMounts: []
   # Additional volumes to add to the insights controller pods.

--- a/tests/helm/schema/alloy.autoscaling.enabled.pass.yaml
+++ b/tests/helm/schema/alloy.autoscaling.enabled.pass.yaml
@@ -1,10 +1,11 @@
-# Valid: Autoscaling enabled with Alloy
+# Valid: Autoscaling enabled with Alloy (clustered mode)
 apiKey: "test-key-123"
 existingSecretName: null
-alloy:
-  enabled: true
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 10
-    targetCPUUtilizationPercentage: 70
+components:
+  agent:
+    mode: clustered
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 70

--- a/tests/helm/schema/alloy.enabled.enabled.pass.yaml
+++ b/tests/helm/schema/alloy.enabled.enabled.pass.yaml
@@ -1,5 +1,6 @@
-# Valid: Alloy enabled with standard configuration
+# Valid: Alloy enabled with standard configuration (clustered mode)
 apiKey: "test-key-123"
 existingSecretName: null
-alloy:
-  enabled: true
+components:
+  agent:
+    mode: clustered

--- a/tests/helm/schema/alloy.federated-mode.pass.yaml
+++ b/tests/helm/schema/alloy.federated-mode.pass.yaml
@@ -1,9 +1,12 @@
-# Valid: Alloy in federated mode with clustering
+# Valid: defaults.federation.enabled=true with components.agent.mode=null
+# When mode is null and defaults.federation.enabled is true, the helper function
+# will automatically resolve the mode to "federated" for template rendering purposes.
 apiKey: "test-key-123"
 existingSecretName: null
 clusterName: "production-cluster"
 defaults:
   federation:
     enabled: true
-alloy:
-  enabled: true
+components:
+  agent:
+    mode: null

--- a/tests/helm/schema/alloy.image.custom.pass.yaml
+++ b/tests/helm/schema/alloy.image.custom.pass.yaml
@@ -1,9 +1,14 @@
-# Valid: Custom default Alloy image
+# Valid: Custom default Alloy image (clustered mode)
 apiKey: "test-key-123"
 existingSecretName: null
-alloy:
-  enabled: true
-  image:
-    repository: ghcr.io/grafana/alloy
-    tag: latest
-    pullPolicy: Never
+defaults:
+  federation:
+    enabled: false
+components:
+  agent:
+    mode: clustered
+    clusteredNode:
+      image:
+        repository: ghcr.io/grafana/alloy
+        tag: latest
+        pullPolicy: Never

--- a/tests/helm/schema/alloy.image.repository-override.pass.yaml
+++ b/tests/helm/schema/alloy.image.repository-override.pass.yaml
@@ -1,9 +1,14 @@
-# Valid: Custom Alloy image with registry override
+# Valid: Custom Alloy image with registry override (clustered mode)
 apiKey: "test-key-123"
 existingSecretName: null
-alloy:
-  enabled: true
-  image:
-    repository: custom.registry.io/custom/alloy
-    tag: v2.0.0
-    pullPolicy: Always
+defaults:
+  federation:
+    enabled: false
+components:
+  agent:
+    mode: clustered
+    clusteredNode:
+      image:
+        repository: custom.registry.io/custom/alloy
+        tag: v2.0.0
+        pullPolicy: Always

--- a/tests/helm/schema/alloy.with-hpa-no-federation.pass.yaml
+++ b/tests/helm/schema/alloy.with-hpa-no-federation.pass.yaml
@@ -1,14 +1,15 @@
-# Valid: Alloy with HPA in non-federated mode
+# Valid: Alloy with HPA in non-federated mode (clustered mode)
 apiKey: "test-key-123"
 existingSecretName: null
 defaults:
   federation:
     enabled: false
-alloy:
-  enabled: true
-  autoscaling:
-    enabled: true
-    minReplicas: 3
-    maxReplicas: 20
-    targetCPUUtilizationPercentage: 80
-    targetMemoryUtilizationPercentage: 85
+components:
+  agent:
+    mode: clustered
+    autoscaling:
+      enabled: true
+      minReplicas: 3
+      maxReplicas: 20
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 85

--- a/tests/helm/schema/components.agent.autoscaling.agent-mode-invalid.fail.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.agent-mode-invalid.fail.yaml
@@ -1,6 +1,7 @@
-# Valid: Alloy explicitly disabled (Prometheus agent mode)
 apiKey: "test-key-123"
 existingSecretName: null
 components:
   agent:
     mode: agent
+    autoscaling:
+      enabled: true

--- a/tests/helm/schema/components.agent.autoscaling.clustered-enabled.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.clustered-enabled.pass.yaml
@@ -1,4 +1,3 @@
-# Valid: CPU target at boundary (1%) in clustered mode
 apiKey: "test-key-123"
 existingSecretName: null
 defaults:
@@ -9,6 +8,5 @@ components:
     mode: clustered
     autoscaling:
       enabled: true
-      minReplicas: 2
+      minReplicas: 1
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 1

--- a/tests/helm/schema/components.agent.autoscaling.disabled-any-mode.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.disabled-any-mode.pass.yaml
@@ -1,6 +1,10 @@
-# Valid: Alloy explicitly disabled (Prometheus agent mode)
 apiKey: "test-key-123"
 existingSecretName: null
+defaults:
+  federation:
+    enabled: false
 components:
   agent:
     mode: agent
+    autoscaling:
+      enabled: false

--- a/tests/helm/schema/components.agent.autoscaling.fallback-to-defaults.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.fallback-to-defaults.pass.yaml
@@ -1,0 +1,14 @@
+# Valid: Agent autoscaling null falls back to defaults
+apiKey: "test-key-123"
+existingSecretName: null
+defaults:
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 15
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+components:
+  agent:
+    mode: clustered
+    autoscaling: null

--- a/tests/helm/schema/components.agent.autoscaling.federated-mode-disabled.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.federated-mode-disabled.pass.yaml
@@ -1,0 +1,9 @@
+# Valid: autoscaling.enabled: false with mode: federated should work
+# This test verifies that when mode is federated, autoscaling.enabled can be false.
+apiKey: "test-key-123"
+existingSecretName: null
+components:
+  agent:
+    mode: federated
+    autoscaling:
+      enabled: false

--- a/tests/helm/schema/components.agent.autoscaling.federated-mode-invalid.fail.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.federated-mode-invalid.fail.yaml
@@ -1,10 +1,7 @@
-# Invalid: minReplicas must be >= 1
 apiKey: "test-key-123"
 existingSecretName: null
 components:
   agent:
-    mode: clustered
+    mode: federated
     autoscaling:
       enabled: true
-      minReplicas: 0
-      maxReplicas: 10

--- a/tests/helm/schema/components.agent.autoscaling.federated-mode-null.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.federated-mode-null.pass.yaml
@@ -1,0 +1,9 @@
+# Valid: autoscaling: null with mode: federated should work
+# This test verifies that when mode is federated, autoscaling can be null,
+# which will fall back to defaults.autoscaling.
+apiKey: "test-key-123"
+existingSecretName: null
+components:
+  agent:
+    mode: federated
+    autoscaling: null

--- a/tests/helm/schema/components.agent.autoscaling.null-any-mode.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.null-any-mode.pass.yaml
@@ -1,6 +1,10 @@
-# Valid: Alloy explicitly disabled (Prometheus agent mode)
 apiKey: "test-key-123"
 existingSecretName: null
+defaults:
+  federation:
+    enabled: false
 components:
   agent:
     mode: agent
+    autoscaling:
+      enabled: false

--- a/tests/helm/schema/components.agent.autoscaling.null-mode-disabled.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.null-mode-disabled.pass.yaml
@@ -1,0 +1,9 @@
+# Valid: autoscaling.enabled: false with mode: null (automatic) should work
+# This test verifies that when mode is null (automatic), autoscaling.enabled can be false.
+apiKey: "test-key-123"
+existingSecretName: null
+components:
+  agent:
+    mode: null
+    autoscaling:
+      enabled: false

--- a/tests/helm/schema/components.agent.autoscaling.null-mode-invalid.fail.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.null-mode-invalid.fail.yaml
@@ -1,0 +1,12 @@
+# Invalid: autoscaling.enabled: true is not allowed with mode: null (automatic)
+# This test verifies that when mode is null (automatic), autoscaling.enabled must be false
+# or autoscaling must be null.
+#
+# Expected: Should fail with error about autoscaling.enabled, not about mode
+apiKey: "test-key-123"
+existingSecretName: null
+components:
+  agent:
+    mode: null
+    autoscaling:
+      enabled: true

--- a/tests/helm/schema/components.agent.autoscaling.null-mode-null.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.null-mode-null.pass.yaml
@@ -1,0 +1,9 @@
+# Valid: autoscaling: null with mode: null (automatic) should work
+# This test verifies that when mode is null (automatic), autoscaling can be null,
+# which will fall back to defaults.autoscaling.
+apiKey: "test-key-123"
+existingSecretName: null
+components:
+  agent:
+    mode: null
+    autoscaling: null

--- a/tests/helm/schema/components.agent.autoscaling.null-with-federated-mode.fail.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.null-with-federated-mode.fail.yaml
@@ -1,0 +1,12 @@
+# Invalid: autoscaling.enabled: true is not allowed with mode: federated
+# This test verifies that when mode is not "clustered", autoscaling.enabled must be false
+# or autoscaling must be null.
+#
+# Expected: Should fail with error about autoscaling.enabled, not about mode
+apiKey: "test-key-123"
+existingSecretName: null
+components:
+  agent:
+    mode: federated
+    autoscaling:
+      enabled: true

--- a/tests/helm/schema/components.agent.autoscaling.partial-fallback.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.partial-fallback.pass.yaml
@@ -1,0 +1,20 @@
+# Valid: Agent autoscaling with partial values falls back to defaults for missing properties
+apiKey: "test-key-123"
+existingSecretName: null
+defaults:
+  federation:
+    enabled: false
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+components:
+  agent:
+    mode: clustered
+    autoscaling:
+      enabled: true
+      minReplicas: 5
+      # maxReplicas, targetCPUUtilizationPercentage, targetMemoryUtilizationPercentage
+      # will fall back to defaults

--- a/tests/helm/schema/components.agent.autoscaling.server-mode-disabled.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.server-mode-disabled.pass.yaml
@@ -1,0 +1,12 @@
+# Valid: autoscaling.enabled: false with mode: server should work
+# This test verifies that when mode is server, autoscaling.enabled can be false.
+apiKey: "test-key-123"
+existingSecretName: null
+defaults:
+  federation:
+    enabled: false
+components:
+  agent:
+    mode: server
+    autoscaling:
+      enabled: false

--- a/tests/helm/schema/components.agent.autoscaling.server-mode-invalid.fail.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.server-mode-invalid.fail.yaml
@@ -1,0 +1,5 @@
+components:
+  agent:
+    mode: server
+    autoscaling:
+      enabled: true

--- a/tests/helm/schema/components.agent.autoscaling.server-mode-null.pass.yaml
+++ b/tests/helm/schema/components.agent.autoscaling.server-mode-null.pass.yaml
@@ -1,0 +1,9 @@
+# Valid: autoscaling: null with mode: server should work
+# This test verifies that when mode is server, autoscaling can be null,
+# which will fall back to defaults.autoscaling.
+apiKey: "test-key-123"
+existingSecretName: null
+components:
+  agent:
+    mode: server
+    autoscaling: null

--- a/tests/helm/schema/components.agent.mode.federation-conflict.fail.yaml
+++ b/tests/helm/schema/components.agent.mode.federation-conflict.fail.yaml
@@ -1,0 +1,11 @@
+# Invalid: defaults.federation.enabled=true conflicts with components.agent.mode=clustered
+# When defaults.federation.enabled is true, components.agent.mode must be null or "federated"
+apiKey: "test-key-123"
+existingSecretName: null
+clusterName: "production-cluster"
+defaults:
+  federation:
+    enabled: true
+components:
+  agent:
+    mode: clustered

--- a/tests/helm/schema/defaults.autoscaling.null-metrics.pass.yaml
+++ b/tests/helm/schema/defaults.autoscaling.null-metrics.pass.yaml
@@ -1,0 +1,14 @@
+# Valid: Defaults autoscaling with null metrics (disabled)
+apiKey: "test-key-123"
+existingSecretName: null
+defaults:
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: null
+    targetMemoryUtilizationPercentage: null
+components:
+  agent:
+    autoscaling:
+      enabled: false

--- a/tests/helm/schema/defaults.autoscaling.valid.pass.yaml
+++ b/tests/helm/schema/defaults.autoscaling.valid.pass.yaml
@@ -1,0 +1,14 @@
+# Valid: Defaults autoscaling configuration
+apiKey: "test-key-123"
+existingSecretName: null
+defaults:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 75
+    targetMemoryUtilizationPercentage: 85
+components:
+  agent:
+    autoscaling:
+      enabled: false

--- a/tests/helm/schema/insightsController.autoscaling.fallback-to-defaults.pass.yaml
+++ b/tests/helm/schema/insightsController.autoscaling.fallback-to-defaults.pass.yaml
@@ -1,0 +1,18 @@
+# Valid: Webhook autoscaling null falls back to defaults
+apiKey: "test-key-123"
+existingSecretName: null
+defaults:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+components:
+  agent:
+    autoscaling:
+      enabled: false
+  webhookServer:
+    autoscaling: null
+insightsController:
+  enabled: true

--- a/tests/helm/schema/insightsController.autoscaling.partial-fallback.pass.yaml
+++ b/tests/helm/schema/insightsController.autoscaling.partial-fallback.pass.yaml
@@ -1,0 +1,22 @@
+# Valid: Webhook autoscaling with partial values falls back to defaults for missing properties
+apiKey: "test-key-123"
+existingSecretName: null
+defaults:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
+components:
+  agent:
+    autoscaling:
+      enabled: false
+  webhookServer:
+    autoscaling:
+      enabled: true
+      minReplicas: 3
+      # maxReplicas, targetCPUUtilizationPercentage, targetMemoryUtilizationPercentage
+      # will fall back to defaults
+insightsController:
+  enabled: true

--- a/tests/helm/schema/webhook.autoscaling.both-metrics.pass.yaml
+++ b/tests/helm/schema/webhook.autoscaling.both-metrics.pass.yaml
@@ -1,11 +1,16 @@
 # Valid: Both CPU and memory targets configured
 apiKey: "test-key-123"
 existingSecretName: null
+components:
+  agent:
+    autoscaling:
+      enabled: false
+  webhookServer:
+    autoscaling:
+      enabled: true
+      minReplicas: 3
+      maxReplicas: 15
+      targetCPUUtilizationPercentage: 75
+      targetMemoryUtilizationPercentage: 80
 insightsController:
   enabled: true
-  autoscaling:
-    enabled: true
-    minReplicas: 3
-    maxReplicas: 15
-    targetCPUUtilizationPercentage: 75
-    targetMemoryUtilizationPercentage: 80

--- a/tests/helm/schema/webhook.autoscaling.enabled.pass.yaml
+++ b/tests/helm/schema/webhook.autoscaling.enabled.pass.yaml
@@ -1,10 +1,15 @@
 # Valid: Autoscaling enabled with webhook server
 apiKey: "test-key-123"
 existingSecretName: null
+components:
+  agent:
+    autoscaling:
+      enabled: false
+  webhookServer:
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 70
 insightsController:
   enabled: true
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 10
-    targetCPUUtilizationPercentage: 70

--- a/tests/helm/schema/webhook.autoscaling.memory-only.pass.yaml
+++ b/tests/helm/schema/webhook.autoscaling.memory-only.pass.yaml
@@ -1,11 +1,16 @@
 # Valid: Memory target only (CPU explicitly null)
 apiKey: "test-key-123"
 existingSecretName: null
+components:
+  agent:
+    autoscaling:
+      enabled: false
+  webhookServer:
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: null
+      targetMemoryUtilizationPercentage: 85
 insightsController:
   enabled: true
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 10
-    targetCPUUtilizationPercentage: null
-    targetMemoryUtilizationPercentage: 85

--- a/tests/helm/schema/webhook.autoscaling.targetCPU-boundary.pass.yaml
+++ b/tests/helm/schema/webhook.autoscaling.targetCPU-boundary.pass.yaml
@@ -1,10 +1,15 @@
 # Valid: CPU target at boundary (1%)
 apiKey: "test-key-123"
 existingSecretName: null
+components:
+  agent:
+    autoscaling:
+      enabled: false
+  webhookServer:
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 1
 insightsController:
   enabled: true
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 10
-    targetCPUUtilizationPercentage: 1

--- a/tests/helm/schema/webhook.autoscaling.targetCPU-invalid.fail.yaml
+++ b/tests/helm/schema/webhook.autoscaling.targetCPU-invalid.fail.yaml
@@ -1,10 +1,15 @@
 # Invalid: CPU target must be <= 100
 apiKey: "test-key-123"
 existingSecretName: null
+components:
+  agent:
+    autoscaling:
+      enabled: false
+  webhookServer:
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 101
 insightsController:
   enabled: true
-  autoscaling:
-    enabled: true
-    minReplicas: 2
-    maxReplicas: 10
-    targetCPUUtilizationPercentage: 101

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -817,29 +817,24 @@ data:
             cpu: ""
             memory: ""
       tolerations: []
-    alloy:
-      autoscaling:
-        enabled: true
-        maxReplicas: 10
-        minReplicas: 1
-        targetCPUUtilizationPercentage: 80
-        targetMemoryUtilizationPercentage: 80
-      image:
-        repository: docker.io/grafana/alloy
-        tag: v1.11.3
-      resources:
-        limits:
-          cpu: 100m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 256Mi
     apiKey: '***'
     cloudAccountId: "1234567890"
     clusterName: alloy-test-cluster
     commonMetaLabels: {}
     components:
       agent:
+        autoscaling: null
+        clusteredNode:
+          image:
+            repository: docker.io/grafana/alloy
+            tag: v1.11.3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 256Mi
         federatedNode:
           resources:
             limits:
@@ -945,6 +940,7 @@ data:
             cpu: 50m
             memory: 64Mi
       webhookServer:
+        autoscaling: null
         backfill:
           resources:
             limits:
@@ -983,6 +979,12 @@ data:
     defaults:
       affinity: {}
       annotations: {}
+      autoscaling:
+        enabled: false
+        maxReplicas: 10
+        minReplicas: 1
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
       dns:
         config: {}
         policy: null
@@ -1071,13 +1073,6 @@ data:
           nodes: false
           pods: true
           statefulsets: false
-      autoscaling:
-        annotations: {}
-        enabled: false
-        maxReplicas: 10
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
-        targetMemoryUtilizationPercentage: 80
       configurationMountPath: null
       enabled: true
       labels:
@@ -2777,63 +2772,6 @@ spec:
         - name: cloudzero-api-key
           secret:
             secretName: cz-agent-api-key
----
-# Source: cloudzero-agent/templates/agent-hpa.yaml
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: cz-agent-cz-server
-  namespace: cz-agent
-  labels:
-    app.kubernetes.io/component: server
-    app.kubernetes.io/instance: cz-agent
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
-    app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v2.55.1
-    helm.sh/chart: cloudzero-agent-1.1.0-dev
-  
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: cz-agent-cz-server
-  minReplicas: 1
-  maxReplicas: 10
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 80
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: 300
-      policies:
-      - type: Percent
-        value: 50
-        periodSeconds: 60
-      - type: Pods
-        value: 2
-        periodSeconds: 60
-      selectPolicy: Min
-    scaleUp:
-      stabilizationWindowSeconds: 0
-      policies:
-      - type: Percent
-        value: 100
-        periodSeconds: 30
-      - type: Pods
-        value: 4
-        periodSeconds: 30
-      selectPolicy: Max
 ---
 # Source: cloudzero-agent/templates/backfill-job.yaml
 apiVersion: batch/v1

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -778,29 +778,24 @@ data:
             cpu: ""
             memory: ""
       tolerations: []
-    alloy:
-      autoscaling:
-        enabled: true
-        maxReplicas: 10
-        minReplicas: 1
-        targetCPUUtilizationPercentage: 80
-        targetMemoryUtilizationPercentage: 80
-      image:
-        repository: docker.io/grafana/alloy
-        tag: v1.11.3
-      resources:
-        limits:
-          cpu: 100m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 256Mi
     apiKey: '***'
     cloudAccountId: "1234567890"
     clusterName: my-cluster
     commonMetaLabels: {}
     components:
       agent:
+        autoscaling: null
+        clusteredNode:
+          image:
+            repository: docker.io/grafana/alloy
+            tag: v1.11.3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 256Mi
         federatedNode:
           resources:
             limits:
@@ -905,6 +900,7 @@ data:
             cpu: 50m
             memory: 64Mi
       webhookServer:
+        autoscaling: null
         backfill:
           resources:
             limits:
@@ -943,6 +939,12 @@ data:
     defaults:
       affinity: {}
       annotations: {}
+      autoscaling:
+        enabled: false
+        maxReplicas: 10
+        minReplicas: 1
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
       dns:
         config: {}
         policy: null
@@ -1031,13 +1033,6 @@ data:
           nodes: false
           pods: true
           statefulsets: false
-      autoscaling:
-        annotations: {}
-        enabled: false
-        maxReplicas: 10
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
-        targetMemoryUtilizationPercentage: 80
       configurationMountPath: null
       enabled: true
       labels:

--- a/tests/helm/template/federated-overrides.yml
+++ b/tests/helm/template/federated-overrides.yml
@@ -6,7 +6,6 @@ apiKey: "not-a-real-api-key"
 # For testing only, you should never use this property in production.
 jobConfigID: "DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E"
 
-# Use new mode property - equivalent to defaults.federation.enabled=true
 components:
   agent:
     mode: federated

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -847,29 +847,24 @@ data:
             cpu: ""
             memory: ""
       tolerations: []
-    alloy:
-      autoscaling:
-        enabled: true
-        maxReplicas: 10
-        minReplicas: 1
-        targetCPUUtilizationPercentage: 80
-        targetMemoryUtilizationPercentage: 80
-      image:
-        repository: docker.io/grafana/alloy
-        tag: v1.11.3
-      resources:
-        limits:
-          cpu: 100m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 256Mi
     apiKey: '***'
     cloudAccountId: "1234567890"
     clusterName: my-cluster
     commonMetaLabels: {}
     components:
       agent:
+        autoscaling: null
+        clusteredNode:
+          image:
+            repository: docker.io/grafana/alloy
+            tag: v1.11.3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 256Mi
         federatedNode:
           resources:
             limits:
@@ -974,6 +969,7 @@ data:
             cpu: 50m
             memory: 64Mi
       webhookServer:
+        autoscaling: null
         backfill:
           resources:
             limits:
@@ -1012,6 +1008,12 @@ data:
     defaults:
       affinity: {}
       annotations: {}
+      autoscaling:
+        enabled: false
+        maxReplicas: 10
+        minReplicas: 1
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
       dns:
         config: {}
         policy: null
@@ -1100,13 +1102,6 @@ data:
           nodes: false
           pods: true
           statefulsets: false
-      autoscaling:
-        annotations: {}
-        enabled: false
-        maxReplicas: 10
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
-        targetMemoryUtilizationPercentage: 80
       configurationMountPath: null
       enabled: true
       labels:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -794,29 +794,24 @@ data:
             cpu: ""
             memory: ""
       tolerations: []
-    alloy:
-      autoscaling:
-        enabled: true
-        maxReplicas: 10
-        minReplicas: 1
-        targetCPUUtilizationPercentage: 80
-        targetMemoryUtilizationPercentage: 80
-      image:
-        repository: docker.io/grafana/alloy
-        tag: v1.11.3
-      resources:
-        limits:
-          cpu: 100m
-          memory: 512Mi
-        requests:
-          cpu: 50m
-          memory: 256Mi
     apiKey: '***'
     cloudAccountId: "1234567890"
     clusterName: my-cluster
     commonMetaLabels: {}
     components:
       agent:
+        autoscaling: null
+        clusteredNode:
+          image:
+            repository: docker.io/grafana/alloy
+            tag: v1.11.3
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 256Mi
         federatedNode:
           resources:
             limits:
@@ -921,6 +916,7 @@ data:
             cpu: 50m
             memory: 64Mi
       webhookServer:
+        autoscaling: null
         backfill:
           resources:
             limits:
@@ -959,6 +955,12 @@ data:
     defaults:
       affinity: {}
       annotations: {}
+      autoscaling:
+        enabled: false
+        maxReplicas: 10
+        minReplicas: 1
+        targetCPUUtilizationPercentage: 80
+        targetMemoryUtilizationPercentage: 80
       dns:
         config: {}
         policy: null
@@ -1047,13 +1049,6 @@ data:
           nodes: false
           pods: true
           statefulsets: false
-      autoscaling:
-        annotations: {}
-        enabled: false
-        maxReplicas: 10
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
-        targetMemoryUtilizationPercentage: 80
       configurationMountPath: null
       enabled: true
       labels:


### PR DESCRIPTION
Consolidates all Alloy-related configuration under the components.agent section and adds schema validation to ensure autoscaling can only be enabled in clustered mode.

## Why

The Alloy configuration was previously scattered across a top-level `alloy` section and component-specific settings. This made it difficult to understand the relationship between Alloy configuration and the agent component. Additionally, autoscaling should only be available when using clustered mode (Alloy), but there was no validation to enforce this.

## What

### Configuration Reorganization

- **Moved `alloy.autoscaling` → `components.agent.autoscaling`**
  - All HPA configuration now lives under the agent component
  - Maintains same structure: enabled, minReplicas, maxReplicas, targetCPUUtilizationPercentage, targetMemoryUtilizationPercentage

- **Moved `alloy.image` → `components.agent.clusteredNode.image`**
  - Image configuration now part of the clustered node component
  - Follows the same pattern as `federatedNode` for consistency

- **Moved `alloy.resources` → `components.agent.clusteredNode.resources`**
  - Resource requirements now part of the clustered node component
  - Updated default values to match Alloy's lower resource requirements (256Mi/50m requests, 512Mi/100m limits)

- **Removed top-level `alloy` section**
  - All Alloy configuration is now consolidated under `components.agent.clusteredNode`
  - Eliminates redundant configuration structure

### Schema Validation

- **Added validation: autoscaling.enabled=true requires mode=clustered**
  - Schema validation ensures autoscaling can only be enabled when `components.agent.mode` is set to "clustered"
  - Prevents invalid configurations that would not work correctly

- **Added `clusteredNode` section to `components.agent`**
  - New section for Alloy-specific configuration
  - Includes: image, resources, securityContext
  - Only applies when `components.agent.mode` is "clustered"

- **Marked `server.agentMode` as deprecated**
  - Added deprecation notice pointing to `components.agent.mode`
  - Maintains backward compatibility for legacy configurations

### Template Updates

- **agent-hpa.yaml**: Updated to use `components.agent.autoscaling.*`
- **agent-deploy.yaml**: Updated to use `components.agent.clusteredNode.resources`
- **_helpers.tpl**: Updated `agentCollectorImage` helper to use `components.agent.clusteredNode.image`

### Testing

- **Updated all test files** to use new configuration paths
  - `alloy_hpa_test.yaml`: Updated to `components.agent.autoscaling.*`
  - `alloy_image_configuration_test.yaml`: Updated to `components.agent.clusteredNode.image`
  - `alloy_resources_test.yaml`: Updated to `components.agent.clusteredNode.resources`
  - Fixed tests to properly disable autoscaling when testing non-clustered modes

- **Created schema validation tests** for autoscaling validation
  - `components.agent.autoscaling.clustered-enabled.pass.yaml`: Valid configuration
  - `components.agent.autoscaling.agent-mode-invalid.fail.yaml`: Invalid
    - autoscaling enabled with agent mode
  - `components.agent.autoscaling.federated-mode-invalid.fail.yaml`: Invalid - autoscaling enabled with federated mode
  - `components.agent.autoscaling.server-mode-invalid.fail.yaml`: Invalid
    - autoscaling enabled with server mode
  - `components.agent.autoscaling.disabled-any-mode.pass.yaml`: Valid
    - autoscaling disabled with any mode
  - `components.agent.autoscaling.null-any-mode.pass.yaml`: Valid
    - autoscaling null with any mode

## Migration

Users with existing configurations using `alloy.*` properties should migrate to the new paths:

- `alloy.autoscaling.*` → `components.agent.autoscaling.*`
- `alloy.image.*` → `components.agent.clusteredNode.image.*`
- `alloy.resources.*` → `components.agent.clusteredNode.resources.*`

The top-level `alloy` section should be removed from values files.

# Why?

> This awesome thing improves my smile brightness

# What

> Outline the actions you took to achieve a brighter smile

# How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile
