### PR TITLE
CP-35429: refactor label/annotation system

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -337,6 +337,14 @@ components:
   # The validator component performs validation checks and notifies the platform
   # of installation status changes.
   validator:
+    # Annotations to add to the validator component.
+    #
+    # These annotations are merged with defaults.annotations.
+    annotations: {}
+    # Labels to add to the validator component.
+    #
+    # These labels are merged with defaults.labels.
+    labels: {}
     # Resource requirements and limits for the validator component.
     #
     # For details, see the Kubernetes documentation on resource management:
@@ -405,6 +413,14 @@ components:
       labels: {}
     # The init cert job component initializes TLS certificates.
     initCert:
+      # Annotations to add to the init cert job component.
+      #
+      # These annotations are merged with defaults.annotations.
+      annotations: {}
+      # Labels to add to the init cert job component.
+      #
+      # These labels are merged with defaults.labels.
+      labels: {}
       # Resource requirements and limits for the init cert job component.
       #
       # For details, see the Kubernetes documentation on resource management:
@@ -450,7 +466,14 @@ components:
       # minAvailable:
       # maxUnavailable:
     tolerations: []
+    # Annotations to add to the aggregator component.
+    #
+    # These annotations are merged with defaults.annotations.
     annotations: {}
+    # Labels to add to the aggregator component.
+    #
+    # These labels are merged with defaults.labels.
+    labels: {}
     # Security context for the aggregator pods.
     #
     # For details, see the Kubernetes documentation on security contexts:
@@ -504,6 +527,14 @@ components:
       # enabled:
       # minAvailable:
       # maxUnavailable:
+    # Annotations to add to the webhook server component.
+    #
+    # These annotations are merged with defaults.annotations.
+    annotations: {}
+    # Labels to add to the webhook server component.
+    #
+    # These labels are merged with defaults.labels.
+    labels: {}
     # Security context for the webhook server pods.
     #
     # For details, see the Kubernetes documentation on security contexts:

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -255,6 +255,26 @@ components:
       # enabled:
       # minAvailable:
       # maxUnavailable:
+    # Annotations to add to the agent component.
+    #
+    # These annotations are merged with defaults.annotations and apply to
+    # parent resources (Deployment/DaemonSet) and pods.
+    annotations: {}
+    # Labels to add to the agent component.
+    #
+    # These labels are merged with defaults.labels and apply to parent
+    # resources (Deployment/DaemonSet) and pods.
+    labels: {}
+    # Pod-specific annotations that apply ONLY to pod templates.
+    #
+    # These annotations are merged after component annotations and only
+    # appear in pod metadata, not on parent resources.
+    podAnnotations: {}
+    # Pod-specific labels that apply ONLY to pod templates.
+    #
+    # These labels are merged after component labels with highest priority
+    # and only appear in pod metadata, not on parent resources.
+    podLabels: {}
     # Security context for the agent pods.
     #
     # For details, see the Kubernetes documentation on security contexts:
@@ -274,6 +294,26 @@ components:
 
     # The agent federated node component runs on each node for federation.
     federatedNode:
+      # Annotations to add to the agent federated node component.
+      #
+      # These annotations are merged with defaults.annotations and
+      # components.agent.annotations, applying to the DaemonSet and pods.
+      annotations: {}
+      # Labels to add to the agent federated node component.
+      #
+      # These labels are merged with defaults.labels and components.agent.labels,
+      # applying to the DaemonSet and pods.
+      labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after federated node annotations and only
+      # appear in pod metadata, not on the DaemonSet.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after federated node labels with highest priority
+      # and only appear in pod metadata, not on the DaemonSet.
+      podLabels: {}
       # Security context for the agent federated node pods.
       #
       # For details, see the Kubernetes documentation on security contexts:
@@ -379,12 +419,24 @@ components:
       securityContext: {}
       # Annotations to add to the config loader job.
       #
-      # These annotations are merged with defaults.annotations.
+      # These annotations are merged with defaults.annotations and apply to
+      # the Job and pods.
       annotations: {}
       # Labels to add to the config loader job.
       #
-      # These labels are merged with defaults.labels.
+      # These labels are merged with defaults.labels and apply to the
+      # Job and pods.
       labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after component annotations and only
+      # appear in pod metadata, not on the Job.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after component labels with highest priority
+      # and only appear in pod metadata, not on the Job.
+      podLabels: {}
     # The helmless job component generates configuration without Helm.
     helmless:
       # Resource requirements and limits for the helmless job component.
@@ -405,22 +457,46 @@ components:
       securityContext: {}
       # Annotations to add to the helmless job.
       #
-      # These annotations are merged with defaults.annotations.
+      # These annotations are merged with defaults.annotations and apply to
+      # the Job and pods.
       annotations: {}
       # Labels to add to the helmless job.
       #
-      # These labels are merged with defaults.labels.
+      # These labels are merged with defaults.labels and apply to the
+      # Job and pods.
       labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after component annotations and only
+      # appear in pod metadata, not on the Job.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after component labels with highest priority
+      # and only appear in pod metadata, not on the Job.
+      podLabels: {}
     # The init cert job component initializes TLS certificates.
     initCert:
       # Annotations to add to the init cert job component.
       #
-      # These annotations are merged with defaults.annotations.
+      # These annotations are merged with defaults.annotations and apply to
+      # the Job and pods.
       annotations: {}
       # Labels to add to the init cert job component.
       #
-      # These labels are merged with defaults.labels.
+      # These labels are merged with defaults.labels and apply to the
+      # Job and pods.
       labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after component annotations and only
+      # appear in pod metadata, not on the Job.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after component labels with highest priority
+      # and only appear in pod metadata, not on the Job.
+      podLabels: {}
       # Resource requirements and limits for the init cert job component.
       #
       # For details, see the Kubernetes documentation on resource management:
@@ -468,12 +544,24 @@ components:
     tolerations: []
     # Annotations to add to the aggregator component.
     #
-    # These annotations are merged with defaults.annotations.
+    # These annotations are merged with defaults.annotations and apply to
+    # the Deployment and pods.
     annotations: {}
     # Labels to add to the aggregator component.
     #
-    # These labels are merged with defaults.labels.
+    # These labels are merged with defaults.labels and apply to the
+    # Deployment and pods.
     labels: {}
+    # Pod-specific annotations that apply ONLY to pod templates.
+    #
+    # These annotations are merged after component annotations and only
+    # appear in pod metadata, not on the Deployment.
+    podAnnotations: {}
+    # Pod-specific labels that apply ONLY to pod templates.
+    #
+    # These labels are merged after component labels with highest priority
+    # and only appear in pod metadata, not on the Deployment.
+    podLabels: {}
     # Security context for the aggregator pods.
     #
     # For details, see the Kubernetes documentation on security contexts:
@@ -529,12 +617,24 @@ components:
       # maxUnavailable:
     # Annotations to add to the webhook server component.
     #
-    # These annotations are merged with defaults.annotations.
+    # These annotations are merged with defaults.annotations and apply to
+    # the Deployment and pods.
     annotations: {}
     # Labels to add to the webhook server component.
     #
-    # These labels are merged with defaults.labels.
+    # These labels are merged with defaults.labels and apply to the
+    # Deployment and pods.
     labels: {}
+    # Pod-specific annotations that apply ONLY to pod templates.
+    #
+    # These annotations are merged after component annotations and only
+    # appear in pod metadata, not on the Deployment.
+    podAnnotations: {}
+    # Pod-specific labels that apply ONLY to pod templates.
+    #
+    # These labels are merged after component labels with highest priority
+    # and only appear in pod metadata, not on the Deployment.
+    podLabels: {}
     # Security context for the webhook server pods.
     #
     # For details, see the Kubernetes documentation on security contexts:
@@ -553,6 +653,26 @@ components:
         cpu: "500m"
     # The backfill job component performs initial data backfilling.
     backfill:
+      # Annotations to add to the backfill job component.
+      #
+      # These annotations are merged with defaults.annotations and
+      # components.webhookServer.annotations, applying to the CronJob/Job and pods.
+      annotations: {}
+      # Labels to add to the backfill job component.
+      #
+      # These labels are merged with defaults.labels and
+      # components.webhookServer.labels, applying to the CronJob/Job and pods.
+      labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after backfill annotations and only
+      # appear in pod metadata, not on the CronJob/Job.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after backfill labels with highest priority
+      # and only appear in pod metadata, not on the CronJob/Job.
+      podLabels: {}
       # Schedule for the backfill CronJob. Defaults to every 12 hours. Use standard cron format.
       schedule: "0 */12 * * *"
       # Resource requirements and limits for the backfill job component.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -139,14 +139,14 @@ Returns: string (e.g., "cloudzero-webhook.default.svc")
 {{- end -}}
 
 {{/*
-Create labels for prometheus
+Common match labels for selectors
 */}}
 {{- define "cloudzero-agent.common.matchLabels" -}}
-app.kubernetes.io/name: {{ include "cloudzero-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "cloudzero-agent.server.matchLabels" -}}
+app.kubernetes.io/name: server
 app.kubernetes.io/component: {{ .Values.server.name }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
@@ -156,7 +156,6 @@ Common base labels for all Kubernetes resources
 */}}
 {{- define "cloudzero-agent.baseLabels" -}}
 {{- dict
-    "app.kubernetes.io/name" (include "cloudzero-agent.name" .)
     "app.kubernetes.io/instance" .Release.Name
     "app.kubernetes.io/version" .Chart.AppVersion
     "helm.sh/chart" (include "cloudzero-agent.chart" .)
@@ -498,6 +497,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "cloudzero-agent.insightsController.server.matchLabels" -}}
+app.kubernetes.io/name: webhook-server
 app.kubernetes.io/component: {{ .Values.insightsController.server.name }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
@@ -521,9 +521,9 @@ app.kubernetes.io/component: {{ include "cloudzero-agent.configLoaderJobName" . 
 Create common matchLabels for aggregator
 */}}
 {{- define "cloudzero-agent.aggregator.matchLabels" -}}
+app.kubernetes.io/name: aggregator
 app.kubernetes.io/component: aggregator
-app.kubernetes.io/name: {{ include "cloudzero-agent.aggregator.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
 
 {{/*
@@ -878,42 +878,102 @@ dnsConfig:
 {{- end -}}
 
 {{/*
-Generate labels for a component
+Generate labels for a component with merge support.
+
+Parameters (dict):
+- root: Chart context (.) (required)
+- component: Component name for app.kubernetes.io/component label (optional)
+- labels: List of label dicts to merge in order, from lowest to highest priority (required)
+
+Returns: Formatted "labels:\n  key: value" output
+
+Merge behavior:
+- Starts with base labels (app.kubernetes.io/name, app.kubernetes.io/instance, etc.)
+- Merges each dict in the labels list in order (later values override earlier)
+- Adds app.kubernetes.io/component LAST (highest priority, cannot be overridden)
+
+The caller controls the priority order by arranging the labels list. Common pattern:
+  (list defaults commonLabels componentLabels)
+
+Example:
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "agent"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+      )
+    ) | nindent 8 }}
 */}}
 {{- define "cloudzero-agent.generateLabels" -}}
-{{- if .component -}}
-{{- $merged := mergeOverwrite
-     (include "cloudzero-agent.baseLabels" .globals | fromYaml)
-     (dict "app.kubernetes.io/component" .component)
-     (.globals.Values.defaults.labels | default (dict))
-     (.globals.Values.commonMetaLabels | default (dict))
-     (.labels | default (dict))
--}}
+{{- $root := .root | required "root context required" -}}
+{{- $component := .component | default "" -}}
+{{- $labelsList := .labels | required "labels list required" -}}
+
+{{/* Start with base labels */}}
+{{- $merged := include "cloudzero-agent.baseLabels" $root | fromYaml -}}
+
+{{/* Merge each label dict in order (lowest to highest priority) */}}
+{{- range $labelDict := $labelsList -}}
+  {{- if $labelDict -}}
+    {{- $merged = mergeOverwrite $merged $labelDict -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Add component label LAST so it has highest priority and cannot be overridden */}}
+{{- if $component -}}
+  {{- $merged = mergeOverwrite $merged (dict "app.kubernetes.io/component" $component) -}}
+{{- end -}}
+
+{{/* Output formatted labels */}}
 {{- if len $merged -}}
 labels:
 {{- $merged | toYaml | nindent 2 -}}
-{{- end -}}
-{{- else -}}
-{{- $merged := mergeOverwrite
-     (include "cloudzero-agent.baseLabels" .globals | fromYaml)
-     (.globals.Values.defaults.labels | default (dict))
-     (.globals.Values.commonMetaLabels | default (dict))
-     (.labels | default (dict))
--}}
-{{- if len $merged -}}
-labels:
-{{- $merged | toYaml | nindent 2 -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Generate annotations
+Generate annotations with merge support.
+
+Parameters (dict):
+- root: Chart context (.) (required)
+- annotations: List of annotation dicts to merge in order, from lowest to highest priority (required)
+
+Returns: Formatted "annotations:\n  key: value" output
+
+Merge behavior:
+- Merges each dict in the annotations list in order (later values override earlier)
+- The caller controls the priority order by arranging the annotations list
+
+Example:
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.agent.annotations
+        .Values.server.podAnnotations
+        (dict "checksum/config" (include "cloudzero-agent.configChecksum" .))
+      )
+    ) | nindent 8 }}
 */}}
 {{- define "cloudzero-agent.generateAnnotations" -}}
-{{- if . -}}
+{{- $root := .root | required "root context required" -}}
+{{- $annotationsList := .annotations | required "annotations list required" -}}
+
+{{- $merged := dict -}}
+
+{{/* Merge each annotation dict in order (lowest to highest priority) */}}
+{{- range $annotDict := $annotationsList -}}
+  {{- if $annotDict -}}
+    {{- $merged = mergeOverwrite $merged $annotDict -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Output formatted annotations */}}
+{{- if len $merged -}}
 annotations:
-{{- . | toYaml | nindent 2 -}}
+{{- $merged | toYaml | nindent 2 -}}
 {{- end -}}
 {{- end -}}
 
@@ -981,8 +1041,20 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ .name }}
   namespace: {{ .root.Release.Namespace }}
-  {{- include "cloudzero-agent.generateLabels" (dict "globals" .root "component" .componentName) | nindent 2 }}
-  {{- include "cloudzero-agent.generateAnnotations" .root.Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .root
+      "component" .componentName
+      "labels" (list
+        .root.Values.defaults.labels
+        .root.Values.commonMetaLabels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .root
+      "annotations" (list
+        .root.Values.defaults.annotations
+      )
+    ) | nindent 2 }}
 spec:
   {{- if $pdb.minAvailable }}
   {{- if lt $replicas (int $pdb.minAvailable) -}}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -147,7 +147,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "cloudzero-agent.server.matchLabels" -}}
 app.kubernetes.io/name: server
-app.kubernetes.io/component: {{ .Values.server.name }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
 
@@ -498,7 +497,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "cloudzero-agent.insightsController.server.matchLabels" -}}
 app.kubernetes.io/name: webhook-server
-app.kubernetes.io/component: {{ .Values.insightsController.server.name }}
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
 
@@ -522,7 +520,6 @@ Create common matchLabels for aggregator
 */}}
 {{- define "cloudzero-agent.aggregator.matchLabels" -}}
 app.kubernetes.io/name: aggregator
-app.kubernetes.io/component: aggregator
 {{ include "cloudzero-agent.common.matchLabels" . }}
 {{- end -}}
 
@@ -878,19 +875,26 @@ dnsConfig:
 {{- end -}}
 
 {{/*
-Generate labels for a component with merge support.
+Generate labels with merge support, name, and optional component.
 
 Parameters (dict):
 - root: Chart context (.) (required)
-- component: Component name for app.kubernetes.io/component label (optional)
+- name: Application name for app.kubernetes.io/name label (required)
+- component: Optional architectural component for app.kubernetes.io/component label (optional)
 - labels: List of label dicts to merge in order, from lowest to highest priority (required)
 
 Returns: Formatted "labels:\n  key: value" output
 
 Merge behavior:
-- Starts with base labels (app.kubernetes.io/name, app.kubernetes.io/instance, etc.)
+- Starts with base labels (app.kubernetes.io/instance, app.kubernetes.io/part-of, etc.)
 - Merges each dict in the labels list in order (later values override earlier)
-- Adds app.kubernetes.io/component LAST (highest priority, cannot be overridden)
+- Adds app.kubernetes.io/name LAST (highest priority, cannot be overridden)
+- Adds app.kubernetes.io/component LAST if provided (highest priority, cannot be overridden)
+
+Following Kubernetes recommended labels:
+- app.kubernetes.io/name: The application (e.g., "server", "aggregator", "webhook-server")
+- app.kubernetes.io/component: Optional architectural role (e.g., "gatherer", "processor")
+- app.kubernetes.io/part-of: Set to "cloudzero-agent" in baseLabels
 
 The caller controls the priority order by arranging the labels list. Common pattern:
   (list defaults commonLabels componentLabels)
@@ -898,7 +902,7 @@ The caller controls the priority order by arranging the labels list. Common patt
 Example:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "agent"
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels
@@ -908,6 +912,7 @@ Example:
 */}}
 {{- define "cloudzero-agent.generateLabels" -}}
 {{- $root := .root | required "root context required" -}}
+{{- $name := .name | required "name parameter required" -}}
 {{- $component := .component | default "" -}}
 {{- $labelsList := .labels | required "labels list required" -}}
 
@@ -921,7 +926,10 @@ Example:
   {{- end -}}
 {{- end -}}
 
-{{/* Add component label LAST so it has highest priority and cannot be overridden */}}
+{{/* Add name label LAST so it has highest priority and cannot be overridden */}}
+{{- $merged = mergeOverwrite $merged (dict "app.kubernetes.io/name" $name) -}}
+
+{{/* Add component label if provided */}}
 {{- if $component -}}
   {{- $merged = mergeOverwrite $merged (dict "app.kubernetes.io/component" $component) -}}
 {{- end -}}
@@ -1043,7 +1051,7 @@ metadata:
   namespace: {{ .root.Release.Namespace }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .root
-      "component" .componentName
+      "name" .componentName
       "labels" (list
         .root.Values.defaults.labels
         .root.Values.commonMetaLabels

--- a/helm/templates/agent-clusterrole.yaml
+++ b/helm/templates/agent-clusterrole.yaml
@@ -2,9 +2,22 @@
 apiVersion: {{ template "cloudzero-agent.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.agent.annotations
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+      )
+    ) | nindent 2 }}
   name: {{ include "cloudzero-agent.clusterRoleName" . }}
 rules:
   - apiGroups:

--- a/helm/templates/agent-clusterrole.yaml
+++ b/helm/templates/agent-clusterrole.yaml
@@ -11,7 +11,7 @@ metadata:
     ) | nindent 2 }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.server.name
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/agent-clusterrolebinding.yaml
+++ b/helm/templates/agent-clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.server.name
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/agent-clusterrolebinding.yaml
+++ b/helm/templates/agent-clusterrolebinding.yaml
@@ -2,9 +2,22 @@
 apiVersion: {{ template "cloudzero-agent.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.agent.annotations
+      )
+    ) | nindent 2 }}
   name: {{ include "cloudzero-agent.clusterRoleName" . }}
 subjects:
   - kind: ServiceAccount

--- a/helm/templates/agent-cm.yaml
+++ b/helm/templates/agent-cm.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.server.name
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/agent-cm.yaml
+++ b/helm/templates/agent-cm.yaml
@@ -1,11 +1,25 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+      )
+    ) | nindent 2 }}
   name: {{ include "cloudzero-agent.configMapName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.prometheusConfig.configMapAnnotations
+        .Values.components.agent.annotations
+      )
+    ) | nindent 2 }}
 data:
 {{- if eq (include "cloudzero-agent.Values.components.agent.mode" .) "clustered" }}
   # Alloy River configuration

--- a/helm/templates/agent-daemonset-cm.yaml
+++ b/helm/templates/agent-daemonset-cm.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "agent"
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/agent-daemonset-cm.yaml
+++ b/helm/templates/agent-daemonset-cm.yaml
@@ -2,11 +2,27 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "agent"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+        .Values.components.agent.federatedNode.labels
+      )
+    ) | nindent 2 }}
   name: {{ .Release.Name }}-daemonset-cm
   namespace: {{ include "cloudzero-agent.namespace" . }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.prometheusConfig.configMapAnnotations
+        .Values.components.agent.annotations
+        .Values.components.agent.federatedNode.annotations
+      )
+    ) | nindent 2 }}
 data:
   prometheus.yml.in: |-
     {{- if and (ne (include "cloudzero-agent.Values.components.agent.mode" .) "federated") .Values.prometheusConfig.configOverride }}

--- a/helm/templates/agent-daemonset.yaml
+++ b/helm/templates/agent-daemonset.yaml
@@ -38,6 +38,7 @@ spec:
             .Values.components.agent.labels
             .Values.components.agent.federatedNode.labels
             .Values.server.podLabels
+            .Values.components.agent.federatedNode.podLabels
           )
         ) | nindent 6 }}
       {{- include "cloudzero-agent.generateAnnotations" (dict
@@ -47,6 +48,7 @@ spec:
             .Values.server.podAnnotations
             .Values.components.agent.annotations
             .Values.components.agent.federatedNode.annotations
+            .Values.components.agent.federatedNode.podAnnotations
           )
         ) | nindent 6 }}
     spec:

--- a/helm/templates/agent-daemonset.yaml
+++ b/helm/templates/agent-daemonset.yaml
@@ -4,7 +4,7 @@ kind: DaemonSet
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "agent"
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels
@@ -31,7 +31,7 @@ spec:
     metadata:
       {{- include "cloudzero-agent.generateLabels" (dict
           "root" .
-          "component" "agent"
+          "name" "server"
           "labels" (list
             .Values.defaults.labels
             .Values.commonMetaLabels

--- a/helm/templates/agent-daemonset.yaml
+++ b/helm/templates/agent-daemonset.yaml
@@ -2,10 +2,25 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  {{- include "cloudzero-agent.generateAnnotations" .Values.server.deploymentAnnotations | nindent 2 }}
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "agent"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+        .Values.components.agent.federatedNode.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.server.deploymentAnnotations
+        .Values.components.agent.annotations
+        .Values.components.agent.federatedNode.annotations
+      )
+    ) | nindent 2 }}
   name: {{ .Release.Name }}-daemonset
   namespace: {{ include "cloudzero-agent.namespace" . }}
 spec:
@@ -14,12 +29,26 @@ spec:
       {{- include "cloudzero-agent.server.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- include "cloudzero-agent.generateAnnotations" .Values.server.podAnnotations | nindent 8 }}
-      labels:
-        {{- include "cloudzero-agent.server.labels" . | nindent 8 }}
-        {{- if .Values.server.podLabels}}
-        {{ toYaml .Values.server.podLabels | nindent 8 }}
-        {{- end}}
+      {{- include "cloudzero-agent.generateLabels" (dict
+          "root" .
+          "component" "agent"
+          "labels" (list
+            .Values.defaults.labels
+            .Values.commonMetaLabels
+            .Values.components.agent.labels
+            .Values.components.agent.federatedNode.labels
+            .Values.server.podLabels
+          )
+        ) | nindent 6 }}
+      {{- include "cloudzero-agent.generateAnnotations" (dict
+          "root" .
+          "annotations" (list
+            .Values.defaults.annotations
+            .Values.server.podAnnotations
+            .Values.components.agent.annotations
+            .Values.components.agent.federatedNode.annotations
+          )
+        ) | nindent 6 }}
     spec:
       {{- include "cloudzero-agent.generatePriorityClassName" (.Values.defaults.priorityClassName | default .Values.server.priorityClassName) | nindent 6 }}
       serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}

--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -1,10 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  {{- include "cloudzero-agent.generateAnnotations" .Values.server.deploymentAnnotations | nindent 2 }}
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.server.deploymentAnnotations
+        .Values.components.agent.annotations
+      )
+    ) | nindent 2 }}
   name: {{ template "cloudzero-agent.server.fullname" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 spec:
@@ -22,12 +35,24 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- include "cloudzero-agent.generateAnnotations" .Values.server.podAnnotations | nindent 8 }}
-      labels:
-        {{- include "cloudzero-agent.server.labels" . | nindent 8 }}
-        {{- if .Values.server.podLabels}}
-        {{ toYaml .Values.server.podLabels | nindent 8 }}
-        {{- end}}
+      {{- include "cloudzero-agent.generateLabels" (dict
+          "root" .
+          "component" .Values.server.name
+          "labels" (list
+            .Values.defaults.labels
+            .Values.commonMetaLabels
+            .Values.components.agent.labels
+            .Values.server.podLabels
+          )
+        ) | nindent 6 }}
+      {{- include "cloudzero-agent.generateAnnotations" (dict
+          "root" .
+          "annotations" (list
+            .Values.defaults.annotations
+            .Values.server.podAnnotations
+            .Values.components.agent.annotations
+          )
+        ) | nindent 6 }}
     spec:
       {{- include "cloudzero-agent.generatePriorityClassName" (.Values.defaults.priorityClassName | default .Values.server.priorityClassName) | nindent 6 }}
       serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}

--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.server.name
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels
@@ -37,7 +37,7 @@ spec:
     metadata:
       {{- include "cloudzero-agent.generateLabels" (dict
           "root" .
-          "component" .Values.server.name
+          "name" "server"
           "labels" (list
             .Values.defaults.labels
             .Values.commonMetaLabels

--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -43,6 +43,7 @@ spec:
             .Values.commonMetaLabels
             .Values.components.agent.labels
             .Values.server.podLabels
+            .Values.components.agent.podLabels
           )
         ) | nindent 6 }}
       {{- include "cloudzero-agent.generateAnnotations" (dict
@@ -51,6 +52,7 @@ spec:
             .Values.defaults.annotations
             .Values.server.podAnnotations
             .Values.components.agent.annotations
+            .Values.components.agent.podAnnotations
           )
         ) | nindent 6 }}
     spec:

--- a/helm/templates/agent-hpa.yaml
+++ b/helm/templates/agent-hpa.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: {{ include "cloudzero-agent.namespace" . }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.server.name
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/agent-hpa.yaml
+++ b/helm/templates/agent-hpa.yaml
@@ -16,9 +16,22 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "cloudzero-agent.server.fullname" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.agent.annotations
+      )
+    ) | nindent 2 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/helm/templates/agent-issuer.yaml
+++ b/helm/templates/agent-issuer.yaml
@@ -4,8 +4,22 @@ kind: Issuer
 metadata:
   name: {{ include "cloudzero-agent.issuerName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateLabels" (dict "globals" . "labels" .Values.commonMetaLabels) | nindent 2 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "webhook-server"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.webhookServer.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.webhookServer.annotations
+      )
+    ) | nindent 2 }}
 spec:
   {{- if .Values.insightsController.tls.issuerSpec }}
   {{- toYaml .Values.insightsController.tls.issuerSpec | nindent 2 }}

--- a/helm/templates/agent-issuer.yaml
+++ b/helm/templates/agent-issuer.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "webhook-server"
+      "name" "webhook-server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/agent-pdb.yaml
+++ b/helm/templates/agent-pdb.yaml
@@ -1,6 +1,6 @@
 {{ include "cloudzero-agent.generatePodDisruptionBudget" (dict
     "component" .Values.components.agent
-    "componentName" .Values.server.name
+    "componentName" "server"
     "name" (include "cloudzero-agent.server.fullname" .)
     "matchLabels" (include "cloudzero-agent.server.matchLabels" .)
     "root" .

--- a/helm/templates/agent-pvc.yaml
+++ b/helm/templates/agent-pvc.yaml
@@ -5,7 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.server.name
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/agent-pvc.yaml
+++ b/helm/templates/agent-pvc.yaml
@@ -3,12 +3,24 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-    {{- with .Values.server.persistentVolume.labels }}
-       {{- toYaml . | nindent 4 }}
-    {{- end }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.server.persistentVolume.annotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+        .Values.server.persistentVolume.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.server.persistentVolume.annotations
+        .Values.components.agent.annotations
+      )
+    ) | nindent 2 }}
   name: {{ template "cloudzero-agent.server.fullname" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 spec:

--- a/helm/templates/agent-serviceaccount.yaml
+++ b/helm/templates/agent-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.server.name
+      "name" "server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/agent-serviceaccount.yaml
+++ b/helm/templates/agent-serviceaccount.yaml
@@ -2,9 +2,23 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.serviceAccount.annotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.agent.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.serviceAccount.annotations
+        .Values.components.agent.annotations
+      )
+    ) | nindent 2 }}
   name: {{ template "cloudzero-agent.serviceAccountName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 {{- if kindIs "bool" .Values.server.automountServiceAccountToken }}

--- a/helm/templates/aggregator-cm.yaml
+++ b/helm/templates/aggregator-cm.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "aggregator"
+      "name" "aggregator"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/aggregator-cm.yaml
+++ b/helm/templates/aggregator-cm.yaml
@@ -3,8 +3,22 @@ kind: ConfigMap
 metadata:
   name: {{ include "cloudzero-agent.aggregator.name" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateLabels" (dict "globals" . "labels" .Values.commonMetaLabels) | nindent 2 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "aggregator"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.aggregator.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.aggregator.annotations
+      )
+    ) | nindent 2 }}
 data:
   config.yml: |-
 {{- include "cloudzero-agent.aggregator.configuration" . | nindent 4 -}}

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -37,7 +37,7 @@ metadata:
   # Provides consistent labeling for service discovery, monitoring, and resource management
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "aggregator"
+      "name" "aggregator"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels
@@ -61,7 +61,7 @@ spec:
         ) | nindent 6 }}
       {{- include "cloudzero-agent.generateLabels" (dict
           "root" .
-          "component" "aggregator"
+          "name" "aggregator"
           "labels" (list
             .Values.defaults.labels
             .Values.commonMetaLabels

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -26,16 +26,23 @@ metadata:
   namespace: {{ .Release.Namespace }}
   # Annotations: Merge default annotations with aggregator-specific annotations
   # Enables custom metadata for monitoring, backup policies, and operational tooling
-  {{- include "cloudzero-agent.generateAnnotations" (merge
-      (deepCopy .Values.defaults.annotations)
-      .Values.components.aggregator.annotations
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.aggregator.annotations
+      )
     ) | nindent 2 }}
   # Labels: Combine standard aggregator labels with user-defined metadata labels
   # Provides consistent labeling for service discovery, monitoring, and resource management
   {{- include "cloudzero-agent.generateLabels" (dict
-      "globals" .
-      "labels" (merge (include "cloudzero-agent.aggregator.matchLabels" . | fromYaml) .Values.commonMetaLabels)
+      "root" .
       "component" "aggregator"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.aggregator.labels
+      )
     ) | nindent 2 }}
 spec:
   selector:
@@ -44,14 +51,22 @@ spec:
   replicas: {{ .Values.components.aggregator.replicas | default .Values.defaults.replicas }}
   template:
     metadata:
-      {{- include "cloudzero-agent.generateAnnotations" (merge
-          (deepCopy .Values.defaults.annotations)
-          (dict "checksum/config" (include "cloudzero-agent.configurationChecksum" .))
+      {{- include "cloudzero-agent.generateAnnotations" (dict
+          "root" .
+          "annotations" (list
+            .Values.defaults.annotations
+            .Values.components.aggregator.annotations
+            (dict "checksum/config" (include "cloudzero-agent.configurationChecksum" .))
+          )
         ) | nindent 6 }}
       {{- include "cloudzero-agent.generateLabels" (dict
-          "globals" .
-          "labels" (merge (include "cloudzero-agent.aggregator.matchLabels" . | fromYaml) .Values.commonMetaLabels)
+          "root" .
           "component" "aggregator"
+          "labels" (list
+            .Values.defaults.labels
+            .Values.commonMetaLabels
+            .Values.components.aggregator.labels
+          )
         ) | nindent 6 }}
     spec:
       serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -56,6 +56,7 @@ spec:
           "annotations" (list
             .Values.defaults.annotations
             .Values.components.aggregator.annotations
+            .Values.components.aggregator.podAnnotations
             (dict "checksum/config" (include "cloudzero-agent.configurationChecksum" .))
           )
         ) | nindent 6 }}
@@ -66,6 +67,7 @@ spec:
             .Values.defaults.labels
             .Values.commonMetaLabels
             .Values.components.aggregator.labels
+            .Values.components.aggregator.podLabels
           )
         ) | nindent 6 }}
     spec:

--- a/helm/templates/aggregator-secret.yaml
+++ b/helm/templates/aggregator-secret.yaml
@@ -2,9 +2,23 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.secretAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "aggregator"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.aggregator.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.secretAnnotations
+        .Values.components.aggregator.annotations
+      )
+    ) | nindent 2 }}
   name: {{ include "cloudzero-agent.secretName" .}}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 data:

--- a/helm/templates/aggregator-secret.yaml
+++ b/helm/templates/aggregator-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "aggregator"
+      "name" "aggregator"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/aggregator-service.yaml
+++ b/helm/templates/aggregator-service.yaml
@@ -5,7 +5,13 @@ metadata:
   name: {{ include "cloudzero-agent.aggregator.name" . }}
   labels:
     {{- include "cloudzero-agent.aggregator.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.aggregator.annotations
+      )
+    ) | nindent 2 }}
 spec:
   selector:
     {{- include "cloudzero-agent.aggregator.matchLabels" . | nindent 4 }}

--- a/helm/templates/backfill-job.yaml
+++ b/helm/templates/backfill-job.yaml
@@ -42,7 +42,7 @@ metadata:
     ) | nindent 2 }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" $
-      "component" "webhook-server"
+      "name" "backfill"
       "labels" (list
         $.Values.defaults.labels
         $.Values.commonMetaLabels
@@ -66,7 +66,7 @@ spec:
           namespace: {{ $.Release.Namespace }}
           {{- include "cloudzero-agent.generateLabels" (dict
               "root" $
-              "component" "webhook-server"
+              "name" "backfill"
               "labels" (list
                 $.Values.defaults.labels
                 $.Values.commonMetaLabels
@@ -92,7 +92,7 @@ spec:
       namespace: {{ $.Release.Namespace }}
       {{- include "cloudzero-agent.generateLabels" (dict
           "root" $
-          "component" "webhook-server"
+          "name" "backfill"
           "labels" (list
             $.Values.defaults.labels
             $.Values.commonMetaLabels

--- a/helm/templates/backfill-job.yaml
+++ b/helm/templates/backfill-job.yaml
@@ -72,6 +72,7 @@ spec:
                 $.Values.commonMetaLabels
                 $.Values.components.webhookServer.labels
                 $.Values.components.webhookServer.backfill.labels
+                $.Values.components.webhookServer.backfill.podLabels
                 (dict "job-type" "backfill")
                 (dict "job-category" "cronjob")
               )
@@ -82,6 +83,7 @@ spec:
                 $.Values.defaults.annotations
                 $.Values.components.webhookServer.annotations
                 $.Values.components.webhookServer.backfill.annotations
+                $.Values.components.webhookServer.backfill.podAnnotations
               )
             ) | nindent 10 }}
         spec:
@@ -98,6 +100,7 @@ spec:
             $.Values.commonMetaLabels
             $.Values.components.webhookServer.labels
             $.Values.components.webhookServer.backfill.labels
+            $.Values.components.webhookServer.backfill.podLabels
             (dict "job-type" "backfill")
             (dict "job-category" "onetime")
           )
@@ -108,6 +111,7 @@ spec:
             $.Values.defaults.annotations
             $.Values.components.webhookServer.annotations
             $.Values.components.webhookServer.backfill.annotations
+            $.Values.components.webhookServer.backfill.podAnnotations
           )
         ) | nindent 6 }}
     spec:

--- a/helm/templates/backfill-job.yaml
+++ b/helm/templates/backfill-job.yaml
@@ -25,20 +25,33 @@
   specifications.
 */ -}}
 {{- range $jobType := list "CronJob" "Job" }}
+{{- $jobCategory := ternary "cronjob" "onetime" (eq $jobType "CronJob") }}
 apiVersion: batch/v1
 kind: {{ $jobType }}
 metadata:
   name: {{ if eq $jobType "CronJob" }}{{ include "cloudzero-agent.initBackfillCronJobName" $ }}{{ else }}{{ include "cloudzero-agent.initBackfillJobName" $ }}{{ end }}
   namespace: {{ $.Release.Namespace }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy $.Values.defaults.annotations) $.Values.initBackfillJob.annotations) | nindent 2 }}
-  labels:
-    {{- include "cloudzero-agent.insightsController.labels" $ | nindent 4 }}
-    job-type: backfill
-    {{- if eq $jobType "CronJob" }}
-    job-category: cronjob
-    {{- else }}
-    job-category: onetime
-    {{- end }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" $
+      "annotations" (list
+        $.Values.defaults.annotations
+        $.Values.initBackfillJob.annotations
+        $.Values.components.webhookServer.annotations
+        $.Values.components.webhookServer.backfill.annotations
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" $
+      "component" "webhook-server"
+      "labels" (list
+        $.Values.defaults.labels
+        $.Values.commonMetaLabels
+        $.Values.components.webhookServer.labels
+        $.Values.components.webhookServer.backfill.labels
+        (dict "job-type" "backfill")
+        (dict "job-category" $jobCategory)
+      )
+    ) | nindent 2 }}
 spec:
   {{- if eq $jobType "CronJob" }}
   schedule: {{ $.Values.components.webhookServer.backfill.schedule | default "0 */3 * * *" | quote }}
@@ -51,22 +64,52 @@ spec:
         metadata:
           name: {{ include "cloudzero-agent.initBackfillCronJobName" $ }}
           namespace: {{ $.Release.Namespace }}
-          labels:
-            {{- include "cloudzero-agent.insightsController.initBackfillJob.matchLabels" $ | nindent 12 }}
-            job-type: backfill
-            job-category: cronjob
-          {{- include "cloudzero-agent.generateAnnotations" $.Values.defaults.annotations | nindent 10 }}
+          {{- include "cloudzero-agent.generateLabels" (dict
+              "root" $
+              "component" "webhook-server"
+              "labels" (list
+                $.Values.defaults.labels
+                $.Values.commonMetaLabels
+                $.Values.components.webhookServer.labels
+                $.Values.components.webhookServer.backfill.labels
+                (dict "job-type" "backfill")
+                (dict "job-category" "cronjob")
+              )
+            ) | nindent 10 }}
+          {{- include "cloudzero-agent.generateAnnotations" (dict
+              "root" $
+              "annotations" (list
+                $.Values.defaults.annotations
+                $.Values.components.webhookServer.annotations
+                $.Values.components.webhookServer.backfill.annotations
+              )
+            ) | nindent 10 }}
         spec:
   {{- else }}
   template:
     metadata:
       name: {{ include "cloudzero-agent.initBackfillJobName" $ }}
       namespace: {{ $.Release.Namespace }}
-      labels:
-        {{- include "cloudzero-agent.insightsController.initBackfillJob.matchLabels" $ | nindent 8 }}
-        job-type: backfill
-        job-category: onetime
-      {{- include "cloudzero-agent.generateAnnotations" $.Values.defaults.annotations | nindent 6 }}
+      {{- include "cloudzero-agent.generateLabels" (dict
+          "root" $
+          "component" "webhook-server"
+          "labels" (list
+            $.Values.defaults.labels
+            $.Values.commonMetaLabels
+            $.Values.components.webhookServer.labels
+            $.Values.components.webhookServer.backfill.labels
+            (dict "job-type" "backfill")
+            (dict "job-category" "onetime")
+          )
+        ) | nindent 6 }}
+      {{- include "cloudzero-agent.generateAnnotations" (dict
+          "root" $
+          "annotations" (list
+            $.Values.defaults.annotations
+            $.Values.components.webhookServer.annotations
+            $.Values.components.webhookServer.backfill.annotations
+          )
+        ) | nindent 6 }}
     spec:
   {{- end }}
           serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" $ }}

--- a/helm/templates/config-loader-job.yaml
+++ b/helm/templates/config-loader-job.yaml
@@ -3,21 +3,43 @@ kind: Job
 metadata:
   name: {{ include "cloudzero-agent.configLoaderJobName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge
-      (dict "checksum/values" (include "cloudzero-agent.configurationChecksum" .))
-      (.Values.components.miscellaneous.configLoader.annotations | default (dict))
-      (deepCopy .Values.defaults.annotations)
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.miscellaneous.configLoader.annotations
+        (dict "checksum/values" (include "cloudzero-agent.configurationChecksum" .))
+      )
     ) | nindent 2 }}
-  {{- include "cloudzero-agent.generateLabels" (dict "globals" . "component" "config-loader" "labels" .Values.components.miscellaneous.configLoader.labels) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "config-loader"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.miscellaneous.configLoader.labels
+      )
+    ) | nindent 2 }}
 spec:
   template:
     metadata:
       name: {{ include "cloudzero-agent.configLoaderJobName" . }}
       namespace: {{ .Release.Namespace }}
-      {{- include "cloudzero-agent.generateLabels" (dict "globals" . "component" "config-loader" "labels" .Values.components.miscellaneous.configLoader.labels) | nindent 6 }}
-      {{- include "cloudzero-agent.generateAnnotations" (merge
-          (.Values.components.miscellaneous.configLoader.annotations | default (dict))
-          (deepCopy .Values.defaults.annotations)
+      {{- include "cloudzero-agent.generateLabels" (dict
+          "root" .
+          "component" "config-loader"
+          "labels" (list
+            .Values.defaults.labels
+            .Values.commonMetaLabels
+            .Values.components.miscellaneous.configLoader.labels
+          )
+        ) | nindent 6 }}
+      {{- include "cloudzero-agent.generateAnnotations" (dict
+          "root" .
+          "annotations" (list
+            .Values.defaults.annotations
+            .Values.components.miscellaneous.configLoader.annotations
+          )
         ) | nindent 6 }}
     spec:
       {{- include "cloudzero-agent.generateImagePullSecrets" (dict "root" . "image" .Values.validator.image) | nindent 6 }}

--- a/helm/templates/config-loader-job.yaml
+++ b/helm/templates/config-loader-job.yaml
@@ -32,6 +32,7 @@ spec:
             .Values.defaults.labels
             .Values.commonMetaLabels
             .Values.components.miscellaneous.configLoader.labels
+            .Values.components.miscellaneous.configLoader.podLabels
           )
         ) | nindent 6 }}
       {{- include "cloudzero-agent.generateAnnotations" (dict
@@ -39,6 +40,7 @@ spec:
           "annotations" (list
             .Values.defaults.annotations
             .Values.components.miscellaneous.configLoader.annotations
+            .Values.components.miscellaneous.configLoader.podAnnotations
           )
         ) | nindent 6 }}
     spec:

--- a/helm/templates/config-loader-job.yaml
+++ b/helm/templates/config-loader-job.yaml
@@ -13,7 +13,7 @@ metadata:
     ) | nindent 2 }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "config-loader"
+      "name" "validator"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels
@@ -27,7 +27,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       {{- include "cloudzero-agent.generateLabels" (dict
           "root" .
-          "component" "config-loader"
+          "name" "validator"
           "labels" (list
             .Values.defaults.labels
             .Values.commonMetaLabels

--- a/helm/templates/helmless-cm.yaml
+++ b/helm/templates/helmless-cm.yaml
@@ -3,8 +3,22 @@ kind: ConfigMap
 metadata:
   name: {{ include "cloudzero-agent.helmlessConfigMapName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateLabels" (dict "globals" . "labels" .Values.commonMetaLabels) | nindent 2 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "helmless"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.miscellaneous.helmless.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.miscellaneous.helmless.annotations
+      )
+    ) | nindent 2 }}
 data:
   values.yaml: |-
 {{- merge (dict "apiKey" (ternary "***" nil (not (empty .Values.apiKey)))) .Values | toYaml | nindent 4 -}}

--- a/helm/templates/helmless-cm.yaml
+++ b/helm/templates/helmless-cm.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "helmless"
+      "name" "helmless"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/helmless-job.yaml
+++ b/helm/templates/helmless-job.yaml
@@ -12,7 +12,7 @@ metadata:
     ) | nindent 2 }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "helmless"
+      "name" "helmless"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels
@@ -26,7 +26,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       {{- include "cloudzero-agent.generateLabels" (dict
           "root" .
-          "component" "helmless"
+          "name" "helmless"
           "labels" (list
             .Values.defaults.labels
             .Values.commonMetaLabels

--- a/helm/templates/helmless-job.yaml
+++ b/helm/templates/helmless-job.yaml
@@ -31,6 +31,7 @@ spec:
             .Values.defaults.labels
             .Values.commonMetaLabels
             .Values.components.miscellaneous.helmless.labels
+            .Values.components.miscellaneous.helmless.podLabels
           )
         ) | nindent 6 }}
       {{- include "cloudzero-agent.generateAnnotations" (dict
@@ -38,6 +39,7 @@ spec:
           "annotations" (list
             .Values.defaults.annotations
             .Values.components.miscellaneous.helmless.annotations
+            .Values.components.miscellaneous.helmless.podAnnotations
           )
         ) | nindent 6 }}
     spec:

--- a/helm/templates/helmless-job.yaml
+++ b/helm/templates/helmless-job.yaml
@@ -3,20 +3,42 @@ kind: Job
 metadata:
   name: {{ include "cloudzero-agent.helmlessJobName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge
-      (.Values.components.miscellaneous.helmless.annotations | default (dict))
-      (deepCopy .Values.defaults.annotations)
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.miscellaneous.helmless.annotations
+      )
     ) | nindent 2 }}
-  {{- include "cloudzero-agent.generateLabels" (dict "globals" . "component" "helmless" "labels" .Values.components.miscellaneous.helmless.labels) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "helmless"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.miscellaneous.helmless.labels
+      )
+    ) | nindent 2 }}
 spec:
   template:
     metadata:
       name: {{ include "cloudzero-agent.helmlessJobName" . }}
       namespace: {{ .Release.Namespace }}
-      {{- include "cloudzero-agent.generateLabels" (dict "globals" . "component" "helmless" "labels" .Values.components.miscellaneous.helmless.labels) | nindent 6 }}
-      {{- include "cloudzero-agent.generateAnnotations" (merge
-          (.Values.components.miscellaneous.helmless.annotations | default (dict))
-          (deepCopy .Values.defaults.annotations)
+      {{- include "cloudzero-agent.generateLabels" (dict
+          "root" .
+          "component" "helmless"
+          "labels" (list
+            .Values.defaults.labels
+            .Values.commonMetaLabels
+            .Values.components.miscellaneous.helmless.labels
+          )
+        ) | nindent 6 }}
+      {{- include "cloudzero-agent.generateAnnotations" (dict
+          "root" .
+          "annotations" (list
+            .Values.defaults.annotations
+            .Values.components.miscellaneous.helmless.annotations
+          )
         ) | nindent 6 }}
     spec:
       restartPolicy: OnFailure

--- a/helm/templates/init-cert-clusterrole.yaml
+++ b/helm/templates/init-cert-clusterrole.yaml
@@ -9,7 +9,7 @@ kind: ClusterRole
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "init-cert"
+      "name" "init-cert"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/init-cert-clusterrole.yaml
+++ b/helm/templates/init-cert-clusterrole.yaml
@@ -7,10 +7,22 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  {{- include "cloudzero-agent.generateLabels" (dict "globals" . "component" "init-cert") | nindent 2 }}
-  {{- include "cloudzero-agent.generateAnnotations" (mergeOverwrite
-      (.Values.defaults.annotations | default (dict))
-      (dict "checkov.io/skip_1" "CKV_K8S_155")
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "init-cert"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.miscellaneous.initCert.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.miscellaneous.initCert.annotations
+        (dict "checkov.io/skip_1" "CKV_K8S_155")
+      )
     ) | nindent 2 }}
   name: {{ include "cloudzero-agent.initCertJob.clusterRoleName" . }}
 

--- a/helm/templates/init-cert-clusterrolebinding.yaml
+++ b/helm/templates/init-cert-clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "init-cert"
+      "name" "init-cert"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/init-cert-clusterrolebinding.yaml
+++ b/helm/templates/init-cert-clusterrolebinding.yaml
@@ -2,9 +2,22 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
-    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "init-cert"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.miscellaneous.initCert.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.miscellaneous.initCert.annotations
+      )
+    ) | nindent 2 }}
   name: {{ include "cloudzero-agent.initCertJob.clusterRoleBindingName" . }}
 subjects:
   - kind: ServiceAccount

--- a/helm/templates/init-cert-job.yaml
+++ b/helm/templates/init-cert-job.yaml
@@ -33,6 +33,7 @@ spec:
             .Values.defaults.labels
             .Values.commonMetaLabels
             .Values.components.miscellaneous.initCert.labels
+            .Values.components.miscellaneous.initCert.podLabels
           )
         ) | nindent 6 }}
       {{- include "cloudzero-agent.generateAnnotations" (dict
@@ -40,6 +41,7 @@ spec:
           "annotations" (list
             .Values.defaults.annotations
             .Values.components.miscellaneous.initCert.annotations
+            .Values.components.miscellaneous.initCert.podAnnotations
           )
         ) | nindent 6 }}
     spec:

--- a/helm/templates/init-cert-job.yaml
+++ b/helm/templates/init-cert-job.yaml
@@ -15,7 +15,7 @@ metadata:
     ) | nindent 2 }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "init-cert"
+      "name" "init-cert"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels
@@ -28,7 +28,7 @@ spec:
       name: {{ include "cloudzero-agent.initCertJobName" . }}
       {{- include "cloudzero-agent.generateLabels" (dict
           "root" .
-          "component" "init-cert"
+          "name" "init-cert"
           "labels" (list
             .Values.defaults.labels
             .Values.commonMetaLabels

--- a/helm/templates/init-cert-job.yaml
+++ b/helm/templates/init-cert-job.yaml
@@ -5,16 +5,43 @@ kind: Job
 metadata:
   name: {{ include "cloudzero-agent.initCertJobName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.initCertJob.annotations) | nindent 2 }}
-  labels:
-    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.initCertJob.annotations
+        .Values.components.miscellaneous.initCert.annotations
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "init-cert"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.miscellaneous.initCert.labels
+      )
+    ) | nindent 2 }}
 spec:
   template:
     metadata:
       name: {{ include "cloudzero-agent.initCertJobName" . }}
-      labels:
-        {{- include "cloudzero-agent.insightsController.initCertJob.matchLabels" . | nindent 8 }}
-      {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 6 }}
+      {{- include "cloudzero-agent.generateLabels" (dict
+          "root" .
+          "component" "init-cert"
+          "labels" (list
+            .Values.defaults.labels
+            .Values.commonMetaLabels
+            .Values.components.miscellaneous.initCert.labels
+          )
+        ) | nindent 6 }}
+      {{- include "cloudzero-agent.generateAnnotations" (dict
+          "root" .
+          "annotations" (list
+            .Values.defaults.annotations
+            .Values.components.miscellaneous.initCert.annotations
+          )
+        ) | nindent 6 }}
     spec:
       {{- include "cloudzero-agent.generateNodeSelector" (dict "default" .Values.defaults.nodeSelector "nodeSelector" (.Values.initCertJob.nodeSelector | default .Values.insightsController.server.nodeSelector)) | nindent 6 }}
       {{- include "cloudzero-agent.generateAffinity" (dict "default" .Values.defaults.affinity "affinity" .Values.insightsController.server.affinity) | nindent 6 }}

--- a/helm/templates/validator-cm.yaml
+++ b/helm/templates/validator-cm.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" "validator"
+      "name" "validator"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/validator-cm.yaml
+++ b/helm/templates/validator-cm.yaml
@@ -1,11 +1,25 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" "validator"
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.validator.labels
+      )
+    ) | nindent 2 }}
   name: {{ include "cloudzero-agent.validatorConfigMapName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.prometheusConfig.configMapAnnotations
+        .Values.components.validator.annotations
+      )
+    ) | nindent 2 }}
 data:
   validator.yml: |-
     versions:

--- a/helm/templates/webhook-certificate.yaml
+++ b/helm/templates/webhook-certificate.yaml
@@ -4,13 +4,35 @@ kind: Certificate
 metadata:
   name: {{ include "cloudzero-agent.certificateName" . }}
   namespace: {{ .Release.Namespace }}
-  {{- include "cloudzero-agent.generateLabels" (dict "globals" . "labels" .Values.commonMetaLabels) | nindent 2 }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.secretAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.insightsController.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.webhookServer.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.secretAnnotations
+        .Values.components.webhookServer.annotations
+      )
+    ) | nindent 2 }}
 spec:
   secretName: {{ include "cloudzero-agent.tlsSecretName" .}}
   secretTemplate:
-    labels:
-      {{- include "cloudzero-agent.insightsController.labels" . | nindent 6 }}
+    {{- include "cloudzero-agent.generateLabels" (dict
+        "root" .
+        "component" .Values.insightsController.server.name
+        "labels" (list
+          .Values.defaults.labels
+          .Values.commonMetaLabels
+          .Values.components.webhookServer.labels
+        )
+      ) | nindent 4 }}
   privateKey:
     algorithm: RSA
     encoding: PKCS1

--- a/helm/templates/webhook-certificate.yaml
+++ b/helm/templates/webhook-certificate.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.insightsController.server.name
+      "name" "webhook-server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels
@@ -26,7 +26,7 @@ spec:
   secretTemplate:
     {{- include "cloudzero-agent.generateLabels" (dict
         "root" .
-        "component" .Values.insightsController.server.name
+        "name" "webhook-server"
         "labels" (list
           .Values.defaults.labels
           .Values.commonMetaLabels

--- a/helm/templates/webhook-cm.yaml
+++ b/helm/templates/webhook-cm.yaml
@@ -18,7 +18,7 @@ kind: ConfigMap
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.server.name
+      "name" "webhook-server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/webhook-cm.yaml
+++ b/helm/templates/webhook-cm.yaml
@@ -16,11 +16,25 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  labels:
-    {{- include "cloudzero-agent.server.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.webhookServer.labels
+      )
+    ) | nindent 2 }}
   name: {{ include "cloudzero-agent.webhookConfigMapName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.prometheusConfig.configMapAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.prometheusConfig.configMapAnnotations
+        .Values.components.webhookServer.annotations
+      )
+    ) | nindent 2 }}
 data:
   server-config.yaml: |-
 {{- include "cloudzero-agent.insightsController.configuration" . | nindent 4 -}}

--- a/helm/templates/webhook-deploy.yaml
+++ b/helm/templates/webhook-deploy.yaml
@@ -30,11 +30,25 @@ metadata:
   name: {{ include "cloudzero-agent.insightsController.deploymentName" . }}
   namespace: {{ .Release.Namespace }}
   # Standard webhook server labels for consistent resource identification
-  labels:
-    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.insightsController.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.webhookServer.labels
+      )
+    ) | nindent 2 }}
   # Deployment annotations: Merge defaults with webhook-specific annotations
   # Supports monitoring, backup policies, and operational tooling integration
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy .Values.defaults.annotations) .Values.insightsController.server.deploymentAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.insightsController.server.deploymentAnnotations
+        .Values.components.webhookServer.annotations
+      )
+    ) | nindent 2 }}
 spec:
   replicas: {{ .Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas | default .Values.defaults.replicas }}
   selector:
@@ -42,20 +56,28 @@ spec:
       {{- include "cloudzero-agent.insightsController.server.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      labels:
-        {{- include "cloudzero-agent.insightsController.labels" . | nindent 8 }}
-        {{- with .Values.insightsController.server.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- include "cloudzero-agent.generateLabels" (dict
+          "root" .
+          "component" .Values.insightsController.server.name
+          "labels" (list
+            .Values.defaults.labels
+            .Values.commonMetaLabels
+            .Values.components.webhookServer.labels
+          )
+        ) | nindent 6 }}
       {{- $istioAnnotations := dict -}}
       {{- if not .Values.insightsController.server.suppressIstioAnnotations -}}
       {{- $istioAnnotations = dict "sidecar.istio.io/inject" "false" -}}
       {{- end -}}
-      {{- include "cloudzero-agent.generateAnnotations" (merge
-          (deepCopy .Values.defaults.annotations)
-          .Values.insightsController.server.podAnnotations
-          $istioAnnotations
-          (dict "checksum/config" (include "cloudzero-agent.configurationChecksum" .))
+      {{- include "cloudzero-agent.generateAnnotations" (dict
+          "root" .
+          "annotations" (list
+            .Values.defaults.annotations
+            .Values.insightsController.server.podAnnotations
+            .Values.components.webhookServer.annotations
+            $istioAnnotations
+            (dict "checksum/config" (include "cloudzero-agent.configurationChecksum" .))
+          )
         ) | nindent 6 }}
     spec:
       serviceAccountName: {{ include "cloudzero-agent.serviceAccountName" . }}

--- a/helm/templates/webhook-deploy.yaml
+++ b/helm/templates/webhook-deploy.yaml
@@ -32,7 +32,7 @@ metadata:
   # Standard webhook server labels for consistent resource identification
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.insightsController.server.name
+      "name" "webhook-server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels
@@ -58,7 +58,7 @@ spec:
     metadata:
       {{- include "cloudzero-agent.generateLabels" (dict
           "root" .
-          "component" .Values.insightsController.server.name
+          "name" "webhook-server"
           "labels" (list
             .Values.defaults.labels
             .Values.commonMetaLabels

--- a/helm/templates/webhook-deploy.yaml
+++ b/helm/templates/webhook-deploy.yaml
@@ -63,6 +63,7 @@ spec:
             .Values.defaults.labels
             .Values.commonMetaLabels
             .Values.components.webhookServer.labels
+            .Values.components.webhookServer.podLabels
           )
         ) | nindent 6 }}
       {{- $istioAnnotations := dict -}}
@@ -75,6 +76,7 @@ spec:
             .Values.defaults.annotations
             .Values.insightsController.server.podAnnotations
             .Values.components.webhookServer.annotations
+            .Values.components.webhookServer.podAnnotations
             $istioAnnotations
             (dict "checksum/config" (include "cloudzero-agent.configurationChecksum" .))
           )

--- a/helm/templates/webhook-hpa.yaml
+++ b/helm/templates/webhook-hpa.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.insightsController.server.name
+      "name" "webhook-server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/webhook-hpa.yaml
+++ b/helm/templates/webhook-hpa.yaml
@@ -18,11 +18,21 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "cloudzero-agent.insightsController.deploymentName" . }}
   namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge
-      (deepCopy .Values.defaults.annotations)
-      (.Values.insightsController.server.podAnnotations | default (dict))
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.insightsController.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.webhookServer.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.webhookServer.annotations
+      )
     ) | nindent 2 }}
 spec:
   scaleTargetRef:

--- a/helm/templates/webhook-pdb.yaml
+++ b/helm/templates/webhook-pdb.yaml
@@ -1,6 +1,6 @@
 {{ include "cloudzero-agent.generatePodDisruptionBudget" (dict
     "component" .Values.components.webhookServer
-    "componentName" .Values.insightsController.server.name
+    "componentName" "webhook-server"
     "name" (include "cloudzero-agent.insightsController.deploymentName" .)
     "matchLabels" (include "cloudzero-agent.insightsController.server.matchLabels" .)
     "replicas" (.Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas | default .Values.defaults.replicas)

--- a/helm/templates/webhook-service.yaml
+++ b/helm/templates/webhook-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "cloudzero-agent.serviceName" . }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.insightsController.server.name
+      "name" "webhook-server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/webhook-service.yaml
+++ b/helm/templates/webhook-service.yaml
@@ -2,9 +2,23 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cloudzero-agent.serviceName" . }}
-  labels:
-    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (dict "nginx.ingress.kubernetes.io/ssl-redirect" "false") .Values.defaults.annotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.insightsController.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.webhookServer.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.webhookServer.annotations
+        (dict "nginx.ingress.kubernetes.io/ssl-redirect" "false")
+      )
+    ) | nindent 2 }}
   namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP

--- a/helm/templates/webhook-serviceaccount.yaml
+++ b/helm/templates/webhook-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.insightsController.server.name
+      "name" "webhook-server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/webhook-serviceaccount.yaml
+++ b/helm/templates/webhook-serviceaccount.yaml
@@ -2,9 +2,22 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.insightsController.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.webhookServer.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.webhookServer.annotations
+      )
+    ) | nindent 2 }}
   name: {{ template "cloudzero-agent.initCertJob.serviceAccountName" . }}
   namespace: {{ include "cloudzero-agent.namespace" . }}
 {{- end }}

--- a/helm/templates/webhook-tls-secret.yaml
+++ b/helm/templates/webhook-tls-secret.yaml
@@ -2,9 +2,22 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  labels:
-    {{- include "cloudzero-agent.insightsController.labels" . | nindent 4 }}
-  {{- include "cloudzero-agent.generateAnnotations" .Values.defaults.annotations | nindent 2 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" .
+      "component" .Values.insightsController.server.name
+      "labels" (list
+        .Values.defaults.labels
+        .Values.commonMetaLabels
+        .Values.components.webhookServer.labels
+      )
+    ) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" .
+      "annotations" (list
+        .Values.defaults.annotations
+        .Values.components.webhookServer.annotations
+      )
+    ) | nindent 2 }}
   name: {{ include "cloudzero-agent.tlsSecretName" . }}
   namespace: {{ .Release.Namespace }}
 {{- with .Values.insightsController.tls }}

--- a/helm/templates/webhook-tls-secret.yaml
+++ b/helm/templates/webhook-tls-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" .
-      "component" .Values.insightsController.server.name
+      "name" "webhook-server"
       "labels" (list
         .Values.defaults.labels
         .Values.commonMetaLabels

--- a/helm/templates/webhook-validating-config.yaml
+++ b/helm/templates/webhook-validating-config.yaml
@@ -32,15 +32,29 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "cloudzero-agent.validatingWebhookConfigName" $ }}
   namespace: {{ $.Release.Namespace }}
-  labels:
-    {{- include "cloudzero-agent.insightsController.labels" $ | nindent 4 }}
+  {{- include "cloudzero-agent.generateLabels" (dict
+      "root" $
+      "component" $.Values.insightsController.server.name
+      "labels" (list
+        $.Values.defaults.labels
+        $.Values.commonMetaLabels
+        $.Values.components.webhookServer.labels
+      )
+    ) | nindent 2 }}
   # Certificate management annotations for automatic TLS certificate injection
   # When cert-manager is enabled, automatically injects CA bundle for webhook TLS validation
   {{- $certManagerAnnotations := dict -}}
   {{- if $.Values.insightsController.tls.useCertManager -}}
   {{- $certManagerAnnotations = dict "cert-manager.io/inject-ca-from" ($.Values.insightsController.webhooks.caInjection | default (printf "%s/%s" $.Release.Namespace (include "cloudzero-agent.certificateName" $))) -}}
   {{- end -}}
-  {{- include "cloudzero-agent.generateAnnotations" (merge (deepCopy $.Values.defaults.annotations) $certManagerAnnotations) | nindent 2 }}
+  {{- include "cloudzero-agent.generateAnnotations" (dict
+      "root" $
+      "annotations" (list
+        $.Values.defaults.annotations
+        $.Values.components.webhookServer.annotations
+        $certManagerAnnotations
+      )
+    ) | nindent 2 }}
 webhooks:
   - name: {{ include "cloudzero-agent.validatingWebhookName" $ }}
     # Namespace selector: Controls which namespaces trigger webhook processing

--- a/helm/templates/webhook-validating-config.yaml
+++ b/helm/templates/webhook-validating-config.yaml
@@ -34,7 +34,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   {{- include "cloudzero-agent.generateLabels" (dict
       "root" $
-      "component" $.Values.insightsController.server.name
+      "name" "webhook-server"
       "labels" (list
         $.Values.defaults.labels
         $.Values.commonMetaLabels

--- a/helm/tests/alloy_hpa_test.yaml
+++ b/helm/tests/alloy_hpa_test.yaml
@@ -177,7 +177,7 @@ tests:
           value: Max
 
   # Test HPA labels
-  - it: should have correct labels including component label
+  - it: should have correct labels including name label
     set:
       components.agent.mode: clustered
       components.agent.autoscaling.enabled: true
@@ -185,7 +185,7 @@ tests:
       - isNotEmpty:
           path: metadata.labels
       - equal:
-          path: metadata.labels["app.kubernetes.io/component"]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: server
 
   # Test that HPA scaleTargetRef.name matches deployment name

--- a/helm/tests/config_loader_job_labels_annotations_test.yaml
+++ b/helm/tests/config_loader_job_labels_annotations_test.yaml
@@ -196,12 +196,12 @@ tests:
           path: metadata.annotations["another"]
           value: "annotation"
 
-  # Test app.kubernetes.io/component label is set correctly
-  - it: should set app.kubernetes.io/component label to config-loader
+  # Test app.kubernetes.io/name label is set correctly
+  - it: should set app.kubernetes.io/name label to validator
     asserts:
       - equal:
-          path: metadata.labels["app.kubernetes.io/component"]
-          value: "config-loader"
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: "validator"
       - equal:
-          path: spec.template.metadata.labels["app.kubernetes.io/component"]
-          value: "config-loader"
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: "validator"

--- a/helm/tests/defaults_labels_annotations_all_resources_test.yaml
+++ b/helm/tests/defaults_labels_annotations_all_resources_test.yaml
@@ -17,7 +17,7 @@ templates:
   - agent-clusterrole.yaml
   - agent-clusterrolebinding.yaml
   - agent-cm.yaml
-  # agent-daemonset-cm.yaml and agent-daemonset.yaml only render in federated mode
+  # agent-daemonset-cm.yaml and agent-daemonset.yaml are tested in component_labels_hierarchy_test.yaml
   - agent-deploy.yaml
   - agent-pdb.yaml
   - agent-pvc.yaml
@@ -84,4 +84,190 @@ tests:
     asserts:
       - equal:
           path: metadata.annotations.foo
+          value: "bar"
+
+  # Pod template metadata tests - ensuring defaults propagate to pod-level metadata
+  # These tests verify that defaults.labels and defaults.annotations appear not just
+  # on resource metadata, but also on spec.template.metadata for workload resources.
+
+  - it: should apply defaults.labels to agent deployment pod template metadata
+    set:
+      defaults.labels:
+        foo: "bar"
+      components.agent.mode: agent
+    template: agent-deploy.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.foo
+          value: "bar"
+
+  # agent daemonset tests are in component_labels_hierarchy_test.yaml
+
+  - it: should apply defaults.labels to aggregator deployment pod template metadata
+    set:
+      defaults.labels:
+        foo: "bar"
+    template: aggregator-deploy.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.foo
+          value: "bar"
+
+  - it: should apply defaults.labels to webhook deployment pod template metadata
+    set:
+      defaults.labels:
+        foo: "bar"
+      insightsController.enabled: true
+    template: webhook-deploy.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.foo
+          value: "bar"
+
+  - it: should apply defaults.labels to config-loader job pod template metadata
+    set:
+      defaults.labels:
+        foo: "bar"
+    template: config-loader-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.foo
+          value: "bar"
+
+  - it: should apply defaults.labels to helmless job pod template metadata
+    set:
+      defaults.labels:
+        foo: "bar"
+    template: helmless-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.foo
+          value: "bar"
+
+  - it: should apply defaults.labels to init-cert job pod template metadata
+    set:
+      defaults.labels:
+        foo: "bar"
+      initCertJob.enabled: true
+    template: init-cert-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.foo
+          value: "bar"
+
+  - it: should apply defaults.labels to backfill cronjob pod template metadata
+    set:
+      defaults.labels:
+        foo: "bar"
+      insightsController.enabled: true
+      initBackfillJob.enabled: true
+    template: backfill-job.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels.foo
+          value: "bar"
+
+  - it: should apply defaults.labels to backfill onetime job pod template metadata
+    set:
+      defaults.labels:
+        foo: "bar"
+      insightsController.enabled: true
+      initBackfillJob.enabled: true
+    template: backfill-job.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.foo
+          value: "bar"
+
+  - it: should apply defaults.annotations to agent deployment pod template metadata
+    set:
+      defaults.annotations:
+        foo: "bar"
+      components.agent.mode: agent
+    template: agent-deploy.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.foo
+          value: "bar"
+
+  # agent daemonset tests are in component_labels_hierarchy_test.yaml
+
+  - it: should apply defaults.annotations to aggregator deployment pod template metadata
+    set:
+      defaults.annotations:
+        foo: "bar"
+    template: aggregator-deploy.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.foo
+          value: "bar"
+
+  - it: should apply defaults.annotations to webhook deployment pod template metadata
+    set:
+      defaults.annotations:
+        foo: "bar"
+      insightsController.enabled: true
+    template: webhook-deploy.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.foo
+          value: "bar"
+
+  - it: should apply defaults.annotations to config-loader job pod template metadata
+    set:
+      defaults.annotations:
+        foo: "bar"
+    template: config-loader-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.foo
+          value: "bar"
+
+  - it: should apply defaults.annotations to helmless job pod template metadata
+    set:
+      defaults.annotations:
+        foo: "bar"
+    template: helmless-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.foo
+          value: "bar"
+
+  - it: should apply defaults.annotations to backfill cronjob pod template metadata
+    set:
+      defaults.annotations:
+        foo: "bar"
+      insightsController.enabled: true
+      initBackfillJob.enabled: true
+    template: backfill-job.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations.foo
+          value: "bar"
+
+  - it: should apply defaults.annotations to backfill onetime job pod template metadata
+    set:
+      defaults.annotations:
+        foo: "bar"
+      insightsController.enabled: true
+      initBackfillJob.enabled: true
+    template: backfill-job.yaml
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.foo
+          value: "bar"
+
+  - it: should apply defaults.annotations to init-cert job pod template metadata
+    set:
+      defaults.annotations:
+        foo: "bar"
+      initCertJob.enabled: true
+    template: init-cert-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.foo
           value: "bar"

--- a/helm/tests/helmless_job_labels_annotations_test.yaml
+++ b/helm/tests/helmless_job_labels_annotations_test.yaml
@@ -179,12 +179,12 @@ tests:
           path: metadata.annotations["build"]
           value: "12345"
 
-  # Test app.kubernetes.io/component label is set correctly
-  - it: should set app.kubernetes.io/component label to helmless
+  # Test app.kubernetes.io/name label is set correctly
+  - it: should set app.kubernetes.io/name label to helmless
     asserts:
       - equal:
-          path: metadata.labels["app.kubernetes.io/component"]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: "helmless"
       - equal:
-          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: "helmless"

--- a/helm/tests/pod_labels_annotations_test.yaml
+++ b/helm/tests/pod_labels_annotations_test.yaml
@@ -1,0 +1,545 @@
+suite: test pod-specific labels and annotations
+templates:
+  - agent-deploy.yaml
+  - agent-daemonset.yaml
+  - aggregator-deploy.yaml
+  - webhook-deploy.yaml
+  - backfill-job.yaml
+  - config-loader-job.yaml
+  - helmless-job.yaml
+  - init-cert-job.yaml
+tests:
+  # ============================================================================
+  # Agent Deployment (components.agent)
+  # ============================================================================
+  - it: agent deployment should apply podLabels only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.agent.labels:
+        component-label: "component-value"
+      components.agent.podLabels:
+        pod-label: "pod-value"
+    template: agent-deploy.yaml
+    asserts:
+      # Pod template should have both component and pod labels
+      - equal:
+          path: spec.template.metadata.labels.component-label
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.labels.pod-label
+          value: "pod-value"
+      # Deployment metadata should NOT have pod labels
+      - equal:
+          path: metadata.labels.component-label
+          value: "component-value"
+      - isNull:
+          path: metadata.labels.pod-label
+
+  - it: agent deployment should apply podAnnotations only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.agent.annotations:
+        component-annotation: "component-value"
+      components.agent.podAnnotations:
+        pod-annotation: "pod-value"
+    template: agent-deploy.yaml
+    asserts:
+      # Pod template should have both component and pod annotations
+      - equal:
+          path: spec.template.metadata.annotations.component-annotation
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.annotations.pod-annotation
+          value: "pod-value"
+      # Deployment metadata should NOT have pod annotations
+      - equal:
+          path: metadata.annotations.component-annotation
+          value: "component-value"
+      - isNull:
+          path: metadata.annotations.pod-annotation
+
+  - it: agent deployment podLabels should have highest priority
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      defaults.labels:
+        priority-test: "defaults"
+      commonMetaLabels:
+        priority-test: "common"
+      components.agent.labels:
+        priority-test: "component"
+      components.agent.podLabels:
+        priority-test: "pod"
+    template: agent-deploy.yaml
+    asserts:
+      # Pod template should use pod-level value (highest priority)
+      - equal:
+          path: spec.template.metadata.labels.priority-test
+          value: "pod"
+
+  - it: agent deployment podAnnotations should have highest priority
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      defaults.annotations:
+        priority-test: "defaults"
+      components.agent.annotations:
+        priority-test: "component"
+      components.agent.podAnnotations:
+        priority-test: "pod"
+    template: agent-deploy.yaml
+    asserts:
+      # Pod template should use pod-level value (highest priority)
+      - equal:
+          path: spec.template.metadata.annotations.priority-test
+          value: "pod"
+
+  # ============================================================================
+  # Agent DaemonSet (components.agent.federatedNode)
+  # ============================================================================
+  - it: agent daemonset should apply podLabels only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: federated
+      components.agent.federatedNode.labels:
+        federated-label: "federated-value"
+      components.agent.federatedNode.podLabels:
+        pod-label: "pod-value"
+    template: agent-daemonset.yaml
+    asserts:
+      # Pod template should have both federated and pod labels
+      - equal:
+          path: spec.template.metadata.labels.federated-label
+          value: "federated-value"
+      - equal:
+          path: spec.template.metadata.labels.pod-label
+          value: "pod-value"
+      # DaemonSet metadata should NOT have pod labels
+      - equal:
+          path: metadata.labels.federated-label
+          value: "federated-value"
+      - isNull:
+          path: metadata.labels.pod-label
+
+  - it: agent daemonset should apply podAnnotations only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: federated
+      components.agent.federatedNode.annotations:
+        federated-annotation: "federated-value"
+      components.agent.federatedNode.podAnnotations:
+        pod-annotation: "pod-value"
+    template: agent-daemonset.yaml
+    asserts:
+      # Pod template should have both federated and pod annotations
+      - equal:
+          path: spec.template.metadata.annotations.federated-annotation
+          value: "federated-value"
+      - equal:
+          path: spec.template.metadata.annotations.pod-annotation
+          value: "pod-value"
+      # DaemonSet metadata should NOT have pod annotations
+      - equal:
+          path: metadata.annotations.federated-annotation
+          value: "federated-value"
+      - isNull:
+          path: metadata.annotations.pod-annotation
+
+  - it: agent daemonset podLabels should have highest priority
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: federated
+      components.agent.labels:
+        priority-test: "agent"
+      components.agent.federatedNode.labels:
+        priority-test: "federated"
+      components.agent.federatedNode.podLabels:
+        priority-test: "pod"
+    template: agent-daemonset.yaml
+    asserts:
+      # Pod template should use pod-level value (highest priority)
+      - equal:
+          path: spec.template.metadata.labels.priority-test
+          value: "pod"
+
+  # ============================================================================
+  # Aggregator Deployment (components.aggregator)
+  # ============================================================================
+  - it: aggregator deployment should apply podLabels only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.aggregator.labels:
+        component-label: "component-value"
+      components.aggregator.podLabels:
+        pod-label: "pod-value"
+    template: aggregator-deploy.yaml
+    asserts:
+      # Pod template should have both component and pod labels
+      - equal:
+          path: spec.template.metadata.labels.component-label
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.labels.pod-label
+          value: "pod-value"
+      # Deployment metadata should NOT have pod labels
+      - equal:
+          path: metadata.labels.component-label
+          value: "component-value"
+      - isNull:
+          path: metadata.labels.pod-label
+
+  - it: aggregator deployment should apply podAnnotations only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.aggregator.annotations:
+        component-annotation: "component-value"
+      components.aggregator.podAnnotations:
+        pod-annotation: "pod-value"
+    template: aggregator-deploy.yaml
+    asserts:
+      # Pod template should have both component and pod annotations
+      - equal:
+          path: spec.template.metadata.annotations.component-annotation
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.annotations.pod-annotation
+          value: "pod-value"
+      # Deployment metadata should NOT have pod annotations
+      - equal:
+          path: metadata.annotations.component-annotation
+          value: "component-value"
+      - isNull:
+          path: metadata.annotations.pod-annotation
+
+  - it: aggregator deployment podLabels should have highest priority
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      defaults.labels:
+        priority-test: "defaults"
+      components.aggregator.labels:
+        priority-test: "component"
+      components.aggregator.podLabels:
+        priority-test: "pod"
+    template: aggregator-deploy.yaml
+    asserts:
+      # Pod template should use pod-level value (highest priority)
+      - equal:
+          path: spec.template.metadata.labels.priority-test
+          value: "pod"
+
+  # ============================================================================
+  # Webhook Server Deployment (components.webhookServer)
+  # ============================================================================
+  - it: webhook deployment should apply podLabels only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.webhookServer.labels:
+        component-label: "component-value"
+      components.webhookServer.podLabels:
+        pod-label: "pod-value"
+    template: webhook-deploy.yaml
+    asserts:
+      # Pod template should have both component and pod labels
+      - equal:
+          path: spec.template.metadata.labels.component-label
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.labels.pod-label
+          value: "pod-value"
+      # Deployment metadata should NOT have pod labels
+      - equal:
+          path: metadata.labels.component-label
+          value: "component-value"
+      - isNull:
+          path: metadata.labels.pod-label
+
+  - it: webhook deployment should apply podAnnotations only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.webhookServer.annotations:
+        component-annotation: "component-value"
+      components.webhookServer.podAnnotations:
+        pod-annotation: "pod-value"
+    template: webhook-deploy.yaml
+    asserts:
+      # Pod template should have both component and pod annotations
+      - equal:
+          path: spec.template.metadata.annotations.component-annotation
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.annotations.pod-annotation
+          value: "pod-value"
+      # Deployment metadata should NOT have pod annotations
+      - equal:
+          path: metadata.annotations.component-annotation
+          value: "component-value"
+      - isNull:
+          path: metadata.annotations.pod-annotation
+
+  # ============================================================================
+  # Backfill CronJob (components.webhookServer.backfill)
+  # ============================================================================
+  - it: backfill cronjob should apply podLabels only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      insightsController.enabled: true
+      components.webhookServer.backfill.labels:
+        component-label: "component-value"
+      components.webhookServer.backfill.podLabels:
+        pod-label: "pod-value"
+    template: backfill-job.yaml
+    documentIndex: 0
+    asserts:
+      # Pod template should have both component and pod labels
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels.component-label
+          value: "component-value"
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels.pod-label
+          value: "pod-value"
+      # CronJob metadata should NOT have pod labels
+      - equal:
+          path: metadata.labels.component-label
+          value: "component-value"
+      - isNull:
+          path: metadata.labels.pod-label
+
+  - it: backfill job should apply podLabels only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      insightsController.enabled: true
+      components.webhookServer.backfill.labels:
+        component-label: "component-value"
+      components.webhookServer.backfill.podLabels:
+        pod-label: "pod-value"
+    template: backfill-job.yaml
+    documentIndex: 1
+    asserts:
+      # Pod template should have both component and pod labels
+      - equal:
+          path: spec.template.metadata.labels.component-label
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.labels.pod-label
+          value: "pod-value"
+      # Job metadata should NOT have pod labels
+      - equal:
+          path: metadata.labels.component-label
+          value: "component-value"
+      - isNull:
+          path: metadata.labels.pod-label
+
+  - it: backfill cronjob should apply podAnnotations only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      insightsController.enabled: true
+      components.webhookServer.backfill.annotations:
+        component-annotation: "component-value"
+      components.webhookServer.backfill.podAnnotations:
+        pod-annotation: "pod-value"
+    template: backfill-job.yaml
+    documentIndex: 0
+    asserts:
+      # Pod template should have both component and pod annotations
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations.component-annotation
+          value: "component-value"
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations.pod-annotation
+          value: "pod-value"
+      # CronJob metadata should NOT have pod annotations
+      - equal:
+          path: metadata.annotations.component-annotation
+          value: "component-value"
+      - isNull:
+          path: metadata.annotations.pod-annotation
+
+  # ============================================================================
+  # Config Loader Job (components.miscellaneous.configLoader)
+  # ============================================================================
+  - it: config-loader job should apply podLabels only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.miscellaneous.configLoader.labels:
+        component-label: "component-value"
+      components.miscellaneous.configLoader.podLabels:
+        pod-label: "pod-value"
+    template: config-loader-job.yaml
+    asserts:
+      # Pod template should have both component and pod labels
+      - equal:
+          path: spec.template.metadata.labels.component-label
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.labels.pod-label
+          value: "pod-value"
+      # Job metadata should NOT have pod labels
+      - equal:
+          path: metadata.labels.component-label
+          value: "component-value"
+      - isNull:
+          path: metadata.labels.pod-label
+
+  - it: config-loader job should apply podAnnotations only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.miscellaneous.configLoader.annotations:
+        component-annotation: "component-value"
+      components.miscellaneous.configLoader.podAnnotations:
+        pod-annotation: "pod-value"
+    template: config-loader-job.yaml
+    asserts:
+      # Pod template should have both component and pod annotations
+      - equal:
+          path: spec.template.metadata.annotations.component-annotation
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.annotations.pod-annotation
+          value: "pod-value"
+      # Job metadata should NOT have pod annotations
+      - equal:
+          path: metadata.annotations.component-annotation
+          value: "component-value"
+      - isNull:
+          path: metadata.annotations.pod-annotation
+
+  # ============================================================================
+  # Helmless Job (components.miscellaneous.helmless)
+  # ============================================================================
+  - it: helmless job should apply podLabels only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.miscellaneous.helmless.labels:
+        component-label: "component-value"
+      components.miscellaneous.helmless.podLabels:
+        pod-label: "pod-value"
+    template: helmless-job.yaml
+    asserts:
+      # Pod template should have both component and pod labels
+      - equal:
+          path: spec.template.metadata.labels.component-label
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.labels.pod-label
+          value: "pod-value"
+      # Job metadata should NOT have pod labels
+      - equal:
+          path: metadata.labels.component-label
+          value: "component-value"
+      - isNull:
+          path: metadata.labels.pod-label
+
+  - it: helmless job should apply podAnnotations only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      components.miscellaneous.helmless.annotations:
+        component-annotation: "component-value"
+      components.miscellaneous.helmless.podAnnotations:
+        pod-annotation: "pod-value"
+    template: helmless-job.yaml
+    asserts:
+      # Pod template should have both component and pod annotations
+      - equal:
+          path: spec.template.metadata.annotations.component-annotation
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.annotations.pod-annotation
+          value: "pod-value"
+      # Job metadata should NOT have pod annotations
+      - equal:
+          path: metadata.annotations.component-annotation
+          value: "component-value"
+      - isNull:
+          path: metadata.annotations.pod-annotation
+
+  # ============================================================================
+  # Init Cert Job (components.miscellaneous.initCert)
+  # ============================================================================
+  - it: init-cert job should apply podLabels only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      initCertJob.enabled: true
+      insightsController.tls.secret.create: true
+      insightsController.tls.useCertManager: false
+      components.miscellaneous.initCert.labels:
+        component-label: "component-value"
+      components.miscellaneous.initCert.podLabels:
+        pod-label: "pod-value"
+    template: init-cert-job.yaml
+    asserts:
+      # Pod template should have both component and pod labels
+      - equal:
+          path: spec.template.metadata.labels.component-label
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.labels.pod-label
+          value: "pod-value"
+      # Job metadata should NOT have pod labels
+      - equal:
+          path: metadata.labels.component-label
+          value: "component-value"
+      - isNull:
+          path: metadata.labels.pod-label
+
+  - it: init-cert job should apply podAnnotations only to pod template
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      initCertJob.enabled: true
+      insightsController.tls.secret.create: true
+      insightsController.tls.useCertManager: false
+      components.miscellaneous.initCert.annotations:
+        component-annotation: "component-value"
+      components.miscellaneous.initCert.podAnnotations:
+        pod-annotation: "pod-value"
+    template: init-cert-job.yaml
+    asserts:
+      # Pod template should have both component and pod annotations
+      - equal:
+          path: spec.template.metadata.annotations.component-annotation
+          value: "component-value"
+      - equal:
+          path: spec.template.metadata.annotations.pod-annotation
+          value: "pod-value"
+      # Job metadata should NOT have pod annotations
+      - equal:
+          path: metadata.annotations.component-annotation
+          value: "component-value"
+      - isNull:
+          path: metadata.annotations.pod-annotation

--- a/helm/tests/server_deployment_name_independence_test.yaml
+++ b/helm/tests/server_deployment_name_independence_test.yaml
@@ -72,10 +72,10 @@ tests:
       # Verify PDB selector has the expected labels
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/name"]
-          value: cloudzero-agent
-      - equal:
-          path: spec.selector.matchLabels["app.kubernetes.io/component"]
           value: server
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
   - it: should have deployment pod labels match PDB selector
     template: templates/agent-deploy.yaml
     set:
@@ -88,10 +88,10 @@ tests:
       # Verify deployment pod labels match PDB selector
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
-          value: cloudzero-agent
-      - equal:
-          path: spec.template.metadata.labels["app.kubernetes.io/component"]
           value: server
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
 
   # Test that deployment references PVC correctly
   - it: should have deployment claimName match PVC name

--- a/helm/tests/webhook_hpa_test.yaml
+++ b/helm/tests/webhook_hpa_test.yaml
@@ -252,7 +252,7 @@ tests:
           value: Max
 
   # Test HPA labels
-  - it: should have correct labels including component label
+  - it: should have correct labels including name label
     set:
       components.agent.autoscaling:
         enabled: false
@@ -262,5 +262,5 @@ tests:
       - isNotEmpty:
           path: metadata.labels
       - equal:
-          path: metadata.labels["app.kubernetes.io/component"]
+          path: metadata.labels["app.kubernetes.io/name"]
           value: webhook-server

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -5759,6 +5759,9 @@
             }
           ],
           "properties": {
+            "annotations": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            },
             "autoscaling": {
               "oneOf": [
                 {
@@ -5787,6 +5790,12 @@
             "federatedNode": {
               "additionalProperties": false,
               "properties": {
+                "annotations": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+                },
+                "labels": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
                 "resources": {
                   "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
                 },
@@ -5798,6 +5807,9 @@
             },
             "image": {
               "$ref": "#/$defs/com.cloudzero.agent.image"
+            },
+            "labels": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },
             "mode": {
               "default": null,
@@ -5878,6 +5890,9 @@
                   "type": "null"
                 }
               ]
+            },
+            "labels": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },
             "podDisruptionBudget": {
               "oneOf": [
@@ -5973,6 +5988,12 @@
             "initCert": {
               "additionalProperties": false,
               "properties": {
+                "annotations": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+                },
+                "labels": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
                 "resources": {
                   "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
                 },
@@ -6006,6 +6027,12 @@
         "validator": {
           "additionalProperties": false,
           "properties": {
+            "annotations": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            },
+            "labels": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+            },
             "resources": {
               "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
             }
@@ -6015,6 +6042,9 @@
         "webhookServer": {
           "additionalProperties": false,
           "properties": {
+            "annotations": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            },
             "autoscaling": {
               "oneOf": [
                 {
@@ -6028,6 +6058,12 @@
             "backfill": {
               "additionalProperties": false,
               "properties": {
+                "annotations": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+                },
+                "labels": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
                 "resources": {
                   "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
                 },
@@ -6040,6 +6076,9 @@
                 }
               },
               "type": "object"
+            },
+            "labels": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },
             "podDisruptionBudget": {
               "oneOf": [

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -5796,6 +5796,12 @@
                 "labels": {
                   "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
                 },
+                "podAnnotations": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+                },
+                "podLabels": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
                 "resources": {
                   "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
                 },
@@ -5822,6 +5828,9 @@
                 }
               ]
             },
+            "podAnnotations": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            },
             "podDisruptionBudget": {
               "oneOf": [
                 {
@@ -5831,6 +5840,9 @@
                   "type": "null"
                 }
               ]
+            },
+            "podLabels": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },
             "reloader": {
               "additionalProperties": false,
@@ -5894,6 +5906,9 @@
             "labels": {
               "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },
+            "podAnnotations": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            },
             "podDisruptionBudget": {
               "oneOf": [
                 {
@@ -5903,6 +5918,9 @@
                   "type": "null"
                 }
               ]
+            },
+            "podLabels": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },
             "replicas": {
               "additionalProperties": false,
@@ -5958,6 +5976,12 @@
                 "labels": {
                   "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
                 },
+                "podAnnotations": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+                },
+                "podLabels": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
                 "resources": {
                   "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
                 },
@@ -5976,6 +6000,12 @@
                 "labels": {
                   "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
                 },
+                "podAnnotations": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+                },
+                "podLabels": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
                 "resources": {
                   "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
                 },
@@ -5992,6 +6022,12 @@
                   "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
                 },
                 "labels": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
+                "podAnnotations": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+                },
+                "podLabels": {
                   "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
                 },
                 "resources": {
@@ -6064,6 +6100,12 @@
                 "labels": {
                   "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
                 },
+                "podAnnotations": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+                },
+                "podLabels": {
+                  "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+                },
                 "resources": {
                   "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
                 },
@@ -6080,6 +6122,9 @@
             "labels": {
               "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },
+            "podAnnotations": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+            },
             "podDisruptionBudget": {
               "oneOf": [
                 {
@@ -6089,6 +6134,9 @@
                   "type": "null"
                 }
               ]
+            },
+            "podLabels": {
+              "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },
             "replicas": {
               "additionalProperties": false,

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -443,12 +443,36 @@ properties:
               For details, see the Kubernetes documentation on security contexts:
               https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
             $ref: "#/$defs/io.k8s.api.core.v1.PodSecurityContext"
+          labels:
+            description: |
+              Labels to be added to agent resources.
+
+              These labels are merged with defaults.labels.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+          annotations:
+            description: |
+              Annotations to be added to agent resources.
+
+              These annotations are merged with defaults.annotations.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           federatedNode:
             description: |
               The agent federated node component runs on each node for federation.
             additionalProperties: false
             type: object
             properties:
+              labels:
+                description: |
+                  Labels to be added to agent federated node resources.
+
+                  These labels are merged with defaults.labels and components.agent.labels.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              annotations:
+                description: |
+                  Annotations to be added to agent federated node resources.
+
+                  These annotations are merged with defaults.annotations and components.agent.annotations.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
               resources:
                 description: |
                   Resource requirements and limits for the agent federated node component.
@@ -595,6 +619,18 @@ properties:
         additionalProperties: false
         type: object
         properties:
+          labels:
+            description: |
+              Labels to be added to validator resources.
+
+              These labels are merged with defaults.labels.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+          annotations:
+            description: |
+              Annotations to be added to validator resources.
+
+              These annotations are merged with defaults.annotations.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           resources:
             description: |
               Resource requirements and limits for the validator component.
@@ -693,6 +729,18 @@ properties:
                   For details, see the Kubernetes documentation on security contexts:
                   https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                 $ref: "#/$defs/io.k8s.api.core.v1.PodSecurityContext"
+              labels:
+                description: |
+                  Labels to add to the init cert job.
+
+                  These labels are merged with defaults.labels.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              annotations:
+                description: |
+                  Annotations to add to the init cert job.
+
+                  These annotations are merged with defaults.annotations.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
 
       aggregator:
         description: |
@@ -703,9 +751,17 @@ properties:
         additionalProperties: false
         type: object
         properties:
+          labels:
+            description: |
+              Labels to be added to aggregator resources.
+
+              These labels are merged with defaults.labels.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
           annotations:
             description: |
               Annotations to be added to the aggregator deployment.
+
+              These annotations are merged with defaults.annotations.
             $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           collector:
             description: |
@@ -875,6 +931,18 @@ properties:
               For details, see the Kubernetes documentation on security contexts:
               https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
             $ref: "#/$defs/io.k8s.api.core.v1.PodSecurityContext"
+          labels:
+            description: |
+              Labels to be added to webhook server resources.
+
+              These labels are merged with defaults.labels.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+          annotations:
+            description: |
+              Annotations to be added to webhook server resources.
+
+              These annotations are merged with defaults.annotations.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           backfill:
             description: |
               The backfill job component performs initial data backfilling.
@@ -886,6 +954,18 @@ properties:
                   Schedule for the backfill CronJob. Defaults to every 3 hours. Use standard cron format.
                 $ref: "#/$defs/io.k8s.api.batch.v1.CronJobSpec/properties/schedule"
                 default: "0 */3 * * *"
+              labels:
+                description: |
+                  Labels to be added to backfill job resources.
+
+                  These labels are merged with defaults.labels and components.webhookServer.labels.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              annotations:
+                description: |
+                  Annotations to be added to backfill job resources.
+
+                  These annotations are merged with defaults.annotations and components.webhookServer.annotations.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
               resources:
                 description: |
                   Resource requirements and limits for the backfill job component.

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -455,6 +455,20 @@ properties:
 
               These annotations are merged with defaults.annotations.
             $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+          podLabels:
+            description: |
+              Pod-specific labels that apply ONLY to pod templates.
+
+              These labels are merged after component labels with highest priority
+              and only appear in pod metadata, not on parent resources.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+          podAnnotations:
+            description: |
+              Pod-specific annotations that apply ONLY to pod templates.
+
+              These annotations are merged after component annotations and only
+              appear in pod metadata, not on parent resources.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           federatedNode:
             description: |
               The agent federated node component runs on each node for federation.
@@ -472,6 +486,20 @@ properties:
                   Annotations to be added to agent federated node resources.
 
                   These annotations are merged with defaults.annotations and components.agent.annotations.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+              podLabels:
+                description: |
+                  Pod-specific labels that apply ONLY to pod templates.
+
+                  These labels are merged after federated node labels with highest priority
+                  and only appear in pod metadata, not on the DaemonSet.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              podAnnotations:
+                description: |
+                  Pod-specific annotations that apply ONLY to pod templates.
+
+                  These annotations are merged after federated node annotations and only
+                  appear in pod metadata, not on the DaemonSet.
                 $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
               resources:
                 description: |
@@ -677,6 +705,20 @@ properties:
 
                   These labels are merged with defaults.labels.
                 $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              podLabels:
+                description: |
+                  Pod-specific labels that apply ONLY to pod templates.
+
+                  These labels are merged after component labels with highest priority
+                  and only appear in pod metadata, not on the Job.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              podAnnotations:
+                description: |
+                  Pod-specific annotations that apply ONLY to pod templates.
+
+                  These annotations are merged after component annotations and only
+                  appear in pod metadata, not on the Job.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           helmless:
             description: |
               The helmless job component generates configuration without Helm.
@@ -709,6 +751,20 @@ properties:
 
                   These labels are merged with defaults.labels.
                 $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              podLabels:
+                description: |
+                  Pod-specific labels that apply ONLY to pod templates.
+
+                  These labels are merged after component labels with highest priority
+                  and only appear in pod metadata, not on the Job.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              podAnnotations:
+                description: |
+                  Pod-specific annotations that apply ONLY to pod templates.
+
+                  These annotations are merged after component annotations and only
+                  appear in pod metadata, not on the Job.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           initCert:
             description: |
               The init cert job component initializes TLS certificates.
@@ -741,6 +797,20 @@ properties:
 
                   These annotations are merged with defaults.annotations.
                 $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+              podLabels:
+                description: |
+                  Pod-specific labels that apply ONLY to pod templates.
+
+                  These labels are merged after component labels with highest priority
+                  and only appear in pod metadata, not on the Job.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              podAnnotations:
+                description: |
+                  Pod-specific annotations that apply ONLY to pod templates.
+
+                  These annotations are merged after component annotations and only
+                  appear in pod metadata, not on the Job.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
 
       aggregator:
         description: |
@@ -762,6 +832,20 @@ properties:
               Annotations to be added to the aggregator deployment.
 
               These annotations are merged with defaults.annotations.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+          podLabels:
+            description: |
+              Pod-specific labels that apply ONLY to pod templates.
+
+              These labels are merged after component labels with highest priority
+              and only appear in pod metadata, not on the Deployment.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+          podAnnotations:
+            description: |
+              Pod-specific annotations that apply ONLY to pod templates.
+
+              These annotations are merged after component annotations and only
+              appear in pod metadata, not on the Deployment.
             $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           collector:
             description: |
@@ -943,6 +1027,20 @@ properties:
 
               These annotations are merged with defaults.annotations.
             $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+          podLabels:
+            description: |
+              Pod-specific labels that apply ONLY to pod templates.
+
+              These labels are merged after component labels with highest priority
+              and only appear in pod metadata, not on the Deployment.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+          podAnnotations:
+            description: |
+              Pod-specific annotations that apply ONLY to pod templates.
+
+              These annotations are merged after component annotations and only
+              appear in pod metadata, not on the Deployment.
+            $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
           backfill:
             description: |
               The backfill job component performs initial data backfilling.
@@ -965,6 +1063,20 @@ properties:
                   Annotations to be added to backfill job resources.
 
                   These annotations are merged with defaults.annotations and components.webhookServer.annotations.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
+              podLabels:
+                description: |
+                  Pod-specific labels that apply ONLY to pod templates.
+
+                  These labels are merged after backfill labels with highest priority
+                  and only appear in pod metadata, not on the CronJob or Job.
+                $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
+              podAnnotations:
+                description: |
+                  Pod-specific annotations that apply ONLY to pod templates.
+
+                  These annotations are merged after backfill annotations and only
+                  appear in pod metadata, not on the CronJob or Job.
                 $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
               resources:
                 description: |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -337,6 +337,14 @@ components:
   # The validator component performs validation checks and notifies the platform
   # of installation status changes.
   validator:
+    # Annotations to add to the validator component.
+    #
+    # These annotations are merged with defaults.annotations.
+    annotations: {}
+    # Labels to add to the validator component.
+    #
+    # These labels are merged with defaults.labels.
+    labels: {}
     # Resource requirements and limits for the validator component.
     #
     # For details, see the Kubernetes documentation on resource management:
@@ -405,6 +413,14 @@ components:
       labels: {}
     # The init cert job component initializes TLS certificates.
     initCert:
+      # Annotations to add to the init cert job component.
+      #
+      # These annotations are merged with defaults.annotations.
+      annotations: {}
+      # Labels to add to the init cert job component.
+      #
+      # These labels are merged with defaults.labels.
+      labels: {}
       # Resource requirements and limits for the init cert job component.
       #
       # For details, see the Kubernetes documentation on resource management:
@@ -450,7 +466,14 @@ components:
       # minAvailable:
       # maxUnavailable:
     tolerations: []
+    # Annotations to add to the aggregator component.
+    #
+    # These annotations are merged with defaults.annotations.
     annotations: {}
+    # Labels to add to the aggregator component.
+    #
+    # These labels are merged with defaults.labels.
+    labels: {}
     # Security context for the aggregator pods.
     #
     # For details, see the Kubernetes documentation on security contexts:
@@ -504,6 +527,14 @@ components:
       # enabled:
       # minAvailable:
       # maxUnavailable:
+    # Annotations to add to the webhook server component.
+    #
+    # These annotations are merged with defaults.annotations.
+    annotations: {}
+    # Labels to add to the webhook server component.
+    #
+    # These labels are merged with defaults.labels.
+    labels: {}
     # Security context for the webhook server pods.
     #
     # For details, see the Kubernetes documentation on security contexts:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -255,6 +255,26 @@ components:
       # enabled:
       # minAvailable:
       # maxUnavailable:
+    # Annotations to add to the agent component.
+    #
+    # These annotations are merged with defaults.annotations and apply to
+    # parent resources (Deployment/DaemonSet) and pods.
+    annotations: {}
+    # Labels to add to the agent component.
+    #
+    # These labels are merged with defaults.labels and apply to parent
+    # resources (Deployment/DaemonSet) and pods.
+    labels: {}
+    # Pod-specific annotations that apply ONLY to pod templates.
+    #
+    # These annotations are merged after component annotations and only
+    # appear in pod metadata, not on parent resources.
+    podAnnotations: {}
+    # Pod-specific labels that apply ONLY to pod templates.
+    #
+    # These labels are merged after component labels with highest priority
+    # and only appear in pod metadata, not on parent resources.
+    podLabels: {}
     # Security context for the agent pods.
     #
     # For details, see the Kubernetes documentation on security contexts:
@@ -274,6 +294,26 @@ components:
 
     # The agent federated node component runs on each node for federation.
     federatedNode:
+      # Annotations to add to the agent federated node component.
+      #
+      # These annotations are merged with defaults.annotations and
+      # components.agent.annotations, applying to the DaemonSet and pods.
+      annotations: {}
+      # Labels to add to the agent federated node component.
+      #
+      # These labels are merged with defaults.labels and components.agent.labels,
+      # applying to the DaemonSet and pods.
+      labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after federated node annotations and only
+      # appear in pod metadata, not on the DaemonSet.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after federated node labels with highest priority
+      # and only appear in pod metadata, not on the DaemonSet.
+      podLabels: {}
       # Security context for the agent federated node pods.
       #
       # For details, see the Kubernetes documentation on security contexts:
@@ -379,12 +419,24 @@ components:
       securityContext: {}
       # Annotations to add to the config loader job.
       #
-      # These annotations are merged with defaults.annotations.
+      # These annotations are merged with defaults.annotations and apply to
+      # the Job and pods.
       annotations: {}
       # Labels to add to the config loader job.
       #
-      # These labels are merged with defaults.labels.
+      # These labels are merged with defaults.labels and apply to the
+      # Job and pods.
       labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after component annotations and only
+      # appear in pod metadata, not on the Job.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after component labels with highest priority
+      # and only appear in pod metadata, not on the Job.
+      podLabels: {}
     # The helmless job component generates configuration without Helm.
     helmless:
       # Resource requirements and limits for the helmless job component.
@@ -405,22 +457,46 @@ components:
       securityContext: {}
       # Annotations to add to the helmless job.
       #
-      # These annotations are merged with defaults.annotations.
+      # These annotations are merged with defaults.annotations and apply to
+      # the Job and pods.
       annotations: {}
       # Labels to add to the helmless job.
       #
-      # These labels are merged with defaults.labels.
+      # These labels are merged with defaults.labels and apply to the
+      # Job and pods.
       labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after component annotations and only
+      # appear in pod metadata, not on the Job.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after component labels with highest priority
+      # and only appear in pod metadata, not on the Job.
+      podLabels: {}
     # The init cert job component initializes TLS certificates.
     initCert:
       # Annotations to add to the init cert job component.
       #
-      # These annotations are merged with defaults.annotations.
+      # These annotations are merged with defaults.annotations and apply to
+      # the Job and pods.
       annotations: {}
       # Labels to add to the init cert job component.
       #
-      # These labels are merged with defaults.labels.
+      # These labels are merged with defaults.labels and apply to the
+      # Job and pods.
       labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after component annotations and only
+      # appear in pod metadata, not on the Job.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after component labels with highest priority
+      # and only appear in pod metadata, not on the Job.
+      podLabels: {}
       # Resource requirements and limits for the init cert job component.
       #
       # For details, see the Kubernetes documentation on resource management:
@@ -468,12 +544,24 @@ components:
     tolerations: []
     # Annotations to add to the aggregator component.
     #
-    # These annotations are merged with defaults.annotations.
+    # These annotations are merged with defaults.annotations and apply to
+    # the Deployment and pods.
     annotations: {}
     # Labels to add to the aggregator component.
     #
-    # These labels are merged with defaults.labels.
+    # These labels are merged with defaults.labels and apply to the
+    # Deployment and pods.
     labels: {}
+    # Pod-specific annotations that apply ONLY to pod templates.
+    #
+    # These annotations are merged after component annotations and only
+    # appear in pod metadata, not on the Deployment.
+    podAnnotations: {}
+    # Pod-specific labels that apply ONLY to pod templates.
+    #
+    # These labels are merged after component labels with highest priority
+    # and only appear in pod metadata, not on the Deployment.
+    podLabels: {}
     # Security context for the aggregator pods.
     #
     # For details, see the Kubernetes documentation on security contexts:
@@ -529,12 +617,24 @@ components:
       # maxUnavailable:
     # Annotations to add to the webhook server component.
     #
-    # These annotations are merged with defaults.annotations.
+    # These annotations are merged with defaults.annotations and apply to
+    # the Deployment and pods.
     annotations: {}
     # Labels to add to the webhook server component.
     #
-    # These labels are merged with defaults.labels.
+    # These labels are merged with defaults.labels and apply to the
+    # Deployment and pods.
     labels: {}
+    # Pod-specific annotations that apply ONLY to pod templates.
+    #
+    # These annotations are merged after component annotations and only
+    # appear in pod metadata, not on the Deployment.
+    podAnnotations: {}
+    # Pod-specific labels that apply ONLY to pod templates.
+    #
+    # These labels are merged after component labels with highest priority
+    # and only appear in pod metadata, not on the Deployment.
+    podLabels: {}
     # Security context for the webhook server pods.
     #
     # For details, see the Kubernetes documentation on security contexts:
@@ -553,6 +653,26 @@ components:
         cpu: "500m"
     # The backfill job component performs initial data backfilling.
     backfill:
+      # Annotations to add to the backfill job component.
+      #
+      # These annotations are merged with defaults.annotations and
+      # components.webhookServer.annotations, applying to the CronJob/Job and pods.
+      annotations: {}
+      # Labels to add to the backfill job component.
+      #
+      # These labels are merged with defaults.labels and
+      # components.webhookServer.labels, applying to the CronJob/Job and pods.
+      labels: {}
+      # Pod-specific annotations that apply ONLY to pod templates.
+      #
+      # These annotations are merged after backfill annotations and only
+      # appear in pod metadata, not on the CronJob/Job.
+      podAnnotations: {}
+      # Pod-specific labels that apply ONLY to pod templates.
+      #
+      # These labels are merged after backfill labels with highest priority
+      # and only appear in pod metadata, not on the CronJob/Job.
+      podLabels: {}
       # Schedule for the backfill CronJob. Defaults to every 12 hours. Use standard cron format.
       schedule: "0 */12 * * *"
       # Resource requirements and limits for the backfill job component.

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -141,7 +141,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -404,6 +404,7 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -756,6 +757,7 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -878,6 +880,7 @@ data:
               cpu: 100m
               memory: 64Mi
           securityContext: {}
+        labels: {}
         podDisruptionBudget: null
         replicas: null
         securityContext: {}
@@ -915,6 +918,8 @@ data:
               memory: 64Mi
           securityContext: {}
         initCert:
+          annotations: {}
+          labels: {}
           resources:
             limits:
               cpu: 200m
@@ -932,6 +937,8 @@ data:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
           tag: v0.84.0
       validator:
+        annotations: {}
+        labels: {}
         resources:
           limits:
             cpu: 200m
@@ -940,6 +947,7 @@ data:
             cpu: 50m
             memory: 64Mi
       webhookServer:
+        annotations: {}
         autoscaling: null
         backfill:
           resources:
@@ -951,6 +959,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        labels: {}
         podDisruptionBudget: null
         replicas: null
         resources:
@@ -1535,7 +1544,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: validator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -2031,7 +2040,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
+    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -2225,7 +2234,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
@@ -2246,7 +2254,6 @@ spec:
   replicas: 2
   template:
     metadata:
-        
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/instance: cz-agent
@@ -2255,6 +2262,7 @@ spec:
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
+      
     spec:
       
       serviceAccountName: cz-agent-cz-server
@@ -2502,7 +2510,7 @@ metadata:
     app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cz-agent-cz-aggregator
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2521,7 +2529,7 @@ spec:
         app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cz-agent-cz-aggregator
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2788,19 +2796,23 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-    job-type: backfill
     job-category: onetime
+    job-type: backfill
 spec:
   template:
     metadata:
       name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
-        job-type: backfill
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v3.7.3
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
         job-category: onetime
+        job-type: backfill
       
     spec:
           serviceAccountName: cz-agent-cz-server
@@ -3055,7 +3067,7 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
+    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -3067,9 +3079,13 @@ spec:
     metadata:
       name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/component: init-cert
         app.kubernetes.io/instance: cz-agent
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v3.7.3
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
       
@@ -3125,8 +3141,8 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-    job-type: backfill
     job-category: cronjob
+    job-type: backfill
 spec:
   schedule: "0 */12 * * *"
   concurrencyPolicy: Forbid
@@ -3139,11 +3155,15 @@ spec:
           name: cz-agent-backfill
           namespace: cz-agent
           labels:
-            app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
-            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/component: webhook-server
             app.kubernetes.io/instance: cz-agent
-            job-type: backfill
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/part-of: cloudzero-agent
+            app.kubernetes.io/version: v3.7.3
+            helm.sh/chart: cloudzero-agent-1.1.0-dev
             job-category: cronjob
+            job-type: backfill
           
         spec:
           serviceAccountName: cz-agent-cz-server

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -26,10 +26,9 @@ metadata:
   name: cz-agent-cz-server
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -38,8 +37,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: server
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/templates/aggregator-pdb.yaml
@@ -49,10 +47,9 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -61,8 +58,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: aggregator
-      app.kubernetes.io/name: cz-agent-cz-aggregator
+      app.kubernetes.io/name: aggregator
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/templates/webhook-pdb.yaml
@@ -72,10 +68,9 @@ metadata:
   name: cz-agent-cz-webhook
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -84,8 +79,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: webhook-server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/charts/kubeStateMetrics/templates/serviceaccount.yaml
@@ -109,10 +103,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -125,10 +118,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -141,10 +133,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -159,10 +150,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -175,10 +165,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -404,10 +393,9 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -757,10 +745,9 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1544,10 +1531,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: validator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1627,10 +1613,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1857,10 +1842,9 @@ kind: ClusterRole
 metadata:
   
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1949,10 +1933,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2017,10 +2000,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2040,10 +2022,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2102,8 +2083,7 @@ metadata:
   
 spec:
   selector:
-    app.kubernetes.io/component: aggregator
-    app.kubernetes.io/name: cz-agent-cz-aggregator
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/instance: cz-agent
   ports:
     - protocol: TCP
@@ -2117,10 +2097,9 @@ kind: Service
 metadata:
   name: cz-agent-cz-webhook
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2135,8 +2114,7 @@ spec:
       name: http
       appProtocol: https
   selector:
-    app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/charts/kubeStateMetrics/templates/deployment.yaml
@@ -2235,10 +2213,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2248,17 +2225,15 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: server
       app.kubernetes.io/instance: cz-agent
   replicas: 2
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2507,18 +2482,16 @@ metadata:
   # Labels: Combine standard aggregator labels with user-defined metadata labels
   # Provides consistent labeling for service discovery, monitoring, and resource management
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: aggregator
-      app.kubernetes.io/name: cz-agent-cz-aggregator
+      app.kubernetes.io/name: aggregator
       app.kubernetes.io/instance: cz-agent
   replicas: 3
   template:
@@ -2526,10 +2499,9 @@ spec:
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: aggregator
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2666,10 +2638,9 @@ metadata:
   namespace: cz-agent
   # Standard webhook server labels for consistent resource identification
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2680,16 +2651,14 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: webhook-server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: cz-agent
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: webhook-server
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2789,10 +2758,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2804,10 +2772,9 @@ spec:
       name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: backfill
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2873,10 +2840,9 @@ metadata:
   annotations:
     checksum/values: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   labels:
-    app.kubernetes.io/component: config-loader
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2886,10 +2852,9 @@ spec:
       name: cz-agent-confload-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: config-loader
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: validator
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2997,10 +2962,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3010,10 +2974,9 @@ spec:
       name: cz-agent-helmless-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: helmless
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: helmless
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3067,10 +3030,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3079,10 +3041,9 @@ spec:
     metadata:
       name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: init-cert
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: init-cert
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3134,10 +3095,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3155,10 +3115,9 @@ spec:
           name: cz-agent-backfill
           namespace: cz-agent
           labels:
-            app.kubernetes.io/component: webhook-server
             app.kubernetes.io/instance: cz-agent
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/name: backfill
             app.kubernetes.io/part-of: cloudzero-agent
             app.kubernetes.io/version: v3.7.3
             helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3222,10 +3181,9 @@ metadata:
   name: cz-agent-cz-webhook
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -812,6 +812,7 @@ data:
     commonMetaLabels: {}
     components:
       agent:
+        annotations: {}
         autoscaling: null
         clusteredNode:
           image:
@@ -825,6 +826,10 @@ data:
               cpu: 50m
               memory: 256Mi
         federatedNode:
+          annotations: {}
+          labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 1000m
@@ -836,8 +841,11 @@ data:
         image:
           repository: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent
           tag: 1.2.8
+        labels: {}
         mode: clustered
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         reloader:
           resources:
             limits:
@@ -868,7 +876,9 @@ data:
               memory: 64Mi
           securityContext: {}
         labels: {}
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         replicas: null
         securityContext: {}
         shipper:
@@ -885,6 +895,8 @@ data:
         configLoader:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 500m
@@ -896,6 +908,8 @@ data:
         helmless:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 200m
@@ -907,6 +921,8 @@ data:
         initCert:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 200m
@@ -937,6 +953,10 @@ data:
         annotations: {}
         autoscaling: null
         backfill:
+          annotations: {}
+          labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 500m
@@ -947,7 +967,9 @@ data:
           schedule: 0 */12 * * *
           securityContext: {}
         labels: {}
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         replicas: null
         resources:
           limits:

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -141,7 +141,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -365,6 +365,7 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -717,6 +718,7 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -838,6 +840,7 @@ data:
               cpu: 100m
               memory: 64Mi
           securityContext: {}
+        labels: {}
         podDisruptionBudget: null
         replicas: null
         securityContext: {}
@@ -875,6 +878,8 @@ data:
               memory: 64Mi
           securityContext: {}
         initCert:
+          annotations: {}
+          labels: {}
           resources:
             limits:
               cpu: 200m
@@ -892,6 +897,8 @@ data:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
           tag: v0.84.0
       validator:
+        annotations: {}
+        labels: {}
         resources:
           limits:
             cpu: 200m
@@ -900,6 +907,7 @@ data:
             cpu: 50m
             memory: 64Mi
       webhookServer:
+        annotations: {}
         autoscaling: null
         backfill:
           resources:
@@ -911,6 +919,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        labels: {}
         podDisruptionBudget: null
         replicas: null
         resources:
@@ -1495,7 +1504,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: validator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -1991,7 +2000,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
+    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -2185,7 +2194,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
@@ -2206,7 +2214,6 @@ spec:
   replicas: 1
   template:
     metadata:
-        
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/instance: cz-agent
@@ -2215,6 +2222,7 @@ spec:
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
+      
     spec:
       
       serviceAccountName: cz-agent-cz-server
@@ -2455,7 +2463,7 @@ metadata:
     app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cz-agent-cz-aggregator
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2474,7 +2482,7 @@ spec:
         app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cz-agent-cz-aggregator
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2741,19 +2749,23 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-    job-type: backfill
     job-category: onetime
+    job-type: backfill
 spec:
   template:
     metadata:
       name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
-        job-type: backfill
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v3.7.3
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
         job-category: onetime
+        job-type: backfill
       
     spec:
           serviceAccountName: cz-agent-cz-server
@@ -3015,8 +3027,8 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-    job-type: backfill
     job-category: cronjob
+    job-type: backfill
 spec:
   schedule: "0 */12 * * *"
   concurrencyPolicy: Forbid
@@ -3029,11 +3041,15 @@ spec:
           name: cz-agent-backfill
           namespace: cz-agent
           labels:
-            app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
-            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/component: webhook-server
             app.kubernetes.io/instance: cz-agent
-            job-type: backfill
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/part-of: cloudzero-agent
+            app.kubernetes.io/version: v3.7.3
+            helm.sh/chart: cloudzero-agent-1.1.0-dev
             job-category: cronjob
+            job-type: backfill
           
         spec:
           serviceAccountName: cz-agent-cz-server
@@ -3092,6 +3108,7 @@ metadata:
   name: cz-agent-cz-webhook-certificate
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -3131,6 +3148,7 @@ metadata:
   name: cz-agent-cz-webhook-issuer
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -774,6 +774,7 @@ data:
     commonMetaLabels: {}
     components:
       agent:
+        annotations: {}
         autoscaling: null
         clusteredNode:
           image:
@@ -787,6 +788,10 @@ data:
               cpu: 50m
               memory: 256Mi
         federatedNode:
+          annotations: {}
+          labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 1000m
@@ -798,8 +803,11 @@ data:
         image:
           repository: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent
           tag: 1.2.8
+        labels: {}
         mode: null
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         reloader:
           resources:
             limits:
@@ -829,7 +837,9 @@ data:
               memory: 64Mi
           securityContext: {}
         labels: {}
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         replicas: null
         securityContext: {}
         shipper:
@@ -846,6 +856,8 @@ data:
         configLoader:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 500m
@@ -857,6 +869,8 @@ data:
         helmless:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 200m
@@ -868,6 +882,8 @@ data:
         initCert:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 200m
@@ -898,6 +914,10 @@ data:
         annotations: {}
         autoscaling: null
         backfill:
+          annotations: {}
+          labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 500m
@@ -908,7 +928,9 @@ data:
           schedule: 0 */12 * * *
           securityContext: {}
         labels: {}
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         replicas: null
         resources:
           limits:

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -26,10 +26,9 @@ metadata:
   name: cz-agent-cz-server
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -38,8 +37,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: server
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/templates/aggregator-pdb.yaml
@@ -49,10 +47,9 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -61,8 +58,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: aggregator
-      app.kubernetes.io/name: cz-agent-cz-aggregator
+      app.kubernetes.io/name: aggregator
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/templates/webhook-pdb.yaml
@@ -72,10 +68,9 @@ metadata:
   name: cz-agent-cz-webhook
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -84,8 +79,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: webhook-server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/charts/kubeStateMetrics/templates/serviceaccount.yaml
@@ -109,10 +103,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -125,10 +118,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -141,10 +133,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -159,10 +150,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -365,10 +355,9 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -718,10 +707,9 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1504,10 +1492,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: validator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1587,10 +1574,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1817,10 +1803,9 @@ kind: ClusterRole
 metadata:
   
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1909,10 +1894,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1977,10 +1961,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2000,10 +1983,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2062,8 +2044,7 @@ metadata:
   
 spec:
   selector:
-    app.kubernetes.io/component: aggregator
-    app.kubernetes.io/name: cz-agent-cz-aggregator
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/instance: cz-agent
   ports:
     - protocol: TCP
@@ -2077,10 +2058,9 @@ kind: Service
 metadata:
   name: cz-agent-cz-webhook
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2095,8 +2075,7 @@ spec:
       name: http
       appProtocol: https
   selector:
-    app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/charts/kubeStateMetrics/templates/deployment.yaml
@@ -2195,10 +2174,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2208,17 +2186,15 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: server
       app.kubernetes.io/instance: cz-agent
   replicas: 1
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2460,18 +2436,16 @@ metadata:
   # Labels: Combine standard aggregator labels with user-defined metadata labels
   # Provides consistent labeling for service discovery, monitoring, and resource management
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: aggregator
-      app.kubernetes.io/name: cz-agent-cz-aggregator
+      app.kubernetes.io/name: aggregator
       app.kubernetes.io/instance: cz-agent
   replicas: 3
   template:
@@ -2479,10 +2453,9 @@ spec:
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: aggregator
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2619,10 +2592,9 @@ metadata:
   namespace: cz-agent
   # Standard webhook server labels for consistent resource identification
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2633,16 +2605,14 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: webhook-server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: cz-agent
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: webhook-server
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2742,10 +2712,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2757,10 +2726,9 @@ spec:
       name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: backfill
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2826,10 +2794,9 @@ metadata:
   annotations:
     checksum/values: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   labels:
-    app.kubernetes.io/component: config-loader
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2839,10 +2806,9 @@ spec:
       name: cz-agent-confload-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: config-loader
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: validator
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2950,10 +2916,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2963,10 +2928,9 @@ spec:
       name: cz-agent-helmless-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: helmless
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: helmless
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3020,10 +2984,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3041,10 +3004,9 @@ spec:
           name: cz-agent-backfill
           namespace: cz-agent
           labels:
-            app.kubernetes.io/component: webhook-server
             app.kubernetes.io/instance: cz-agent
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/name: backfill
             app.kubernetes.io/part-of: cloudzero-agent
             app.kubernetes.io/version: v3.7.3
             helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3108,10 +3070,9 @@ metadata:
   name: cz-agent-cz-webhook-certificate
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3120,10 +3081,9 @@ spec:
   secretName: cz-agent-cz-webhook-tls
   secretTemplate:
     labels:
-      app.kubernetes.io/component: webhook-server
       app.kubernetes.io/instance: cz-agent
       app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: webhook-server
       app.kubernetes.io/part-of: cloudzero-agent
       app.kubernetes.io/version: v3.7.3
       helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3148,10 +3108,9 @@ metadata:
   name: cz-agent-cz-webhook-issuer
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3166,10 +3125,9 @@ metadata:
   name: cz-agent-cz-webhook
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -141,7 +141,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -325,7 +325,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -434,6 +434,7 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -786,6 +787,7 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -907,6 +909,7 @@ data:
               cpu: 100m
               memory: 64Mi
           securityContext: {}
+        labels: {}
         podDisruptionBudget: null
         replicas: null
         securityContext: {}
@@ -944,6 +947,8 @@ data:
               memory: 64Mi
           securityContext: {}
         initCert:
+          annotations: {}
+          labels: {}
           resources:
             limits:
               cpu: 200m
@@ -961,6 +966,8 @@ data:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
           tag: v0.84.0
       validator:
+        annotations: {}
+        labels: {}
         resources:
           limits:
             cpu: 200m
@@ -969,6 +976,7 @@ data:
             cpu: 50m
             memory: 64Mi
       webhookServer:
+        annotations: {}
         autoscaling: null
         backfill:
           resources:
@@ -980,6 +988,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        labels: {}
         podDisruptionBudget: null
         replicas: null
         resources:
@@ -1564,7 +1573,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: validator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -2060,7 +2069,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
+    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -2163,9 +2172,8 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -2183,15 +2191,15 @@ spec:
       app.kubernetes.io/instance: cz-agent
   template:
     metadata:
-        
       labels:
-        app.kubernetes.io/component: server
+        app.kubernetes.io/component: agent
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
+      
     spec:
       
       serviceAccountName: cz-agent-cz-server
@@ -2453,7 +2461,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
@@ -2474,7 +2481,6 @@ spec:
   replicas: 1
   template:
     metadata:
-        
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/instance: cz-agent
@@ -2483,6 +2489,7 @@ spec:
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
+      
     spec:
       
       serviceAccountName: cz-agent-cz-server
@@ -2723,7 +2730,7 @@ metadata:
     app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cz-agent-cz-aggregator
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2742,7 +2749,7 @@ spec:
         app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cz-agent-cz-aggregator
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3009,19 +3016,23 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-    job-type: backfill
     job-category: onetime
+    job-type: backfill
 spec:
   template:
     metadata:
       name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
-        job-type: backfill
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v3.7.3
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
         job-category: onetime
+        job-type: backfill
       
     spec:
           serviceAccountName: cz-agent-cz-server
@@ -3276,7 +3287,7 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
+    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -3288,9 +3299,13 @@ spec:
     metadata:
       name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/component: init-cert
         app.kubernetes.io/instance: cz-agent
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v3.7.3
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
       
@@ -3346,8 +3361,8 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-    job-type: backfill
     job-category: cronjob
+    job-type: backfill
 spec:
   schedule: "0 */12 * * *"
   concurrencyPolicy: Forbid
@@ -3360,11 +3375,15 @@ spec:
           name: cz-agent-backfill
           namespace: cz-agent
           labels:
-            app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
-            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/component: webhook-server
             app.kubernetes.io/instance: cz-agent
-            job-type: backfill
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/part-of: cloudzero-agent
+            app.kubernetes.io/version: v3.7.3
+            helm.sh/chart: cloudzero-agent-1.1.0-dev
             job-category: cronjob
+            job-type: backfill
           
         spec:
           serviceAccountName: cz-agent-cz-server

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -841,6 +841,7 @@ data:
     commonMetaLabels: {}
     components:
       agent:
+        annotations: {}
         autoscaling: null
         clusteredNode:
           image:
@@ -854,6 +855,10 @@ data:
               cpu: 50m
               memory: 256Mi
         federatedNode:
+          annotations: {}
+          labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 1000m
@@ -865,8 +870,11 @@ data:
         image:
           repository: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent
           tag: 1.2.8
+        labels: {}
         mode: federated
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         reloader:
           resources:
             limits:
@@ -896,7 +904,9 @@ data:
               memory: 64Mi
           securityContext: {}
         labels: {}
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         replicas: null
         securityContext: {}
         shipper:
@@ -913,6 +923,8 @@ data:
         configLoader:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 500m
@@ -924,6 +936,8 @@ data:
         helmless:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 200m
@@ -935,6 +949,8 @@ data:
         initCert:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 200m
@@ -965,6 +981,10 @@ data:
         annotations: {}
         autoscaling: null
         backfill:
+          annotations: {}
+          labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 500m
@@ -975,7 +995,9 @@ data:
           schedule: 0 */12 * * *
           securityContext: {}
         labels: {}
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         replicas: null
         resources:
           limits:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -26,10 +26,9 @@ metadata:
   name: cz-agent-cz-server
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -38,8 +37,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: server
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/templates/aggregator-pdb.yaml
@@ -49,10 +47,9 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -61,8 +58,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: aggregator
-      app.kubernetes.io/name: cz-agent-cz-aggregator
+      app.kubernetes.io/name: aggregator
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/templates/webhook-pdb.yaml
@@ -72,10 +68,9 @@ metadata:
   name: cz-agent-cz-webhook
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -84,8 +79,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: webhook-server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/charts/kubeStateMetrics/templates/serviceaccount.yaml
@@ -109,10 +103,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -125,10 +118,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -141,10 +133,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -159,10 +150,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -175,10 +165,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -325,10 +314,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -434,10 +422,9 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -787,10 +774,9 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1573,10 +1559,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: validator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1656,10 +1641,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1886,10 +1870,9 @@ kind: ClusterRole
 metadata:
   
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1978,10 +1961,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2046,10 +2028,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2069,10 +2050,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2131,8 +2111,7 @@ metadata:
   
 spec:
   selector:
-    app.kubernetes.io/component: aggregator
-    app.kubernetes.io/name: cz-agent-cz-aggregator
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/instance: cz-agent
   ports:
     - protocol: TCP
@@ -2146,10 +2125,9 @@ kind: Service
 metadata:
   name: cz-agent-cz-webhook
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2164,8 +2142,7 @@ spec:
       name: http
       appProtocol: https
   selector:
-    app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/templates/agent-daemonset.yaml
@@ -2173,10 +2150,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app.kubernetes.io/component: agent
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2186,16 +2162,14 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: server
       app.kubernetes.io/instance: cz-agent
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: agent
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2462,10 +2436,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2475,17 +2448,15 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: server
       app.kubernetes.io/instance: cz-agent
   replicas: 1
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2727,18 +2698,16 @@ metadata:
   # Labels: Combine standard aggregator labels with user-defined metadata labels
   # Provides consistent labeling for service discovery, monitoring, and resource management
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: aggregator
-      app.kubernetes.io/name: cz-agent-cz-aggregator
+      app.kubernetes.io/name: aggregator
       app.kubernetes.io/instance: cz-agent
   replicas: 3
   template:
@@ -2746,10 +2715,9 @@ spec:
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: aggregator
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2886,10 +2854,9 @@ metadata:
   namespace: cz-agent
   # Standard webhook server labels for consistent resource identification
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2900,16 +2867,14 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: webhook-server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: cz-agent
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: webhook-server
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3009,10 +2974,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3024,10 +2988,9 @@ spec:
       name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: backfill
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3093,10 +3056,9 @@ metadata:
   annotations:
     checksum/values: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   labels:
-    app.kubernetes.io/component: config-loader
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3106,10 +3068,9 @@ spec:
       name: cz-agent-confload-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: config-loader
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: validator
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3217,10 +3178,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3230,10 +3190,9 @@ spec:
       name: cz-agent-helmless-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: helmless
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: helmless
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3287,10 +3246,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3299,10 +3257,9 @@ spec:
     metadata:
       name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: init-cert
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: init-cert
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3354,10 +3311,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3375,10 +3331,9 @@ spec:
           name: cz-agent-backfill
           namespace: cz-agent
           labels:
-            app.kubernetes.io/component: webhook-server
             app.kubernetes.io/instance: cz-agent
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/name: backfill
             app.kubernetes.io/part-of: cloudzero-agent
             app.kubernetes.io/version: v3.7.3
             helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3442,10 +3397,9 @@ metadata:
   name: cz-agent-cz-webhook
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -789,6 +789,7 @@ data:
     commonMetaLabels: {}
     components:
       agent:
+        annotations: {}
         autoscaling: null
         clusteredNode:
           image:
@@ -802,6 +803,10 @@ data:
               cpu: 50m
               memory: 256Mi
         federatedNode:
+          annotations: {}
+          labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 1000m
@@ -813,8 +818,11 @@ data:
         image:
           repository: ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent
           tag: 1.2.8
+        labels: {}
         mode: null
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         reloader:
           resources:
             limits:
@@ -844,7 +852,9 @@ data:
               memory: 64Mi
           securityContext: {}
         labels: {}
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         replicas: null
         securityContext: {}
         shipper:
@@ -861,6 +871,8 @@ data:
         configLoader:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 500m
@@ -872,6 +884,8 @@ data:
         helmless:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 200m
@@ -883,6 +897,8 @@ data:
         initCert:
           annotations: {}
           labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 200m
@@ -913,6 +929,10 @@ data:
         annotations: {}
         autoscaling: null
         backfill:
+          annotations: {}
+          labels: {}
+          podAnnotations: {}
+          podLabels: {}
           resources:
             limits:
               cpu: 500m
@@ -923,7 +943,9 @@ data:
           schedule: 0 */12 * * *
           securityContext: {}
         labels: {}
+        podAnnotations: {}
         podDisruptionBudget: null
+        podLabels: {}
         replicas: null
         resources:
           limits:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -26,10 +26,9 @@ metadata:
   name: cz-agent-cz-server
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -38,8 +37,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: server
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/templates/aggregator-pdb.yaml
@@ -49,10 +47,9 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -61,8 +58,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: aggregator
-      app.kubernetes.io/name: cz-agent-cz-aggregator
+      app.kubernetes.io/name: aggregator
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/templates/webhook-pdb.yaml
@@ -72,10 +68,9 @@ metadata:
   name: cz-agent-cz-webhook
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -84,8 +79,7 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: webhook-server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/charts/kubeStateMetrics/templates/serviceaccount.yaml
@@ -109,10 +103,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -125,10 +118,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -141,10 +133,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -159,10 +150,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -175,10 +165,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -381,10 +370,9 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -734,10 +722,9 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1520,10 +1507,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: validator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1603,10 +1589,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1833,10 +1818,9 @@ kind: ClusterRole
 metadata:
   
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1925,10 +1909,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -1993,10 +1976,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2016,10 +1998,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2078,8 +2059,7 @@ metadata:
   
 spec:
   selector:
-    app.kubernetes.io/component: aggregator
-    app.kubernetes.io/name: cz-agent-cz-aggregator
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/instance: cz-agent
   ports:
     - protocol: TCP
@@ -2093,10 +2073,9 @@ kind: Service
 metadata:
   name: cz-agent-cz-webhook
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2111,8 +2090,7 @@ spec:
       name: http
       appProtocol: https
   selector:
-    app.kubernetes.io/component: webhook-server
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/instance: cz-agent
 ---
 # Source: cloudzero-agent/charts/kubeStateMetrics/templates/deployment.yaml
@@ -2211,10 +2189,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2224,17 +2201,15 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: server
       app.kubernetes.io/instance: cz-agent
   replicas: 1
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2476,18 +2451,16 @@ metadata:
   # Labels: Combine standard aggregator labels with user-defined metadata labels
   # Provides consistent labeling for service discovery, monitoring, and resource management
   labels:
-    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: aggregator
-      app.kubernetes.io/name: cz-agent-cz-aggregator
+      app.kubernetes.io/name: aggregator
       app.kubernetes.io/instance: cz-agent
   replicas: 3
   template:
@@ -2495,10 +2468,9 @@ spec:
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: aggregator
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2635,10 +2607,9 @@ metadata:
   namespace: cz-agent
   # Standard webhook server labels for consistent resource identification
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2649,16 +2620,14 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      app.kubernetes.io/component: webhook-server
-      app.kubernetes.io/name: cloudzero-agent
+      app.kubernetes.io/name: webhook-server
       app.kubernetes.io/instance: cz-agent
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: webhook-server
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2758,10 +2727,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2773,10 +2741,9 @@ spec:
       name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: backfill
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2842,10 +2809,9 @@ metadata:
   annotations:
     checksum/values: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
   labels:
-    app.kubernetes.io/component: config-loader
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2855,10 +2821,9 @@ spec:
       name: cz-agent-confload-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: config-loader
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: validator
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2966,10 +2931,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2979,10 +2943,9 @@ spec:
       name: cz-agent-helmless-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: helmless
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: helmless
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3036,10 +2999,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3048,10 +3010,9 @@ spec:
     metadata:
       name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: init-cert
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/name: init-cert
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3103,10 +3064,9 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3124,10 +3084,9 @@ spec:
           name: cz-agent-backfill
           namespace: cz-agent
           labels:
-            app.kubernetes.io/component: webhook-server
             app.kubernetes.io/instance: cz-agent
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/name: backfill
             app.kubernetes.io/part-of: cloudzero-agent
             app.kubernetes.io/version: v3.7.3
             helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -3191,10 +3150,9 @@ metadata:
   name: cz-agent-cz-webhook
   namespace: cz-agent
   labels:
-    app.kubernetes.io/component: webhook-server
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cloudzero-agent
+    app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -141,7 +141,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -381,6 +381,7 @@ metadata:
   name: cz-agent-cz-aggregator
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -733,6 +734,7 @@ metadata:
   name: cz-agent-helmless-cm
   namespace: cz-agent
   labels:
+    app.kubernetes.io/component: helmless
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -854,6 +856,7 @@ data:
               cpu: 100m
               memory: 64Mi
           securityContext: {}
+        labels: {}
         podDisruptionBudget: null
         replicas: null
         securityContext: {}
@@ -891,6 +894,8 @@ data:
               memory: 64Mi
           securityContext: {}
         initCert:
+          annotations: {}
+          labels: {}
           resources:
             limits:
               cpu: 200m
@@ -908,6 +913,8 @@ data:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
           tag: v0.84.0
       validator:
+        annotations: {}
+        labels: {}
         resources:
           limits:
             cpu: 200m
@@ -916,6 +923,7 @@ data:
             cpu: 50m
             memory: 64Mi
       webhookServer:
+        annotations: {}
         autoscaling: null
         backfill:
           resources:
@@ -927,6 +935,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        labels: {}
         podDisruptionBudget: null
         replicas: null
         resources:
@@ -1511,7 +1520,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: validator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -2007,7 +2016,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: webhook-server
+    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -2201,7 +2210,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: cz-agent
@@ -2222,7 +2230,6 @@ spec:
   replicas: 1
   template:
     metadata:
-        
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/instance: cz-agent
@@ -2231,6 +2238,7 @@ spec:
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
+      
     spec:
       
       serviceAccountName: cz-agent-cz-server
@@ -2471,7 +2479,7 @@ metadata:
     app.kubernetes.io/component: aggregator
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: cz-agent-cz-aggregator
+    app.kubernetes.io/name: cloudzero-agent
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2490,7 +2498,7 @@ spec:
         app.kubernetes.io/component: aggregator
         app.kubernetes.io/instance: cz-agent
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: cz-agent-cz-aggregator
+        app.kubernetes.io/name: cloudzero-agent
         app.kubernetes.io/part-of: cloudzero-agent
         app.kubernetes.io/version: v3.7.3
         helm.sh/chart: cloudzero-agent-1.1.0-dev
@@ -2757,19 +2765,23 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-    job-type: backfill
     job-category: onetime
+    job-type: backfill
 spec:
   template:
     metadata:
       name: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
       namespace: cz-agent
       labels:
-        app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/component: webhook-server
         app.kubernetes.io/instance: cz-agent
-        job-type: backfill
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v3.7.3
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
         job-category: onetime
+        job-type: backfill
       
     spec:
           serviceAccountName: cz-agent-cz-server
@@ -3024,7 +3036,7 @@ metadata:
   namespace: cz-agent
   
   labels:
-    app.kubernetes.io/component: webhook-server
+    app.kubernetes.io/component: init-cert
     app.kubernetes.io/instance: cz-agent
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudzero-agent
@@ -3036,9 +3048,13 @@ spec:
     metadata:
       name: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
       labels:
-        app.kubernetes.io/component: cz-agent-init-cert-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
-        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/component: init-cert
         app.kubernetes.io/instance: cz-agent
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudzero-agent
+        app.kubernetes.io/part-of: cloudzero-agent
+        app.kubernetes.io/version: v3.7.3
+        helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
       
@@ -3094,8 +3110,8 @@ metadata:
     app.kubernetes.io/part-of: cloudzero-agent
     app.kubernetes.io/version: v3.7.3
     helm.sh/chart: cloudzero-agent-1.1.0-dev
-    job-type: backfill
     job-category: cronjob
+    job-type: backfill
 spec:
   schedule: "0 */12 * * *"
   concurrencyPolicy: Forbid
@@ -3108,11 +3124,15 @@ spec:
           name: cz-agent-backfill
           namespace: cz-agent
           labels:
-            app.kubernetes.io/component: cz-agent-backfill-DEADBEEF-FEED-FACE-CAFE-FEE10D15EA
-            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/component: webhook-server
             app.kubernetes.io/instance: cz-agent
-            job-type: backfill
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: cloudzero-agent
+            app.kubernetes.io/part-of: cloudzero-agent
+            app.kubernetes.io/version: v3.7.3
+            helm.sh/chart: cloudzero-agent-1.1.0-dev
             job-category: cronjob
+            job-type: backfill
           
         spec:
           serviceAccountName: cz-agent-cz-server


### PR DESCRIPTION
This comprehensive refactoring overhauls the Helm chart's label and annotation
system to provide a unified, flexible, and Kubernetes-compliant metadata
framework. The changes include: (1) consolidating label/annotation generation
across all templates into consistent helper functions, (2) fixing label
structure to follow Kubernetes recommended labels best practices, (3) refining
parameter semantics to properly distinguish component identity from
architectural roles, and (4) adding support for pod-specific metadata that
applies only to pod templates.

These changes provide users with fine-grained control over metadata at multiple
levels (defaults, components, and pods) while maintaining consistency across all
chart resources and following Kubernetes ecosystem standards.

Functional Change:

Before:
- Label and annotation generation was inconsistent across templates, using
  different helper functions or manual merge operations with no unified pattern
- Component-specific label and annotation overrides were not available or
  documented
- Label structure violated Kubernetes best practices:
  - Agent/Webhook used chart name: `app.kubernetes.io/name: cloudzero-agent`
  - Aggregator used full resource name: `app.kubernetes.io/name: cloudzero-agent-cz-aggregator`
  - Inconsistent use of `app.kubernetes.io/part-of`
- The generateLabels helper used "component" parameter ambiguously for both
  component identity (app.kubernetes.io/name) and architectural role
- Users could only set labels and annotations that applied to both parent
  resources (Deployment/DaemonSet/Job) and their pod templates - no way to add
  metadata exclusively to pods

After:
- All templates use unified `generateLabels` and `generateAnnotations` helpers
  with explicit merge order
- Component-specific `labels` and `annotations` properties are available at 8
  component locations and documented in schema
- Label structure follows Kubernetes recommended labels:
  - All components use simple, semantic names: `app.kubernetes.io/name: server|aggregator|webhook-server`
  - All components consistently use: `app.kubernetes.io/part-of: cloudzero-agent`
  - Selectors match pod labels correctly with component-specific names
- The generateLabels helper uses "name" parameter (required) for component
  identity (app.kubernetes.io/name) and optional "component" parameter for
  architectural roles (app.kubernetes.io/component)
- Selectors simplified to use only `app.kubernetes.io/name` and
  `app.kubernetes.io/instance`, removing redundant `app.kubernetes.io/component`
- Users can set `podLabels` and `podAnnotations` at 8 component locations that
  apply only to pod template metadata with highest priority in merge hierarchy

Solution:

1. Unified label/annotation generation system:

   a. Refactored `_helpers.tpl` with new generation functions:
      - `generateLabels`: Accepts list of label dicts to merge in priority
        order, with explicit parameter passing (dict with root, name, labels)
      - `generateAnnotations`: Accepts list of annotation dicts to merge in
        priority order with explicit parameters (dict with root, annotations)
      - Updated `baseLabels` to remove `app.kubernetes.io/name` (now
        component-specific) and ensure consistent `app.kubernetes.io/part-of`
      - Updated all `matchLabels` helpers to include component-specific names
        and simplified to use only name+instance labels

   b. Updated all 32 Helm templates to use new helpers with consistent pattern:
      - Agent templates (deploy, daemonset, configmap, serviceaccount, etc.)
      - Aggregator templates (deploy, configmap, service, secret)
      - Webhook server templates (deploy, service, serviceaccount, certificate, etc.)
      - Job templates (backfill, init-cert, config-loader, helmless)
      - All follow same merge order: defaults � commonMetaLabels �
        component name dict � component-specific labels/annotations �
        pod-specific labels/annotations (for pod templates only)

2. Component-specific metadata support:

   a. Added schema documentation in `helm/values.schema.yaml` for
      component-specific properties:
      - `components.agent.labels` and `.annotations`
      - `components.agent.federatedNode.labels` and `.annotations`
      - `components.aggregator.labels` and `.annotations`
      - `components.webhookServer.labels` and `.annotations`
      - `components.webhookServer.backfill.labels` and `.annotations`
      - `components.miscellaneous.configLoader.labels` and `.annotations`
      - `components.miscellaneous.helmless.labels` and `.annotations`
      - `components.miscellaneous.initCert.labels` and `.annotations`

   b. Updated `helm/values.yaml` to document new properties with commented
      examples showing component-specific overrides and merge hierarchy

3. Refined parameter semantics for Kubernetes compliance:

   a. Refactored `generateLabels` helper function:
      - Changed from "component" parameter to "name" parameter (required)
      - "name" parameter sets `app.kubernetes.io/name` with highest priority
        for component identity (what it is)
      - "component" parameter made optional for `app.kubernetes.io/component`
        architectural role (what it does)
      - Updated documentation to clarify Kubernetes recommended labels semantics

   b. Updated `generatePodDisruptionBudget` helper:
      - Changed "component" parameter to "name"
      - Passes through to generateLabels with new signature

   c. Updated all 29 Helm templates to use "name" parameter:
      - Changed parameter name from "component" to "name"
      - Replaced `.Values.*.name` references with hardcoded semantic names:
        - "server" for agent components
        - "aggregator" for aggregator components
        - "webhook-server" for webhook server components
        - "init-cert", "helmless", "validator" for job components
      - Examples: webhook-deploy.yaml, agent-deploy.yaml,
        aggregator-deploy.yaml, agent-daemonset.yaml, backfill-job.yaml,
        init-cert-job.yaml, config-loader-job.yaml, helmless-job.yaml

   d. Updated matchLabels helpers to remove `app.kubernetes.io/component`:
      - `cloudzero-agent.server.matchLabels`
      - `cloudzero-agent.insightsController.server.matchLabels`
      - `cloudzero-agent.aggregator.matchLabels`
      - Selectors now only use `app.kubernetes.io/name` and
        `app.kubernetes.io/instance`

4. Pod-specific metadata support:

   a. Added `podLabels` and `podAnnotations` properties to 8 component
      locations in `helm/values.yaml`:
      - `components.agent`
      - `components.agent.federatedNode`
      - `components.aggregator`
      - `components.webhookServer`
      - `components.webhookServer.backfill`
      - `components.miscellaneous.configLoader`
      - `components.miscellaneous.helmless`
      - `components.miscellaneous.initCert`

   b. Updated `helm/values.schema.yaml` with JSON schema definitions for all
      new pod-specific properties using proper `$ref` references to Kubernetes
      ObjectMeta schema

   c. Modified 8 template files to include pod-specific properties in pod
      template metadata `generateLabels`/`generateAnnotations` calls:
      - `helm/templates/agent-deploy.yaml`
      - `helm/templates/agent-daemonset.yaml`
      - `helm/templates/aggregator-deploy.yaml`
      - `helm/templates/webhook-deploy.yaml`
      - `helm/templates/backfill-job.yaml` (both CronJob and Job)
      - `helm/templates/config-loader-job.yaml`
      - `helm/templates/helmless-job.yaml`
      - `helm/templates/init-cert-job.yaml`

   d. Pod-specific properties are added as the last items in merge lists to
      ensure highest priority, overriding any conflicting values from
      defaults.labels, commonMetaLabels, or component labels/annotations

   e. Parent resource metadata uses only defaults, commonMetaLabels, and
      component-specific labels/annotations - pod-specific properties are
      excluded from parent resources

5. Test coverage and validation:

   a. Extended `defaults_labels_annotations_all_resources_test.yaml` with 16
      new tests verifying defaults.labels and defaults.annotations propagate to
      pod template metadata for all workload types

   b. Created comprehensive test suite
      `helm/tests/pod_labels_annotations_test.yaml` with 28 tests covering all
      8 components for pod-specific metadata

   c. Updated 5 test files to reflect new label structure and parameter
      semantics:
      - `server_deployment_name_independence_test.yaml`: Expect simple
        component names and removed `app.kubernetes.io/component` assertions
      - `config_loader_job_labels_annotations_test.yaml`: Changed to verify
        `app.kubernetes.io/name`
      - `helmless_job_labels_annotations_test.yaml`: Changed to verify
        `app.kubernetes.io/name`
      - `webhook_hpa_test.yaml`: Removed `app.kubernetes.io/component`
        assertions
      - `alloy_hpa_test.yaml`: Removed `app.kubernetes.io/component` assertions

Validation:

- All Helm unit tests pass (48 test suites, 0 failures)
- Tests verify pod-specific labels/annotations appear only in pod template
  metadata, not on parent resources
- Tests verify priority ordering with pod-specific properties having highest
  priority
- Helm lint passes with no errors
- Schema validation confirms all new properties are properly defined
- Generated test manifests show correct label/annotation application with proper
  merge order and Kubernetes-compliant label structure
- Deployed successfully to test clusters in both clustered and agent mode
- Verified continued receipt of all expected metrics post-deployment
- Templates render correctly with both `make helm-template` and cluster
  deployments
- Backward compatibility maintained with legacy properties (`server.podLabels`,
  `server.podAnnotations`, `insightsController.server.podAnnotations`)
