### PR TITLE
CP-36332: Update docs to use new Kubernetes label selectors

### DIFF
--- a/app/domain/transform/dcgm/CLAUDE.md
+++ b/app/domain/transform/dcgm/CLAUDE.md
@@ -270,15 +270,15 @@ aggregator:
 
 ```bash
 # Check if DCGM metrics are being received
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator \
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator \
   | grep "DCGM_FI_DEV"
 
 # Check if transformed metrics are produced
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator \
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator \
   | grep "container_resources_gpu"
 
 # Check for dropped metrics
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator \
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator \
   | grep "dropping"
 ```text
 
@@ -555,7 +555,7 @@ make build
 CLUSTER_NAME=brahms make helm-install helm-wait
 
 # Check logs for GPU metrics
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator \
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator \
   --tail=100 | grep -E "(DCGM|container_resources_gpu)"
 ```text
 

--- a/app/domain/transform/dcgm/README.md
+++ b/app/domain/transform/dcgm/README.md
@@ -345,7 +345,7 @@ Future enhancements may include:
 
 3. Check aggregator logs for DCGM metrics:
    ```bash
-   kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator \
+   kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator \
      | grep "DCGM_FI_DEV"
    ```
 
@@ -356,7 +356,7 @@ Future enhancements may include:
 **Diagnosis**: Check for missing required labels:
 
 ````bash
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator \
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator \
   | grep "dropping DCGM metric missing required labels"
 ```text
 
@@ -369,7 +369,7 @@ kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator \
 **Diagnosis**: Check for incomplete pairs:
 
 ```bash
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator \
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator \
   | grep "incomplete DCGM memory metric pair"
 ```text
 

--- a/app/functions/certifik8s/README.md
+++ b/app/functions/certifik8s/README.md
@@ -206,7 +206,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cloudzero-agent-webhook-server-init-cert
-  namespace: cza # Limited to specific namespace
+  namespace: cloudzero-agent # Limited to specific namespace
 ```
 
 The service account is bound to the ClusterRole using a ClusterRoleBinding:
@@ -219,7 +219,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: cloudzero-agent-webhook-server-init-cert
-    namespace: cza
+    namespace: cloudzero-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/app/functions/helmless/README.md
+++ b/app/functions/helmless/README.md
@@ -26,7 +26,7 @@ The tool now includes embedded default values from the Helm chart, so you can us
 1. Extract the current values from a deployed Helm release:
 
    ```sh
-   kubectl -n cza get cm/cz-agent-helmless-cm -o jsonpath='{.data.values\.yaml}' > configured-values.yaml
+   kubectl -n cloudzero-agent get cm/cloudzero-agent-helmless-cm -o jsonpath='{.data.values\.yaml}' > configured-values.yaml
    ```
 
 2. Compare the values and generate a minimal overrides file:
@@ -43,7 +43,7 @@ If you need to use a different version of defaults or want explicit control:
 1. Extract the current values from a deployed Helm release:
 
    ```sh
-   kubectl -n cza get cm/cz-agent-helmless-cm -o jsonpath='{.data.values\.yaml}' > configured-values.yaml
+   kubectl -n cloudzero-agent get cm/cloudzero-agent-helmless-cm -o jsonpath='{.data.values\.yaml}' > configured-values.yaml
    ```
 
 2. Get the default values from the Helm chart:

--- a/app/functions/helmless/README.md
+++ b/app/functions/helmless/README.md
@@ -68,7 +68,7 @@ defaults, making it easy to understand what has been customized.
 When the helmless job runs as part of a Helm deployment, you can view its logs without needing to know the chart name by using the job's component label:
 
 ```sh
-kubectl logs -l app.kubernetes.io/component=helmless -n <namespace> --tail=100
+kubectl logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=helmless -n <namespace> --tail=100
 ```
 
 ## Build System Integration

--- a/helm/DEVELOPMENT.md
+++ b/helm/DEVELOPMENT.md
@@ -183,8 +183,8 @@ aggregator:
 
 ```bash
 # Verify HPA configuration in deployed cluster
-kubectl get hpa cloudzero-aggregator -n cza
-kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cza/pods/*/czo_cost_metrics_shipping_progress"
+kubectl get hpa cloudzero-aggregator -n cloudzero-agent
+kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/cloudzero-agent/pods/*/czo_cost_metrics_shipping_progress"
 ```
 
 ## Schema Testing

--- a/helm/docs/cert-trouble-shooting.md
+++ b/helm/docs/cert-trouble-shooting.md
@@ -181,10 +181,9 @@ Ensure that the certificate management configuration in your `values.yaml` or `c
     Secret Name:   cloudzero-agent-webhook-server-tls
     Secret Template:
       Labels:
-        app.kubernetes.io/component:   webhook-server
         app.kubernetes.io/instance:    cloudzero-agent
         app.kubernetes.io/managed-by:  Helm
-        app.kubernetes.io/name:        cloudzero-agent
+        app.kubernetes.io/name:        webhook-server
         app.kubernetes.io/part-of:     cloudzero-agent
         app.kubernetes.io/version:     v2.50.1
         helm.sh/chart:                 cloudzero-agent-1.0.0-beta-5

--- a/helm/docs/deploy-validation.md
+++ b/helm/docs/deploy-validation.md
@@ -27,28 +27,28 @@ The validator runs in multiple phases. To see the validation results:
 **For pre-start validation (most common):**
 
 ```sh
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c env-validator-run
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c env-validator-run
 ```
 
 **For lifecycle validation logs:**
 
 ```sh
 # Get the agent server pod name, then exec into it
-AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -o jsonpath='{.items[0].metadata.name}')
+AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -o jsonpath='{.items[0].metadata.name}')
 kubectl -n cloudzero-agent exec -ti $AGENT_POD -c cloudzero-agent-server -- cat cloudzero-agent-validator.log
 ```
 
 **To check for validation errors quickly:**
 
 ```sh
-AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -o jsonpath='{.items[0].metadata.name}')
+AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -o jsonpath='{.items[0].metadata.name}')
 kubectl -n cloudzero-agent exec -ti $AGENT_POD -c cloudzero-agent-server -- cat cloudzero-agent-validator.log | jq -r 'select(.checks) | .checks[] | select(.error) | "\(.name): \(.error)"'
 ```
 
 **To capture full diagnostics for support:**
 
 ```sh
-AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -o jsonpath='{.items[0].metadata.name}')
+AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -o jsonpath='{.items[0].metadata.name}')
 kubectl -n cloudzero-agent exec -ti $AGENT_POD -c cloudzero-agent-server -- cat cloudzero-agent-validator.log > cloudzero-diagnostics.log
 ```
 
@@ -65,7 +65,7 @@ Diagnostics are run at 3 lifecycle phases of the `cloudzero-agent` pod deploymen
 If needed, you can also access the logs from the prometheus container directly:
 
 ```sh
-AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -o jsonpath='{.items[0].metadata.name}')
+AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -o jsonpath='{.items[0].metadata.name}')
 kubectl -n cloudzero-agent exec -ti $AGENT_POD -c cloudzero-agent-server -- cat cloudzero-agent-validator.log
 ```
 
@@ -93,7 +93,7 @@ Based on these 5 requirements, the checks have been designed to help identify pr
 3. Any error output from the error checking command
 4. Helmless job output (configuration and setup information):
    ```sh
-   kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=helmless --tail=10000
+   kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=helmless --tail=10000
    ```
 
 Contact support@cloudzero.com with this information for assistance.

--- a/helm/docs/troubleshooting-guide.md
+++ b/helm/docs/troubleshooting-guide.md
@@ -39,15 +39,17 @@ helm list -n cloudzero-agent
 kubectl -n cloudzero-agent get pods --show-labels
 
 # Find exact container names for aggregator (needed for some commands)
-kubectl -n cloudzero-agent get pods -l app.kubernetes.io/component=aggregator -o jsonpath='{.items[0].spec.containers[*].name}'
+kubectl -n cloudzero-agent get pods -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -o jsonpath='{.items[0].spec.containers[*].name}'
 ```
 
 **Common Label Selectors:**
 
-- **Agent Server**: `app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent`
-- **Webhook Server**: `app.kubernetes.io/component=webhook-server,app.kubernetes.io/name=cloudzero-agent`
-- **Aggregator**: `app.kubernetes.io/component=aggregator`
-- **All Components**: `app.kubernetes.io/name=cloudzero-agent`
+- **Agent Server**: `app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server`
+- **Webhook Server**: `app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=webhook-server`
+- **Aggregator**: `app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator`
+- **Helmless**: `app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=helmless`
+- **Kube-State-Metrics**: `app.kubernetes.io/name=ksm`
+- **All Components**: `app.kubernetes.io/part-of=cloudzero-agent`
 
 ## Initial Health Check Commands
 
@@ -64,7 +66,7 @@ kubectl -n cloudzero-agent top pods
 kubectl -n cloudzero-agent get events --sort-by=.metadata.creationTimestamp
 
 # Run validator diagnostics (uses label selector)
-kubectl -n cloudzero-agent exec -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server -- cat cloudzero-agent-validator.log | jq -r 'select(.checks) | .checks[] | select(.error) | "\(.name): \(.error)"'
+kubectl -n cloudzero-agent exec -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server -- cat cloudzero-agent-validator.log | jq -r 'select(.checks) | .checks[] | select(.error) | "\(.name): \(.error)"'
 ```
 
 > 💡 **Tip**: For detailed validation results, see [Deployment Validation Guide](./deploy-validation.md)
@@ -79,27 +81,27 @@ kubectl -n cloudzero-agent exec -l app.kubernetes.io/component=server,app.kubern
 
 ```bash
 # Check pod details (example for agent server)
-kubectl -n cloudzero-agent describe pods -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent
+kubectl -n cloudzero-agent describe pods -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server
 
 # Check image pull secrets
-kubectl -n cloudzero-agent get pods -l app.kubernetes.io/name=cloudzero-agent -o jsonpath='{.items[*].spec.imagePullSecrets}'
+kubectl -n cloudzero-agent get pods -l app.kubernetes.io/part-of=cloudzero-agent -o jsonpath='{.items[*].spec.imagePullSecrets}'
 ```
 
 **Pods Crashing (CrashLoopBackOff):**
 
 ```bash
 # Check recent logs (agent server example)
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent --previous
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server --previous
 
 # Check init container logs
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c env-validator-run
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c env-validator-run
 ```
 
 **Resource Issues:**
 
 ```bash
 # Check resource requests/limits for all components
-kubectl -n cloudzero-agent describe pods -l app.kubernetes.io/name=cloudzero-agent | grep -A 10 "Limits:\|Requests:"
+kubectl -n cloudzero-agent describe pods -l app.kubernetes.io/part-of=cloudzero-agent | grep -A 10 "Limits:\|Requests:"
 
 # Check node capacity (you still need the specific node name)
 kubectl describe node <node-name> | grep -A 10 "Allocated resources:"
@@ -117,7 +119,7 @@ The agent server runs Prometheus and handles metrics collection from Kubernetes.
 
 ```bash
 # Check Prometheus targets
-kubectl -n cloudzero-agent port-forward -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent 9090:9090
+kubectl -n cloudzero-agent port-forward -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server 9090:9090
 # Visit http://localhost:9090/targets in browser
 
 # Check kube-state-metrics service
@@ -129,10 +131,10 @@ kubectl -n cloudzero-agent get endpoints cloudzero-agent-cloudzero-state-metrics
 
 ```bash
 # Check agent logs for remote write errors
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server | grep -i "remote_write\|error\|fail"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server | grep -i "remote_write\|error\|fail"
 
 # Test connectivity to aggregator
-kubectl -n cloudzero-agent exec -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server -- wget -O- http://cloudzero-agent-aggregator:8080/healthz
+kubectl -n cloudzero-agent exec -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server -- wget -O- http://cloudzero-agent-aggregator:8080/healthz
 ```
 
 **❌ Problem: API key authentication failures**
@@ -145,14 +147,14 @@ kubectl -n cloudzero-agent get secret cloudzero-agent-api-key
 kubectl -n cloudzero-agent get secrets | grep -i api
 
 # Verify API key is mounted correctly
-kubectl -n cloudzero-agent exec -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server -- ls -la /etc/config/secrets/
+kubectl -n cloudzero-agent exec -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server -- ls -la /etc/config/secrets/
 ```
 
 **❌ Problem: Prometheus configuration errors**
 
 ```bash
 # Check config reload logs
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server | grep -i "reload\|config"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server | grep -i "reload\|config"
 
 # Validate configuration
 kubectl -n cloudzero-agent get configmap cloudzero-agent-configuration -o yaml
@@ -162,13 +164,13 @@ kubectl -n cloudzero-agent get configmap cloudzero-agent-configuration -o yaml
 
 ```bash
 # Real-time monitoring
-kubectl -n cloudzero-agent logs -f -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server
+kubectl -n cloudzero-agent logs -f -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server
 
 # Check validator results
-kubectl -n cloudzero-agent exec -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server -- cat cloudzero-agent-validator.log | jq
+kubectl -n cloudzero-agent exec -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server -- cat cloudzero-agent-validator.log | jq
 
 # Check init container validation
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c env-validator-run
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c env-validator-run
 ```
 
 ---
@@ -207,7 +209,7 @@ kubectl -n cloudzero-agent get secret cloudzero-agent-webhook-server-tls -o json
 
 ```bash
 # Check webhook response times
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=webhook-server,app.kubernetes.io/name=cloudzero-agent | grep -i "duration\|timeout"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=webhook-server | grep -i "duration\|timeout"
 
 # Test webhook health directly
 curl -k https://cloudzero-agent-webhook-server-svc.cloudzero-agent.svc:443/healthz
@@ -220,20 +222,20 @@ curl -k https://cloudzero-agent-webhook-server-svc.cloudzero-agent.svc:443/healt
 kubectl get validatingwebhookconfiguration cloudzero-agent-webhook-server-webhook -o yaml
 
 # Check webhook logs for resource processing
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=webhook-server,app.kubernetes.io/name=cloudzero-agent | grep -i "resource\|admit"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=webhook-server | grep -i "resource\|admit"
 ```
 
 ### Webhook Key Log Commands
 
 ```bash
 # Monitor admission requests
-kubectl -n cloudzero-agent logs -f -l app.kubernetes.io/component=webhook-server,app.kubernetes.io/name=cloudzero-agent
+kubectl -n cloudzero-agent logs -f -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=webhook-server
 
 # Check for certificate errors
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=webhook-server,app.kubernetes.io/name=cloudzero-agent | grep -i "cert\|tls\|ssl"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=webhook-server | grep -i "cert\|tls\|ssl"
 
 # Analyze webhook performance
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=webhook-server,app.kubernetes.io/name=cloudzero-agent | grep -i "latency\|duration"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=webhook-server | grep -i "latency\|duration"
 ```
 
 ---
@@ -242,7 +244,7 @@ kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=webhook-server,ap
 
 The aggregator consists of collector (receives metrics) and shipper (uploads to CloudZero).
 
-> **Note**: Aggregator commands use `app.kubernetes.io/component=aggregator`. The exact container names depend on your Helm release name (e.g., `cloudzero-agent-aggregator-collector`).
+> **Note**: Aggregator commands use `app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator`. The exact container names depend on your Helm release name (e.g., `cloudzero-agent-aggregator-collector`).
 
 ### Collector Issues
 
@@ -250,21 +252,21 @@ The aggregator consists of collector (receives metrics) and shipper (uploads to 
 
 ```bash
 # Check collector health
-kubectl -n cloudzero-agent port-forward -l app.kubernetes.io/component=aggregator 8080:8080
+kubectl -n cloudzero-agent port-forward -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator 8080:8080
 curl http://localhost:8080/healthz
 
 # Check collector logs for remote write requests (replace <release-name> with your release name)
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-collector | grep -i "remote_write\|request"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-collector | grep -i "remote_write\|request"
 ```
 
 **❌ Problem: Disk space issues**
 
 ```bash
 # Check persistent volume usage (if debug container is enabled)
-kubectl -n cloudzero-agent exec -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-debug -- df -h /cloudzero/data
+kubectl -n cloudzero-agent exec -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-debug -- df -h /cloudzero/data
 
 # Check for disk-related errors
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-collector | grep -i "disk\|space\|full"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-collector | grep -i "disk\|space\|full"
 ```
 
 ### Shipper Issues
@@ -273,36 +275,36 @@ kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator -c <re
 
 ```bash
 # Check shipper logs for upload errors
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-shipper | grep -i "upload\|s3\|error"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-shipper | grep -i "upload\|s3\|error"
 
 # Verify API key for CloudZero platform
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-shipper | grep -i "auth\|key\|unauthorized"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-shipper | grep -i "auth\|key\|unauthorized"
 ```
 
 **❌ Problem: File processing issues**
 
 ```bash
 # Check for file compression/processing errors
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-shipper | grep -i "compress\|parquet\|file"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-shipper | grep -i "compress\|parquet\|file"
 
 # Monitor file processing statistics
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-shipper | grep -i "processed\|uploaded"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-shipper | grep -i "processed\|uploaded"
 ```
 
 ### Aggregator Key Log Commands
 
 ```bash
 # Monitor collector in real-time (replace <release-name>)
-kubectl -n cloudzero-agent logs -f -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-collector
+kubectl -n cloudzero-agent logs -f -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-collector
 
 # Monitor shipper uploads (replace <release-name>)
-kubectl -n cloudzero-agent logs -f -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-shipper
+kubectl -n cloudzero-agent logs -f -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-shipper
 
 # Find your exact container names
-kubectl -n cloudzero-agent get pods -l app.kubernetes.io/component=aggregator -o jsonpath='{.items[0].spec.containers[*].name}'
+kubectl -n cloudzero-agent get pods -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -o jsonpath='{.items[0].spec.containers[*].name}'
 
 # Check aggregator metrics (if exposed)
-kubectl -n cloudzero-agent port-forward -l app.kubernetes.io/component=aggregator 8081:8081
+kubectl -n cloudzero-agent port-forward -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator 8081:8081
 curl http://localhost:8081/metrics
 ```
 
@@ -316,7 +318,7 @@ curl http://localhost:8081/metrics
 
 ```bash
 # Check kube-state-metrics pod
-kubectl -n cloudzero-agent get pods -l app.kubernetes.io/name=kube-state-metrics
+kubectl -n cloudzero-agent get pods -l app.kubernetes.io/name=ksm
 
 # Test metrics endpoint
 kubectl -n cloudzero-agent port-forward svc/cloudzero-agent-cloudzero-state-metrics 8080:8080
@@ -329,18 +331,18 @@ curl http://localhost:8080/metrics | head -20
 
 ```bash
 # Find and check backfill job logs
-kubectl -n cloudzero-agent get jobs -l app.kubernetes.io/name=cloudzero-agent
+kubectl -n cloudzero-agent get jobs -l app.kubernetes.io/part-of=cloudzero-agent
 kubectl -n cloudzero-agent logs -l job-name=<backfill-job-name>
 
 # Check job status
-kubectl -n cloudzero-agent describe jobs -l app.kubernetes.io/name=cloudzero-agent
+kubectl -n cloudzero-agent describe jobs -l app.kubernetes.io/part-of=cloudzero-agent
 ```
 
 **❌ Problem: Certificate initialization failed**
 
 ```bash
 # Find and check init-cert job
-kubectl -n cloudzero-agent get jobs -l app.kubernetes.io/name=cloudzero-agent
+kubectl -n cloudzero-agent get jobs -l app.kubernetes.io/part-of=cloudzero-agent
 kubectl -n cloudzero-agent logs -l job-name=<init-cert-job-name>
 
 # Verify certificates were created
@@ -353,11 +355,11 @@ kubectl -n cloudzero-agent get secrets | grep tls
 
 ```bash
 # Check helmless job logs for configuration information
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=helmless --tail=10000
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=helmless --tail=10000
 
 # Check job status
-kubectl -n cloudzero-agent get jobs -l app.kubernetes.io/component=helmless
-kubectl -n cloudzero-agent describe jobs -l app.kubernetes.io/component=helmless
+kubectl -n cloudzero-agent get jobs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=helmless
+kubectl -n cloudzero-agent describe jobs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=helmless
 ```
 
 > **Note**: The helmless job contains important configuration and setup information that's valuable for troubleshooting deployment issues. Include this output when contacting support.
@@ -377,8 +379,8 @@ Network policies can block communication between components or external endpoint
 kubectl -n cloudzero-agent get networkpolicies
 
 # Test connectivity between components
-kubectl -n cloudzero-agent exec -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -- nc -zv cloudzero-agent-aggregator 8080
-kubectl -n cloudzero-agent exec -l app.kubernetes.io/component=webhook-server,app.kubernetes.io/name=cloudzero-agent -- nc -zv cloudzero-agent-aggregator 8080
+kubectl -n cloudzero-agent exec -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -- nc -zv cloudzero-agent-aggregator 8080
+kubectl -n cloudzero-agent exec -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=webhook-server -- nc -zv cloudzero-agent-aggregator 8080
 ```
 
 **Common Solutions:**
@@ -489,11 +491,11 @@ When contacting support, include:
 
    ```bash
    # Generate comprehensive diagnostic bundle
-   AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -o jsonpath='{.items[0].metadata.name}')
+   AGENT_POD=$(kubectl -n cloudzero-agent get pods -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -o jsonpath='{.items[0].metadata.name}')
    kubectl -n cloudzero-agent exec -ti $AGENT_POD -c cloudzero-agent-server -- cat cloudzero-agent-validator.log > validator-diagnostics.log
    kubectl -n cloudzero-agent describe all > pod-descriptions.txt
    kubectl -n cloudzero-agent get events --sort-by=.metadata.creationTimestamp > events.txt
-   kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=helmless --tail=10000 > helmless-config.log
+   kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=helmless --tail=10000 > helmless-config.log
    ```
 
 4. **Recent Logs:**
@@ -517,33 +519,33 @@ When contacting support, include:
 
 ```bash
 # Scrape failures
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server | grep -E "dial|connection refused|timeout"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server | grep -E "dial|connection refused|timeout"
 
 # Remote write issues
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server | grep -E "remote_write.*error|failed to send"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server | grep -E "remote_write.*error|failed to send"
 
 # Config problems
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent -c cloudzero-agent-server | grep -E "config.*error|failed to reload"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server -c cloudzero-agent-server | grep -E "config.*error|failed to reload"
 ```
 
 **Webhook Patterns:**
 
 ```bash
 # Certificate issues
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=webhook-server,app.kubernetes.io/name=cloudzero-agent | grep -E "tls|certificate|x509"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=webhook-server | grep -E "tls|certificate|x509"
 
 # Admission failures
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=webhook-server,app.kubernetes.io/name=cloudzero-agent | grep -E "admission.*denied|webhook.*failed"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=webhook-server | grep -E "admission.*denied|webhook.*failed"
 ```
 
 **Aggregator Patterns:**
 
 ```bash
 # Upload failures (replace <release-name> with your release name)
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-shipper | grep -E "upload.*failed|s3.*error"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-shipper | grep -E "upload.*failed|s3.*error"
 
 # Processing issues (replace <release-name> with your release name)
-kubectl -n cloudzero-agent logs -l app.kubernetes.io/component=aggregator -c <release-name>-aggregator-collector | grep -E "decode.*error|write.*failed"
+kubectl -n cloudzero-agent logs -l app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=aggregator -c <release-name>-aggregator-collector | grep -E "decode.*error|write.*failed"
 ```
 
 ---

--- a/helm/docs/upgrades.md
+++ b/helm/docs/upgrades.md
@@ -42,7 +42,7 @@ Error: UPGRADE FAILED: failed to replace object: Job.batch "cloudzero-agent-back
 1. **Manually delete the running Jobs and retry the upgrade**
 
    ```sh
-   kubectl delete job -n <NAMESPACE> -l app.kubernetes.io/component=webhook-server
+   kubectl delete job -n <NAMESPACE> -l app.kubernetes.io/part-of=cloudzero-agent
    helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -n <NAMESPACE> --version <version> --force
    ```
 

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -92,7 +92,7 @@ kubectl get pods -n monitoring  # or appropriate namespace
 
 ```bash
 # Ensure agent is deployed
-kubectl get pods -n cz-agent
+kubectl get pods -n cloudzero-agent
 
 # Verify monitoring is working
 kubectl port-forward -n monitoring svc/prometheus 9090:9090
@@ -111,11 +111,11 @@ cd tests/load
 kubectl apply -f manifests/
 
 # Monitor webhook performance
-kubectl top pods -n cz-agent
-kubectl logs -n cz-agent -l app=cloudzero-agent-webhook-server -f
+kubectl top pods -n cloudzero-agent
+kubectl logs -n cloudzero-agent -l app=cloudzero-agent-webhook-server -f
 
 # Check webhook metrics
-kubectl port-forward -n cz-agent svc/webhook-service 8080:443
+kubectl port-forward -n cloudzero-agent svc/webhook-service 8080:443
 curl -k https://localhost:8080/metrics
 ```
 
@@ -129,7 +129,7 @@ for i in {1..100}; do
 done
 
 # Monitor resource usage
-watch "kubectl top pods -n cz-agent"
+watch "kubectl top pods -n cloudzero-agent"
 
 # Clean up after testing
 kubectl delete -f manifests/
@@ -250,13 +250,13 @@ Different resource patterns to test various scenarios:
 
 ```bash
 # Check webhook pod resource usage
-kubectl top pod -n cz-agent --containers
+kubectl top pod -n cloudzero-agent --containers
 
 # Get detailed pod metrics
-kubectl describe pod -n cz-agent <webhook-pod-name>
+kubectl describe pod -n cloudzero-agent <webhook-pod-name>
 
 # Check webhook logs for errors
-kubectl logs -n cz-agent -l app=webhook --tail=100
+kubectl logs -n cloudzero-agent -l app=webhook --tail=100
 
 # Monitor API server performance
 kubectl top nodes

--- a/tests/testkube/README.md
+++ b/tests/testkube/README.md
@@ -221,10 +221,10 @@ TestKube results can integrate with:
 
 ```bash
 # Check agent pod status
-kubectl get pods -n cz-agent
+kubectl get pods -n cloudzero-agent
 
 # Check service endpoints
-kubectl get endpoints -n cz-agent
+kubectl get endpoints -n cloudzero-agent
 
 # Test connectivity from within cluster
 kubectl run debug --image=curlimages/curl --rm -it -- /bin/sh

--- a/tests/webhook/README.md
+++ b/tests/webhook/README.md
@@ -147,7 +147,7 @@ This keeps the cluster and chart deployment running for debugging. You can then:
 
 ```bash
 # Access webhook metrics
-kubectl port-forward -n cz-webhook-test svc/webhook-chart-test-cloudzero-agent-webhook-server-svc 8080:443
+kubectl port-forward -n cloudzero-agent svc/webhook-chart-test-cloudzero-agent-webhook-server-svc 8080:443
 
 # View metrics in browser (note: HTTPS with self-signed cert)
 open https://localhost:8080/metrics


### PR DESCRIPTION
PR #606 code review identified that documentation contains outdated Kubernetes label selectors. The label system was refactored in CP-35429 (commit c7a0b6ff) to follow Kubernetes recommended labels best practices, but documentation was not updated to reflect the new selector patterns.

Functional Change:

Before: Documentation examples used `app.kubernetes.io/component=server` combined with `app.kubernetes.io/name=cloudzero-agent` to query agent resources, which no longer matches the actual labels on deployed resources.

After: Documentation examples use `app.kubernetes.io/part-of=cloudzero-agent` combined with `app.kubernetes.io/name=server` (or aggregator, webhook-server, etc.), which correctly matches the current label schema.

Solution:

1. Updated helm/docs/troubleshooting-guide.md (~50 instances) - main troubleshooting documentation with extensive kubectl examples
2. Updated helm/docs/deploy-validation.md (6 instances) - deployment validation guide
3. Updated helm/docs/cert-trouble-shooting.md - example output showing new labels
4. Updated helm/docs/upgrades.md - job deletion command selector
5. Updated docs/wiki/Debugging-Guide.md (5 instances) - debugging procedures
6. Updated docs/wiki/Installation-FAQ.md (7 instances) - FAQ kubectl examples
7. Updated docs/wiki/CloudZero-Agent-Replicas-and-Resources.md (2 instances)
8. Updated app/domain/transform/dcgm/CLAUDE.md and README.md - aggregator examples
9. Updated app/functions/helmless/README.md - helmless job log retrieval
10. Deleted obsolete docs/wiki/Webhook-Server.md.bak backup file

Label transformation pattern applied throughout:
- `app.kubernetes.io/component=server,app.kubernetes.io/name=cloudzero-agent` became `app.kubernetes.io/part-of=cloudzero-agent,app.kubernetes.io/name=server`
- kube-state-metrics uses `app.kubernetes.io/name=kube-state-metrics` (sub-chart, no part-of label)

Validation:

- Verified all documentation files with grep for `app.kubernetes.io/component`
- Confirmed remaining occurrences are intentional (label export config, test fixtures, _helpers.tpl source code)
- No functional changes to code - documentation only
