### PR TITLE
CP-36344: Scout-detected values now override customer-provided values

### DIFF
--- a/app/config/webhook/settings_test.go
+++ b/app/config/webhook/settings_test.go
@@ -76,12 +76,24 @@ destination: "https://api.cloudzero.com/v1/container-metrics"
 		settings, err := NewSettings(configFiles...)
 		require.NoError(t, err)
 		assert.NotNil(t, settings)
-		assert.Equal(t, "123456789012", settings.CloudAccountID)
-		assert.Equal(t, "us-west-2", settings.Region)
+
+		// Note: CloudAccountID and Region may be overridden by Scout auto-detection
+		// if running in a cloud environment (e.g., Azure on GitHub Actions).
+		// Scout-detected values take precedence over config file values.
+		// We verify the values are non-empty (either from config or detection).
+		assert.NotEmpty(t, settings.CloudAccountID, "CloudAccountID should be set from config or Scout detection")
+		assert.NotEmpty(t, settings.Region, "Region should be set from config or Scout detection")
 		assert.Equal(t, "test-cluster", settings.ClusterName)
 		assert.Equal(t, "https://api.cloudzero.com/v1/container-metrics", settings.Destination)
 		assert.Equal(t, apiKeyContent, settings.GetAPIKey())
-		assert.Equal(t, "https://api.cloudzero.com/v1/container-metrics?cloud_account_id=123456789012&cluster_name=test-cluster&region=us-west-2", settings.RemoteWrite.Host)
+
+		// Verify RemoteWrite.Host contains the expected base URL and cluster_name
+		// (cloudAccountId and region may differ due to Scout detection)
+		assert.Contains(t, settings.RemoteWrite.Host, "https://api.cloudzero.com/v1/container-metrics")
+		assert.Contains(t, settings.RemoteWrite.Host, "cluster_name=test-cluster")
+		assert.Contains(t, settings.RemoteWrite.Host, "cloud_account_id="+settings.CloudAccountID)
+		assert.Contains(t, settings.RemoteWrite.Host, "region="+settings.Region)
+
 		assert.Equal(t, 10000000, settings.RemoteWrite.MaxBytesPerSend)
 		assert.Equal(t, 60*time.Second, settings.RemoteWrite.SendInterval)
 	})

--- a/app/utils/scout/detect_configuration.go
+++ b/app/utils/scout/detect_configuration.go
@@ -17,13 +17,12 @@ import (
 // provider information from configuration variables which may or may not
 // already contain values.
 //
-// It is designed for use when loading configuration. If any fields are empty,
-// an auto scout (see the auto subpackage) will be used to attempt to detect the
-// correct values. If the fields are not empty, they will be treated as
-// overrides and left intact, but a warning will be logged if they don't match
-// the detected values.
+// It is designed for use when loading configuration. When Scout is able to
+// detect a value, it will override any customer-provided value (logging a
+// warning if they differ). Customer-provided values are only used as a
+// fallback when Scout cannot detect a value.
 //
-// If any of the fields are unable to be auto-detected AND are required (empty),
+// If any of the fields are unable to be auto-detected AND are not provided,
 // an error will be returned. If all required fields are already provided,
 // detection failures will only result in warning logs.
 //
@@ -68,59 +67,65 @@ func DetectConfiguration(ctx context.Context, logger *zerolog.Logger, scout type
 
 	// Handle region configuration
 	if region != nil {
-		if *region == "" {
-			// Empty field - set with detected value
-			if ei.Region == "" {
-				return errors.New("region could not be auto-detected, manual configuration (setting region in the Helm chart) may be required")
+		if ei.Region != "" {
+			// Detected value available - use it (override customer-provided if different)
+			if *region != "" && *region != ei.Region {
+				// Log warning when overriding customer-provided value
+				if logger != nil {
+					logger.Warn().
+						Str("provided", *region).
+						Str("detected", ei.Region).
+						Msg("provided region does not match detected region; using detected value")
+				}
 			}
 			*region = ei.Region
-		} else if ei.Region != "" && *region != ei.Region {
-			// Non-empty field that doesn't match detected value - log warning
-			if logger != nil {
-				logger.Warn().
-					Str("provided", *region).
-					Str("detected", ei.Region).
-					Msg("provided region does not match detected region")
-			}
+		} else if *region == "" {
+			// Not detected AND not provided - error
+			return errors.New("region could not be auto-detected, manual configuration (setting region in the Helm chart) may be required")
 		}
+		// If detected is empty but customer provided: keep customer value (implicit)
 	}
 
 	// Handle account ID configuration
 	if accountID != nil {
-		if *accountID == "" {
-			// Empty field - set with detected value
-			if ei.AccountID == "" {
-				return errors.New("account ID could not be auto-detected, manual configuration (setting cloudAccountId in the Helm chart) may be required")
+		if ei.AccountID != "" {
+			// Detected value available - use it (override customer-provided if different)
+			if *accountID != "" && *accountID != ei.AccountID {
+				// Log warning when overriding customer-provided value
+				if logger != nil {
+					logger.Warn().
+						Str("provided", *accountID).
+						Str("detected", ei.AccountID).
+						Msg("provided account ID does not match detected account ID; using detected value")
+				}
 			}
 			*accountID = ei.AccountID
-		} else if ei.AccountID != "" && *accountID != ei.AccountID {
-			// Non-empty field that doesn't match detected value - log warning
-			if logger != nil {
-				logger.Warn().
-					Str("provided", *accountID).
-					Str("detected", ei.AccountID).
-					Msg("provided account ID does not match detected account ID")
-			}
+		} else if *accountID == "" {
+			// Not detected AND not provided - error
+			return errors.New("account ID could not be auto-detected, manual configuration (setting cloudAccountId in the Helm chart) may be required")
 		}
+		// If detected is empty but customer provided: keep customer value (implicit)
 	}
 
 	// Handle cluster name configuration
 	if clusterName != nil {
-		if *clusterName == "" {
-			// Empty field - set with detected value
-			if ei.ClusterName == "" {
-				return errors.New("cluster name could not be auto-detected, manual configuration (setting clusterName in the Helm chart) may be required")
+		if ei.ClusterName != "" {
+			// Detected value available - use it (override customer-provided if different)
+			if *clusterName != "" && *clusterName != ei.ClusterName {
+				// Log warning when overriding customer-provided value
+				if logger != nil {
+					logger.Warn().
+						Str("provided", *clusterName).
+						Str("detected", ei.ClusterName).
+						Msg("provided cluster name does not match detected cluster name; using detected value")
+				}
 			}
 			*clusterName = ei.ClusterName
-		} else if ei.ClusterName != "" && *clusterName != ei.ClusterName {
-			// Non-empty field that doesn't match detected value - log warning
-			if logger != nil {
-				logger.Warn().
-					Str("provided", *clusterName).
-					Str("detected", ei.ClusterName).
-					Msg("provided cluster name does not match detected cluster name")
-			}
+		} else if *clusterName == "" {
+			// Not detected AND not provided - error
+			return errors.New("cluster name could not be auto-detected, manual configuration (setting clusterName in the Helm chart) may be required")
 		}
+		// If detected is empty but customer provided: keep customer value (implicit)
 	}
 
 	return nil

--- a/app/utils/scout/detect_configuration_test.go
+++ b/app/utils/scout/detect_configuration_test.go
@@ -49,12 +49,12 @@ func TestDetectConfiguration_Success(t *testing.T) {
 			},
 		},
 		{
-			name:                "detect only region and cluster when account is already set",
+			name:                "detect all - existing account overridden by detected",
 			inputRegion:         stringPtr(""),
 			inputAccountID:      stringPtr("existing-account"),
 			inputClusterName:    stringPtr(""),
 			expectedRegion:      "eu-west-1",
-			expectedAccountID:   "existing-account",
+			expectedAccountID:   "987654321098", // Detected value overrides customer-provided
 			expectedClusterName: "detected-cluster",
 			environmentInfo: &types.EnvironmentInfo{
 				CloudProvider: types.CloudProviderAWS,
@@ -64,11 +64,11 @@ func TestDetectConfiguration_Success(t *testing.T) {
 			},
 		},
 		{
-			name:                "detect only account and cluster when region is already set",
+			name:                "detect all - existing region overridden by detected",
 			inputRegion:         stringPtr("existing-region"),
 			inputAccountID:      stringPtr(""),
 			inputClusterName:    stringPtr(""),
-			expectedRegion:      "existing-region",
+			expectedRegion:      "us-central1", // Detected value overrides customer-provided
 			expectedAccountID:   "detected-account",
 			expectedClusterName: "production-cluster",
 			environmentInfo: &types.EnvironmentInfo{
@@ -79,12 +79,12 @@ func TestDetectConfiguration_Success(t *testing.T) {
 			},
 		},
 		{
-			name:                "detect only cluster when region and account are already set",
+			name:                "detect all - existing region and account overridden by detected",
 			inputRegion:         stringPtr("existing-region"),
 			inputAccountID:      stringPtr("existing-account"),
 			inputClusterName:    stringPtr(""),
-			expectedRegion:      "existing-region",
-			expectedAccountID:   "existing-account",
+			expectedRegion:      "us-west-2",    // Detected value overrides customer-provided
+			expectedAccountID:   "123456789012", // Detected value overrides customer-provided
 			expectedClusterName: "staging-cluster",
 			environmentInfo: &types.EnvironmentInfo{
 				CloudProvider: types.CloudProviderAWS,
@@ -409,7 +409,7 @@ func TestDetectConfiguration_AllEmptyStringValues(t *testing.T) {
 	}
 }
 
-func TestDetectConfiguration_PartialDetection(t *testing.T) {
+func TestDetectConfiguration_DetectedValuesOverrideProvided(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -425,24 +425,24 @@ func TestDetectConfiguration_PartialDetection(t *testing.T) {
 			ClusterName:   "detected-cluster",
 		}, nil)
 
-	region := "existing-region"       // Already set
-	accountID := "existing-account"   // Already set
-	clusterName := "existing-cluster" // Already set
+	region := "existing-region"       // Already set - will be overridden
+	accountID := "existing-account"   // Already set - will be overridden
+	clusterName := "existing-cluster" // Already set - will be overridden
 
 	err := scout.DetectConfiguration(context.Background(), nil, mockScout, &region, &accountID, &clusterName)
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
 	}
 
-	// Values should remain unchanged
-	if region != "existing-region" {
-		t.Errorf("Expected region to remain unchanged, got: %s", region)
+	// Detected values should override customer-provided values
+	if region != "detected-region" {
+		t.Errorf("Expected region to be overridden to 'detected-region', got: %s", region)
 	}
-	if accountID != "existing-account" {
-		t.Errorf("Expected accountID to remain unchanged, got: %s", accountID)
+	if accountID != "detected-account" {
+		t.Errorf("Expected accountID to be overridden to 'detected-account', got: %s", accountID)
 	}
-	if clusterName != "existing-cluster" {
-		t.Errorf("Expected clusterName to remain unchanged, got: %s", clusterName)
+	if clusterName != "detected-cluster" {
+		t.Errorf("Expected clusterName to be overridden to 'detected-cluster', got: %s", clusterName)
 	}
 }
 
@@ -663,15 +663,15 @@ func TestDetectConfiguration_NilScout(t *testing.T) {
 	}
 }
 
-func TestDetectConfiguration_NoDetectionWhenValuesProvided(t *testing.T) {
+func TestDetectConfiguration_ScoutAlwaysCalledAndOverrides(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	// Test that Scout is still invoked even when all values are already
-	// provided. This allows for mismatch warnings to be logged.
+	// Test that Scout is always invoked, and when it returns values,
+	// those values override customer-provided values.
 	mockScout := mocks.NewMockScout(ctrl)
 
-	// Scout should be called to allow comparison and warning logs
+	// Scout should be called and its values should override customer-provided
 	mockScout.EXPECT().
 		EnvironmentInfo(gomock.Any()).
 		Return(&types.EnvironmentInfo{
@@ -690,15 +690,120 @@ func TestDetectConfiguration_NoDetectionWhenValuesProvided(t *testing.T) {
 		t.Errorf("Expected no error when values are pre-set, got: %v", err)
 	}
 
-	// Verify values weren't changed
-	if region != "pre-set-region" {
-		t.Errorf("Expected region to remain unchanged, got: %s", region)
+	// Verify detected values override pre-set values
+	if region != "detected-region" {
+		t.Errorf("Expected region to be overridden to 'detected-region', got: %s", region)
 	}
-	if accountID != "pre-set-account" {
-		t.Errorf("Expected accountID to remain unchanged, got: %s", accountID)
+	if accountID != "detected-account" {
+		t.Errorf("Expected accountID to be overridden to 'detected-account', got: %s", accountID)
 	}
-	if clusterName != "pre-set-cluster" {
-		t.Errorf("Expected clusterName to remain unchanged, got: %s", clusterName)
+	if clusterName != "detected-cluster" {
+		t.Errorf("Expected clusterName to be overridden to 'detected-cluster', got: %s", clusterName)
+	}
+}
+
+func TestDetectConfiguration_CustomerValuesFallbackWhenDetectedEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tests := []struct {
+		name                string
+		inputRegion         *string
+		inputAccountID      *string
+		inputClusterName    *string
+		environmentInfo     *types.EnvironmentInfo
+		expectedRegion      string
+		expectedAccountID   string
+		expectedClusterName string
+	}{
+		{
+			name:                "all detected values empty - use customer values as fallback",
+			inputRegion:         stringPtr("customer-region"),
+			inputAccountID:      stringPtr("customer-account"),
+			inputClusterName:    stringPtr("customer-cluster"),
+			expectedRegion:      "customer-region",  // Fallback to customer value
+			expectedAccountID:   "customer-account", // Fallback to customer value
+			expectedClusterName: "customer-cluster", // Fallback to customer value
+			environmentInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderAWS,
+				Region:        "", // Empty - cannot detect
+				AccountID:     "", // Empty - cannot detect
+				ClusterName:   "", // Empty - cannot detect
+			},
+		},
+		{
+			name:                "region detected empty - use customer value as fallback",
+			inputRegion:         stringPtr("customer-region"),
+			inputAccountID:      stringPtr("customer-account"),
+			inputClusterName:    stringPtr("customer-cluster"),
+			expectedRegion:      "customer-region",  // Fallback to customer value
+			expectedAccountID:   "detected-account", // Detected overrides
+			expectedClusterName: "detected-cluster", // Detected overrides
+			environmentInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderAWS,
+				Region:        "", // Empty - cannot detect
+				AccountID:     "detected-account",
+				ClusterName:   "detected-cluster",
+			},
+		},
+		{
+			name:                "account detected empty - use customer value as fallback",
+			inputRegion:         stringPtr("customer-region"),
+			inputAccountID:      stringPtr("customer-account"),
+			inputClusterName:    stringPtr("customer-cluster"),
+			expectedRegion:      "detected-region",  // Detected overrides
+			expectedAccountID:   "customer-account", // Fallback to customer value
+			expectedClusterName: "detected-cluster", // Detected overrides
+			environmentInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderAWS,
+				Region:        "detected-region",
+				AccountID:     "", // Empty - cannot detect
+				ClusterName:   "detected-cluster",
+			},
+		},
+		{
+			name:                "cluster detected empty - use customer value as fallback",
+			inputRegion:         stringPtr("customer-region"),
+			inputAccountID:      stringPtr("customer-account"),
+			inputClusterName:    stringPtr("customer-cluster"),
+			expectedRegion:      "detected-region",  // Detected overrides
+			expectedAccountID:   "detected-account", // Detected overrides
+			expectedClusterName: "customer-cluster", // Fallback to customer value
+			environmentInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderAWS,
+				Region:        "detected-region",
+				AccountID:     "detected-account",
+				ClusterName:   "", // Empty - cannot detect
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockScout := mocks.NewMockScout(ctrl)
+
+			mockScout.EXPECT().
+				EnvironmentInfo(gomock.Any()).
+				Return(tt.environmentInfo, nil)
+
+			err := scout.DetectConfiguration(context.Background(), nil, mockScout, tt.inputRegion, tt.inputAccountID, tt.inputClusterName)
+			if err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+
+			// Verify results
+			if tt.inputRegion != nil && *tt.inputRegion != tt.expectedRegion {
+				t.Errorf("Expected region %q, got %q", tt.expectedRegion, *tt.inputRegion)
+			}
+
+			if tt.inputAccountID != nil && *tt.inputAccountID != tt.expectedAccountID {
+				t.Errorf("Expected accountID %q, got %q", tt.expectedAccountID, *tt.inputAccountID)
+			}
+
+			if tt.inputClusterName != nil && *tt.inputClusterName != tt.expectedClusterName {
+				t.Errorf("Expected clusterName %q, got %q", tt.expectedClusterName, *tt.inputClusterName)
+			}
+		})
 	}
 }
 
@@ -727,7 +832,7 @@ func TestDetectConfiguration_WarningLogsForMismatchedValues(t *testing.T) {
 				ClusterName:   "detected-cluster",
 			},
 			expectedWarnings: []string{
-				"provided region does not match detected region",
+				"provided region does not match detected region; using detected value",
 				`"provided":"provided-region"`,
 				`"detected":"detected-region"`,
 			},
@@ -748,7 +853,7 @@ func TestDetectConfiguration_WarningLogsForMismatchedValues(t *testing.T) {
 				ClusterName:   "detected-cluster",
 			},
 			expectedWarnings: []string{
-				"provided account ID does not match detected account ID",
+				"provided account ID does not match detected account ID; using detected value",
 				`"provided":"provided-account"`,
 				`"detected":"detected-account"`,
 			},
@@ -769,7 +874,7 @@ func TestDetectConfiguration_WarningLogsForMismatchedValues(t *testing.T) {
 				ClusterName:   "detected-cluster",
 			},
 			expectedWarnings: []string{
-				"provided cluster name does not match detected cluster name",
+				"provided cluster name does not match detected cluster name; using detected value",
 				`"provided":"provided-cluster"`,
 				`"detected":"detected-cluster"`,
 			},
@@ -790,9 +895,9 @@ func TestDetectConfiguration_WarningLogsForMismatchedValues(t *testing.T) {
 				ClusterName:   "detected-cluster",
 			},
 			expectedWarnings: []string{
-				"provided region does not match detected region",
-				"provided account ID does not match detected account ID",
-				"provided cluster name does not match detected cluster name",
+				"provided region does not match detected region; using detected value",
+				"provided account ID does not match detected account ID; using detected value",
+				"provided cluster name does not match detected cluster name; using detected value",
 				`"provided":"provided-region"`,
 				`"detected":"detected-region"`,
 				`"provided":"provided-account"`,


### PR DESCRIPTION
Previously, when customers provided configuration values (region, cloudAccountId, clusterName) that differed from values detected by Scout, the customer-provided values would take precedence. We decided to flip this precedence so that when Scout successfully detects values, those values override any customer-provided values. This ensures the agent uses accurate, environment-detected configuration rather than potentially stale or incorrect manually-provided values.

Functional Change:

Before: Customer-provided values overrode Scout-detected values. When they differed, a warning was logged but the customer value was used.

After: Scout-detected values override customer-provided values. When they differ, a warning is logged (with "; using detected value" suffix) and the detected value is used. Customer-provided values are only used as a fallback when Scout cannot detect a value.

Solution:

1. Restructured DetectConfiguration logic in app/utils/scout/detect_configuration.go to check for detected values first, using them when available and falling back to customer-provided values only when detection returns empty

2. Updated warning messages to include "; using detected value" to clarify the new override behavior

3. Updated function docstring to document the new precedence order

4. Updated existing tests to expect detected values override customer-provided values:
   - Renamed TestDetectConfiguration_PartialDetection to TestDetectConfiguration_DetectedValuesOverrideProvided
   - Renamed TestDetectConfiguration_NoDetectionWhenValuesProvided to TestDetectConfiguration_ScoutAlwaysCalledAndOverrides
   - Updated test case names and expectations in TestDetectConfiguration_Success

5. Added TestDetectConfiguration_CustomerValuesFallbackWhenDetectedEmpty test to verify customer values are still used when detection returns empty (partial detection scenarios)

6. Updated warning message expectations in TestDetectConfiguration_WarningLogsForMismatchedValues

Validation:

- All scout package tests pass: `GO_TEST_TARGET=./app/utils/scout make test`
- Test coverage remains at 100% for detect_configuration.go
- Manually deployed to a cluster to verify the new behavior