### PR TITLE
CP-35460: bump KSM and prometheus-config-reloader versions

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -438,7 +438,7 @@ components:
   prometheusReloader:
     image:
       repository: quay.io/prometheus-operator/prometheus-config-reloader
-      tag: "v0.84.0"
+      tag: "v0.87.0"
 
   # Settings for the aggregator component. This is the piece which accepts
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
@@ -564,7 +564,7 @@ kubeStateMetrics:
   image:
     registry: registry.k8s.io
     repository: kube-state-metrics/kube-state-metrics
-    tag: "v2.16.0"
+    tag: "v2.17.0"
     sha:
     pullPolicy: IfNotPresent
   imagePullSecrets: []

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -438,7 +438,7 @@ components:
   prometheusReloader:
     image:
       repository: quay.io/prometheus-operator/prometheus-config-reloader
-      tag: "v0.84.0"
+      tag: "v0.87.0"
 
   # Settings for the aggregator component. This is the piece which accepts
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
@@ -564,7 +564,7 @@ kubeStateMetrics:
   image:
     registry: registry.k8s.io
     repository: kube-state-metrics/kube-state-metrics
-    tag: "v2.16.0"
+    tag: "v2.17.0"
     sha:
     pullPolicy: IfNotPresent
   imagePullSecrets: []

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -930,7 +930,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.84.0
+          tag: v0.87.0
       validator:
         resources:
           limits:
@@ -1214,7 +1214,7 @@ data:
         pullPolicy: IfNotPresent
         registry: registry.k8s.io
         repository: kube-state-metrics/kube-state-metrics
-        tag: v2.16.0
+        tag: v2.17.0
       imagePullSecrets: []
       initContainers: []
       kubeRBACProxy:
@@ -2181,7 +2181,7 @@ spec:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2333,7 +2333,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -890,7 +890,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.84.0
+          tag: v0.87.0
       validator:
         resources:
           limits:
@@ -1174,7 +1174,7 @@ data:
         pullPolicy: IfNotPresent
         registry: registry.k8s.io
         repository: kube-state-metrics/kube-state-metrics
-        tag: v2.16.0
+        tag: v2.17.0
       imagePullSecrets: []
       initContainers: []
       kubeRBACProxy:
@@ -2141,7 +2141,7 @@ spec:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2293,7 +2293,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -959,7 +959,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.84.0
+          tag: v0.87.0
       validator:
         resources:
           limits:
@@ -1243,7 +1243,7 @@ data:
         pullPolicy: IfNotPresent
         registry: registry.k8s.io
         repository: kube-state-metrics/kube-state-metrics
-        tag: v2.16.0
+        tag: v2.17.0
       imagePullSecrets: []
       initContainers: []
       kubeRBACProxy:
@@ -2201,7 +2201,7 @@ spec:
         # in the prometheus.yml.in file with the actual node name, then use that
         # processed file in the container.
         - name: config-subst
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/sh
@@ -2230,7 +2230,7 @@ spec:
               mountPath: /etc/config/prometheus/configmaps/processed/
       containers:
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -2409,7 +2409,7 @@ spec:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2561,7 +2561,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -906,7 +906,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.84.0
+          tag: v0.87.0
       validator:
         resources:
           limits:
@@ -1190,7 +1190,7 @@ data:
         pullPolicy: IfNotPresent
         registry: registry.k8s.io
         repository: kube-state-metrics/kube-state-metrics
-        tag: v2.16.0
+        tag: v2.17.0
       imagePullSecrets: []
       initContainers: []
       kubeRBACProxy:
@@ -2157,7 +2157,7 @@ spec:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0
         ports:
         - containerPort: 8080
           name: "http"
@@ -2309,7 +2309,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.84.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config


### PR DESCRIPTION
# Why?

Security

# What

Pulling in the latest upstream releases of KSM and prometheus-config-reloader

# How Tested

Deploy
