### PR TITLE
CP-35462: Add GPU metric collection support for Alloy

### DIFF
--- a/helm/templates/_alloy_helpers.tpl
+++ b/helm/templates/_alloy_helpers.tpl
@@ -47,6 +47,10 @@ Usage: {{ include "cloudzero-agent.alloy.riverConfig" . }}
 {{- include "cloudzero-agent.alloy.scrapeAlloy" . }}
 {{- end }}
 
+{{- if .Values.prometheusConfig.scrapeJobs.gpu.enabled }}
+{{- include "cloudzero-agent.alloy.scrapeGPU" . }}
+{{- end }}
+
 // Remote write to CloudZero aggregator
 {{- include "cloudzero-agent.alloy.remoteWrite" . }}
 {{- end -}}
@@ -288,6 +292,110 @@ prometheus.relabel "alloy" {
     source_labels = ["__name__"]
     regex         = "^({{ join "|" (include "cloudzero-agent.defaults" . | fromYaml).prometheusMetrics }})$"
     action        = "keep"
+  }
+}
+{{- end -}}
+
+{{/*
+Alloy DCGM GPU Scrape Job
+
+Generates River configuration for scraping NVIDIA DCGM Exporter metrics.
+Collects raw DCGM metrics which are transformed by the collector into
+container_resources_gpu_* metrics for cost allocation.
+
+This configuration:
+- Discovers dcgm-exporter services via Kubernetes API
+- Scrapes raw DCGM metrics (GPU_UTIL, FB_USED, FB_FREE)
+- Adds provenance label for metric source tracking
+- Filters to only GPU metrics with container attribution
+- Forwards to aggregator for transformation and storage
+
+The collector's DCGM transformer converts raw metrics to:
+- container_resources_gpu_usage_percent (from DCGM_FI_DEV_GPU_UTIL)
+- container_resources_gpu_memory_usage_percent (from DCGM_FI_DEV_FB_USED/FREE)
+
+Usage: {{ include "cloudzero-agent.alloy.scrapeGPU" . }}
+*/}}
+{{- define "cloudzero-agent.alloy.scrapeGPU" -}}
+// NVIDIA DCGM GPU Metrics Scrape Job
+// Collects raw GPU metrics for transformation and cost allocation
+
+discovery.kubernetes "dcgm" {
+  role = "service"
+
+  selectors {
+    role  = "service"
+    label = "app.kubernetes.io/name=dcgm-exporter"
+  }
+}
+
+prometheus.scrape "dcgm" {
+  targets    = discovery.kubernetes.dcgm.targets
+  forward_to = [prometheus.relabel.dcgm_provenance.receiver]
+  scrape_interval = "{{ .Values.prometheusConfig.scrapeJobs.gpu.scrapeInterval }}"
+
+  clustering {
+    enabled = true
+  }
+}
+
+// Add provenance label and Kubernetes metadata
+prometheus.relabel "dcgm_provenance" {
+  forward_to = [prometheus.relabel.dcgm_metrics.receiver]
+
+  // Add provenance label to indicate DCGM as the metric source
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex         = "dcgm-exporter"
+    replacement   = "dcgm"
+    target_label  = "provenance"
+  }
+
+  // Add Kubernetes metadata for cost attribution
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "kubernetes_namespace"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_name"]
+    target_label  = "kubernetes_service"
+  }
+}
+
+// Filter metrics - keep only the 3 DCGM metrics needed
+prometheus.relabel "dcgm_metrics" {
+  forward_to = [prometheus.relabel.dcgm_attribution.receiver]
+
+  // Keep only specific DCGM metrics
+  rule {
+    source_labels = ["__name__"]
+    regex         = "DCGM_FI_DEV_GPU_UTIL|DCGM_FI_DEV_FB_USED|DCGM_FI_DEV_FB_FREE"
+    action        = "keep"
+  }
+}
+
+// Filter out metrics without container attribution
+prometheus.relabel "dcgm_attribution" {
+  forward_to = [prometheus.remote_write.cloudzero.receiver]
+
+  // Drop metrics without container attribution
+  rule {
+    source_labels = ["container"]
+    regex         = "^$"
+    action        = "drop"
+  }
+
+  rule {
+    source_labels = ["pod"]
+    regex         = "^$"
+    action        = "drop"
+  }
+
+  rule {
+    source_labels = ["namespace"]
+    regex         = "^$"
+    action        = "drop"
   }
 }
 {{- end -}}

--- a/helm/tests/alloy_configmap_test.yaml
+++ b/helm/tests/alloy_configmap_test.yaml
@@ -93,3 +93,67 @@ tests:
       - matchRegex:
           path: data["alloy-config.river"]
           pattern: "clustering \\{\\s+enabled = true\\s+\\}"
+
+  # Test that River config includes DCGM GPU scrape when enabled
+  - it: should include DCGM GPU scrape in River config when enabled
+    set:
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.gpu.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'discovery.kubernetes "dcgm"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "dcgm"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.relabel "dcgm_provenance"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.relabel "dcgm_metrics"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.relabel "dcgm_attribution"'
+
+  # Test that River config includes DCGM metric filtering
+  - it: should filter DCGM metrics correctly
+    set:
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.gpu.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "DCGM_FI_DEV_GPU_UTIL"
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "DCGM_FI_DEV_FB_USED"
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "DCGM_FI_DEV_FB_FREE"
+
+  # Test that River config includes provenance label for DCGM
+  - it: should add provenance label to DCGM metrics
+    set:
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.gpu.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'target_label.*=.*"provenance"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'replacement.*=.*"dcgm"'
+
+  # Test that DCGM scrape is excluded when GPU scraping is disabled
+  - it: should not include DCGM scrape when GPU scraping is disabled
+    set:
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.gpu.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'discovery.kubernetes "dcgm"'
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "dcgm"'


### PR DESCRIPTION
This completes GPU cost allocation support for Grafana Alloy deployments. Previously, GPU metrics (DCGM) were only collected when using Prometheus (mode: agent/server/federated). Customers using Alloy (mode: clustered) for better horizontal scalability could not track GPU costs.

Functional Change:

Before: GPU metrics were only collected when using Prometheus. Alloy deployments (mode: clustered) did not collect GPU metrics, leaving GPU costs untracked.

After: GPU metrics are collected in both Prometheus and Alloy deployments when prometheusConfig.scrapeJobs.gpu.enabled is true. Alloy deployments now have full GPU cost allocation capabilities.

Solution:

1. Added cloudzero-agent.alloy.scrapeGPU helper template in helm/templates/_alloy_helpers.tpl
   - Service discovery for dcgm-exporter via Kubernetes API with label selector
   - Scrapes 3 raw DCGM metrics: GPU_UTIL, FB_USED, FB_FREE at configurable interval
   - Adds provenance label (provenance=dcgm) to identify metric source
   - Filters to only metrics with container attribution (container, pod, namespace labels)
   - Forwards to aggregator where DCGM transformer converts to container_resources_gpu_* metrics

2. Integrated GPU scraping into main Alloy River config generation
   - Conditionally includes scrapeGPU helper when prometheusConfig.scrapeJobs.gpu.enabled=true
   - Matches existing Prometheus GPU scraping behavior for consistency

3. Added comprehensive helm unittest coverage in helm/tests/alloy_configmap_test.yaml
   - Verifies DCGM scrape job included when gpu.enabled=true
   - Verifies all DCGM components present (discovery, scrape, relabel stages)
   - Verifies metric filtering includes 3 required DCGM metrics
   - Verifies provenance label correctly added
   - Verifies DCGM excluded when gpu.enabled=false

Validation:

- Added a new Helm unittest test to, which now passes
- Deployed to test cluster with mode=clustered and gpu.enabled=true
- Verified raw DCGM metrics received at aggregator (INFO logs show all 3 metrics)
- Verified DCGM transformer converts to container_resources_gpu_usage_percent and container_resources_gpu_memory_usage_percent
- Verified no metrics dropped (droppedMetrics: 0 in all aggregator logs)
- Verified GPU metrics included in cost metrics count in DEBUG logs
- All 316 helm unit tests pass including 4 new GPU/DCGM tests
- All helm schema validation tests pass (234 tests)
- All helm subchart tests pass (3 tests)

# Why?

> This awesome thing improves my smile brightness

# What

> Outline the actions you took to achieve a brighter smile

# How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile
