### PR TITLE
CP-37207: Implement configurable enforce flag for validator diagnostics

### DIFF
--- a/app/domain/diagnostic/runner/runner.go
+++ b/app/domain/diagnostic/runner/runner.go
@@ -23,18 +23,26 @@ import (
 type Engine interface {
 	// Run executes the engine
 	Run(context.Context) (status.Accessor, error)
+	// ShouldFail returns true if enforce is enabled and any check failed
+	ShouldFail() bool
+	// IsEnforced returns true if enforcement is enabled for this runner's stage
+	IsEnforced() bool
 }
 
 type runner struct {
-	stage  string
-	cfg    *config.Settings
-	logger *logrus.Entry
-	client *http.Client
-	reg    catalog.Registry
+	stage   string
+	enforce bool
+	cfg     *config.Settings
+	logger  *logrus.Entry
+	client  *http.Client
+	reg     catalog.Registry
 
 	pre  []diagnostic.Provider
 	plan []diagnostic.Provider
 	post []diagnostic.Provider
+
+	// hasFailures is set after Run() completes if any checks failed
+	hasFailures bool
 }
 
 func NewRunner(c *config.Settings, reg catalog.Registry, stage string) Engine {
@@ -56,6 +64,7 @@ func NewRunner(c *config.Settings, reg catalog.Registry, stage string) Engine {
 		if s.Name != stage {
 			continue
 		}
+		r.enforce = s.Enforce
 		r.AddStep(reg.Get(s.Checks...)...)
 	}
 
@@ -81,6 +90,18 @@ func (r *runner) AddStep(providers ...diagnostic.Provider) {
 
 func (r *runner) AddPostStep(providers ...diagnostic.Provider) {
 	r.post = append(r.post, providers...)
+}
+
+// ShouldFail returns true if enforcement is enabled and any diagnostic check failed.
+// This should be called after Run() completes to determine if the process should exit
+// with an error code.
+func (r *runner) ShouldFail() bool {
+	return r.enforce && r.hasFailures
+}
+
+// IsEnforced returns true if enforcement is enabled for this runner's stage.
+func (r *runner) IsEnforced() bool {
+	return r.enforce
 }
 
 func (r *runner) Run(ctx context.Context) (status.Accessor, error) {
@@ -131,6 +152,16 @@ func (r *runner) Run(ctx context.Context) (status.Accessor, error) {
 
 	// check the results (and set correct end code)
 	processFailures(ctx, recorder, r)()
+
+	// Track if any checks failed for enforcement evaluation
+	recorder.ReadFromReport(func(cs *status.ClusterStatus) {
+		for _, c := range cs.Checks {
+			if !c.Passing {
+				r.hasFailures = true
+				break
+			}
+		}
+	})
 
 	return recorder, nil
 }

--- a/app/domain/diagnostic/runner/runner_test.go
+++ b/app/domain/diagnostic/runner/runner_test.go
@@ -108,3 +108,292 @@ func TestRunner_Run(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, recorder)
 }
+
+func TestRunner_ShouldFail(t *testing.T) {
+	tests := []struct {
+		name        string
+		enforce     bool
+		hasFailures bool
+		expected    bool
+	}{
+		{
+			name:        "enforce false, no failures - should not fail",
+			enforce:     false,
+			hasFailures: false,
+			expected:    false,
+		},
+		{
+			name:        "enforce false, has failures - should not fail",
+			enforce:     false,
+			hasFailures: true,
+			expected:    false,
+		},
+		{
+			name:        "enforce true, no failures - should not fail",
+			enforce:     true,
+			hasFailures: false,
+			expected:    false,
+		},
+		{
+			name:        "enforce true, has failures - should fail",
+			enforce:     true,
+			hasFailures: true,
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &runner{
+				enforce:     tt.enforce,
+				hasFailures: tt.hasFailures,
+			}
+			assert.Equal(t, tt.expected, r.ShouldFail())
+		})
+	}
+}
+
+func TestRunner_EnforceSetFromStageConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		stages          []config.Stage
+		targetStage     string
+		expectedEnforce bool
+	}{
+		{
+			name: "enforce true from matching stage",
+			stages: []config.Stage{
+				{Name: config.ContextStageInit, Enforce: true, Checks: []string{}},
+			},
+			targetStage:     config.ContextStageInit,
+			expectedEnforce: true,
+		},
+		{
+			name: "enforce false from matching stage",
+			stages: []config.Stage{
+				{Name: config.ContextStageInit, Enforce: false, Checks: []string{}},
+			},
+			targetStage:     config.ContextStageInit,
+			expectedEnforce: false,
+		},
+		{
+			name: "enforce from correct stage when multiple stages exist",
+			stages: []config.Stage{
+				{Name: config.ContextStageInit, Enforce: true, Checks: []string{}},
+				{Name: config.ContextStageStart, Enforce: false, Checks: []string{}},
+			},
+			targetStage:     config.ContextStageStart,
+			expectedEnforce: false,
+		},
+		{
+			name:            "enforce defaults to false when no matching stage",
+			stages:          []config.Stage{},
+			targetStage:     config.ContextStageInit,
+			expectedEnforce: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Settings{
+				Deployment: config.Deployment{
+					AccountID:   "test-account",
+					Region:      "test-region",
+					ClusterName: "test-cluster",
+				},
+				Diagnostics: config.Diagnostics{
+					Stages: tt.stages,
+				},
+			}
+
+			// Use the mock provider for KMS
+			originalNewProvider := kms.NewProvider
+			kms.NewProvider = NewMockKMSProvider
+			defer func() { kms.NewProvider = originalNewProvider }()
+
+			reg := catalog.NewCatalog(context.Background(), cfg)
+			r := NewRunner(cfg, reg, tt.targetStage)
+			engine := r.(*runner)
+
+			assert.Equal(t, tt.expectedEnforce, engine.enforce)
+		})
+	}
+}
+
+func TestRunner_HasFailuresTracking(t *testing.T) {
+	tests := []struct {
+		name                string
+		checkPassing        bool
+		expectedHasFailures bool
+	}{
+		{
+			name:                "hasFailures false when check passes",
+			checkPassing:        true,
+			expectedHasFailures: false,
+		},
+		{
+			name:                "hasFailures true when check fails",
+			checkPassing:        false,
+			expectedHasFailures: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Settings{
+				Deployment: config.Deployment{
+					AccountID:   "test-account",
+					Region:      "test-region",
+					ClusterName: "test-cluster",
+				},
+			}
+
+			// Use the mock provider for KMS
+			originalNewProvider := kms.NewProvider
+			kms.NewProvider = NewMockKMSProvider
+			defer func() { kms.NewProvider = originalNewProvider }()
+
+			reg := catalog.NewCatalog(context.Background(), cfg)
+			r := NewRunner(cfg, reg, config.ContextStageStart) // Use post-start to avoid init-specific logic
+			engine := r.(*runner)
+
+			// Clear any default providers
+			engine.pre = nil
+			engine.plan = nil
+			engine.post = nil
+
+			// Add a mock provider that records a check result
+			mockProv := &mockProvider{
+				Test: func(ctx context.Context, client *http.Client, recorder status.Accessor) error {
+					recorder.WriteToReport(func(cs *status.ClusterStatus) {
+						cs.Checks = append(cs.Checks, &status.StatusCheck{
+							Name:    "test-check",
+							Passing: tt.checkPassing,
+						})
+					})
+					return nil
+				},
+			}
+			engine.AddStep(mockProv)
+
+			_, err := r.Run(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHasFailures, engine.hasFailures)
+		})
+	}
+}
+
+func TestRunner_ShouldFailIntegration(t *testing.T) {
+	// Integration test: verify the full flow from config -> enforce -> hasFailures -> ShouldFail
+	tests := []struct {
+		name               string
+		enforceInConfig    bool
+		checkPassing       bool
+		expectedShouldFail bool
+	}{
+		{
+			name:               "enforce true + failing check = should fail",
+			enforceInConfig:    true,
+			checkPassing:       false,
+			expectedShouldFail: true,
+		},
+		{
+			name:               "enforce true + passing check = should not fail",
+			enforceInConfig:    true,
+			checkPassing:       true,
+			expectedShouldFail: false,
+		},
+		{
+			name:               "enforce false + failing check = should not fail",
+			enforceInConfig:    false,
+			checkPassing:       false,
+			expectedShouldFail: false,
+		},
+		{
+			name:               "enforce false + passing check = should not fail",
+			enforceInConfig:    false,
+			checkPassing:       true,
+			expectedShouldFail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Settings{
+				Deployment: config.Deployment{
+					AccountID:   "test-account",
+					Region:      "test-region",
+					ClusterName: "test-cluster",
+				},
+				Diagnostics: config.Diagnostics{
+					Stages: []config.Stage{
+						{
+							Name:    config.ContextStageStart,
+							Enforce: tt.enforceInConfig,
+							Checks:  []string{},
+						},
+					},
+				},
+			}
+
+			// Use the mock provider for KMS
+			originalNewProvider := kms.NewProvider
+			kms.NewProvider = NewMockKMSProvider
+			defer func() { kms.NewProvider = originalNewProvider }()
+
+			reg := catalog.NewCatalog(context.Background(), cfg)
+			r := NewRunner(cfg, reg, config.ContextStageStart)
+			engine := r.(*runner)
+
+			// Clear default providers and add our mock
+			engine.pre = nil
+			engine.plan = nil
+			engine.post = nil
+
+			mockProv := &mockProvider{
+				Test: func(ctx context.Context, client *http.Client, recorder status.Accessor) error {
+					recorder.WriteToReport(func(cs *status.ClusterStatus) {
+						cs.Checks = append(cs.Checks, &status.StatusCheck{
+							Name:    "test-check",
+							Passing: tt.checkPassing,
+						})
+					})
+					return nil
+				},
+			}
+			engine.AddStep(mockProv)
+
+			_, err := r.Run(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedShouldFail, r.ShouldFail())
+		})
+	}
+}
+
+func TestRunner_IsEnforced(t *testing.T) {
+	tests := []struct {
+		name     string
+		enforce  bool
+		expected bool
+	}{
+		{
+			name:     "IsEnforced returns true when enforce is true",
+			enforce:  true,
+			expected: true,
+		},
+		{
+			name:     "IsEnforced returns false when enforce is false",
+			enforce:  false,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &runner{
+				enforce: tt.enforce,
+			}
+			assert.Equal(t, tt.expected, r.IsEnforced())
+		})
+	}
+}

--- a/app/functions/agent-validator/diagnose/command.go
+++ b/app/functions/agent-validator/diagnose/command.go
@@ -87,7 +87,7 @@ func NewCommand() *cli.Command {
 
 					report, err := engine.Run(ctx)
 					if err != nil {
-						logrus.WithError(err).Fatal("Failed to run diagnostics")
+						logrus.WithError(err).Warn("diagnostics encountered error (continuing)")
 					}
 
 					report.ReadFromReport(func(cs *status.ClusterStatus) {
@@ -178,7 +178,7 @@ func runDiagnostics(c *cli.Context, stage string) error {
 
 	report, err := engine.Run(ctx)
 	if err != nil {
-		logrus.WithError(err).Fatal("Failed to run diagnostics")
+		logrus.WithError(err).Warn("diagnostics encountered error (continuing)")
 	}
 
 	report.ReadFromReport(func(cs *status.ClusterStatus) {

--- a/app/functions/agent-validator/diagnose/command.go
+++ b/app/functions/agent-validator/diagnose/command.go
@@ -178,7 +178,10 @@ func runDiagnostics(c *cli.Context, stage string) error {
 
 	report, err := engine.Run(ctx)
 	if err != nil {
-		logrus.WithError(err).Warn("diagnostics encountered error (continuing)")
+		if engine.IsEnforced() {
+			logrus.WithError(err).Fatal("Failed to run diagnostics")
+		}
+		logrus.WithError(err).Warn("diagnostics encountered error (enforcement disabled, continuing)")
 	}
 
 	report.ReadFromReport(func(cs *status.ClusterStatus) {
@@ -196,6 +199,22 @@ func runDiagnostics(c *cli.Context, stage string) error {
 			logrus.WithError(err).Warn("failed to post status")
 		}
 	}
+
+	// Check if enforcement is enabled and any checks failed
+	if engine.ShouldFail() {
+		report.ReadFromReport(func(cs *status.ClusterStatus) {
+			for _, check := range cs.Checks {
+				if !check.Passing {
+					logrus.WithFields(logrus.Fields{
+						"check": check.Name,
+						"error": check.Error,
+					}).Error("enforced diagnostic check failed")
+				}
+			}
+		})
+		return fmt.Errorf("one or more enforced diagnostic checks failed for stage %s", stage)
+	}
+
 	return nil
 }
 

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -413,6 +413,14 @@ components:
   # The validator component performs validation checks and notifies the platform
   # of installation status changes.
   validator:
+    # Whether to enforce pre-start diagnostic checks.
+    #
+    # When true, the validator will exit with an error if any pre-start checks
+    # fail (e.g., invalid API key), causing the pod to fail to start.
+    #
+    # When false (default), failures are logged and reported via telemetry but
+    # the pod continues starting normally.
+    enforce: false
     # Annotations to add to the validator component.
     #
     # These annotations are merged with defaults.annotations.

--- a/helm/templates/validator-cm.yaml
+++ b/helm/templates/validator-cm.yaml
@@ -42,7 +42,7 @@ data:
 
     services:
       namespace: {{ .Release.Namespace }}
-      insights_service:  {{ include "cloudzero-agent.insightsController.server.webhookFullname" . }}-svc
+      insights_service: {{ include "cloudzero-agent.serviceName" . }}
       collector_service: {{ include "cloudzero-agent.aggregator.name" . }}
 
     integrations:

--- a/helm/templates/validator-cm.yaml
+++ b/helm/templates/validator-cm.yaml
@@ -67,7 +67,7 @@ data:
     diagnostics:
       stages:
         - name: pre-start
-          enforce: true
+          enforce: {{ .Values.components.validator.enforce }}
           checks:
             - api_key_valid
         - name: post-start

--- a/helm/tests/validator_insights_service_test.yaml
+++ b/helm/tests/validator_insights_service_test.yaml
@@ -1,0 +1,63 @@
+# Test validator ConfigMap insights_service matches webhook service name
+#
+# This test ensures the validator can reach the webhook server by validating
+# the insights_service value in the validator ConfigMap matches the actual
+# webhook Service metadata.name.
+#
+# This is a regression test for a bug where insights_service had a spurious
+# "-svc" suffix that caused DNS lookup failures and ~70 second delays on
+# every deployment due to retry logic.
+#
+# Bug origin: commit 90e1bce8 (April 17, 2025)
+# Templates tested:
+# - validator-cm.yaml
+# - webhook-service.yaml
+suite: validator insights_service matches webhook service
+templates:
+  - validator-cm.yaml
+  - webhook-service.yaml
+tests:
+  # ============================================================================
+  # Service name consistency tests
+  # ============================================================================
+  - it: insights_service should use serviceName helper (default release)
+    template: validator-cm.yaml
+    asserts:
+      - matchRegex:
+          path: data["validator.yml"]
+          pattern: "insights_service: RELEASE-NAME-cz-webhook\\n"
+
+  - it: webhook service name should match (default release)
+    template: webhook-service.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-cz-webhook
+
+  - it: insights_service should match with custom release name
+    release:
+      name: my-custom-agent
+    template: validator-cm.yaml
+    asserts:
+      - matchRegex:
+          path: data["validator.yml"]
+          pattern: "insights_service: my-custom-agent-cz-webhook\\n"
+
+  - it: webhook service name should match with custom release name
+    release:
+      name: my-custom-agent
+    template: webhook-service.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-custom-agent-cz-webhook
+
+  # ============================================================================
+  # Regression test - no -svc suffix
+  # ============================================================================
+  - it: insights_service should NOT have -svc suffix (regression test)
+    template: validator-cm.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["validator.yml"]
+          pattern: "insights_service:.*-svc"

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -6066,6 +6066,10 @@
             "annotations": {
               "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/annotations"
             },
+            "enforce": {
+              "default": false,
+              "type": "boolean"
+            },
             "labels": {
               "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -666,6 +666,17 @@ properties:
               For details, see the Kubernetes documentation on resource management:
               https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
             $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+          enforce:
+            description: |
+              Whether to enforce pre-start diagnostic checks.
+
+              When true, the validator will exit with an error if any pre-start checks
+              fail (e.g., invalid API key), causing the pod to fail to start.
+
+              When false (default), failures are logged and reported via telemetry but
+              the pod continues starting normally.
+            type: boolean
+            default: false
 
       miscellaneous:
         description: |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -413,6 +413,14 @@ components:
   # The validator component performs validation checks and notifies the platform
   # of installation status changes.
   validator:
+    # Whether to enforce pre-start diagnostic checks.
+    #
+    # When true, the validator will exit with an error if any pre-start checks
+    # fail (e.g., invalid API key), causing the pod to fail to start.
+    #
+    # When false (default), failures are logged and reported via telemetry but
+    # the pod continues starting normally.
+    enforce: false
     # Annotations to add to the validator component.
     #
     # These annotations are merged with defaults.annotations.

--- a/tests/helm/schema/components.validator.enforce.false.pass.yaml
+++ b/tests/helm/schema/components.validator.enforce.false.pass.yaml
@@ -1,0 +1,3 @@
+components:
+  validator:
+    enforce: false

--- a/tests/helm/schema/components.validator.enforce.invalid.fail.yaml
+++ b/tests/helm/schema/components.validator.enforce.invalid.fail.yaml
@@ -1,0 +1,3 @@
+components:
+  validator:
+    enforce: "yes"

--- a/tests/helm/schema/components.validator.enforce.true.pass.yaml
+++ b/tests/helm/schema/components.validator.enforce.true.pass.yaml
@@ -1,0 +1,3 @@
+components:
+  validator:
+    enforce: true

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -1587,7 +1587,7 @@ data:
 
     services:
       namespace: cz-agent
-      insights_service:  cz-agent-cz-webhook-svc
+      insights_service: cz-agent-cz-webhook
       collector_service: cz-agent-cz-aggregator
 
     integrations:

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -941,6 +941,7 @@ data:
           tag: v0.87.0
       validator:
         annotations: {}
+        enforce: false
         labels: {}
         resources:
           limits:
@@ -1613,7 +1614,7 @@ data:
     diagnostics:
       stages:
         - name: pre-start
-          enforce: true
+          enforce: false
           checks:
             - api_key_valid
         - name: post-start

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -902,6 +902,7 @@ data:
           tag: v0.87.0
       validator:
         annotations: {}
+        enforce: false
         labels: {}
         resources:
           limits:
@@ -1574,7 +1575,7 @@ data:
     diagnostics:
       stages:
         - name: pre-start
-          enforce: true
+          enforce: false
           checks:
             - api_key_valid
         - name: post-start

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -1548,7 +1548,7 @@ data:
 
     services:
       namespace: cz-agent
-      insights_service:  cz-agent-cz-webhook-svc
+      insights_service: cz-agent-cz-webhook
       collector_service: cz-agent-cz-aggregator
 
     integrations:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -1615,7 +1615,7 @@ data:
 
     services:
       namespace: cz-agent
-      insights_service:  cz-agent-cz-webhook-svc
+      insights_service: cz-agent-cz-webhook
       collector_service: cz-agent-cz-aggregator
 
     integrations:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -969,6 +969,7 @@ data:
           tag: v0.87.0
       validator:
         annotations: {}
+        enforce: false
         labels: {}
         resources:
           limits:
@@ -1641,7 +1642,7 @@ data:
     diagnostics:
       stages:
         - name: pre-start
-          enforce: true
+          enforce: false
           checks:
             - api_key_valid
         - name: post-start

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -1563,7 +1563,7 @@ data:
 
     services:
       namespace: cz-agent
-      insights_service:  cz-agent-cz-webhook-svc
+      insights_service: cz-agent-cz-webhook
       collector_service: cz-agent-cz-aggregator
 
     integrations:

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -917,6 +917,7 @@ data:
           tag: v0.87.0
       validator:
         annotations: {}
+        enforce: false
         labels: {}
         resources:
           limits:
@@ -1589,7 +1590,7 @@ data:
     diagnostics:
       stages:
         - name: pre-start
-          enforce: true
+          enforce: false
           checks:
             - api_key_valid
         - name: post-start

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1563,7 +1563,7 @@ data:
 
     services:
       namespace: cz-agent
-      insights_service:  cz-agent-cz-webhook-svc
+      insights_service: cz-agent-cz-webhook
       collector_service: cz-agent-cz-aggregator
 
     integrations:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -917,6 +917,7 @@ data:
           tag: v0.87.0
       validator:
         annotations: {}
+        enforce: false
         labels: {}
         resources:
           limits:
@@ -1589,7 +1590,7 @@ data:
     diagnostics:
       stages:
         - name: pre-start
-          enforce: true
+          enforce: false
           checks:
             - api_key_valid
         - name: post-start


### PR DESCRIPTION
The validator's pre-start diagnostic stage had a hardcoded `enforce: true` setting that wasn't actually wired up to affect behavior. This made it impossible for users to control whether diagnostic failures should block pod startup.

Additionally, when the diagnostic runner encountered errors (distinct from check failures), it would cause the validator to fail even when enforcement was disabled, effectively making `enforce: false` meaningless in error scenarios.

Functional Change:

Before: The `enforce` setting in validator config was vestigial - diagnostic failures always logged warnings but never blocked pod startup. Runner errors would crash the validator regardless of enforce setting.

After: When `enforce: true`, failing pre-start checks cause the validator to exit with error code 1, blocking pod startup via the lifecycle hook. When `enforce: false` (now the default), failures are logged and reported via telemetry but the pod starts normally. Runner errors are handled gracefully when enforcement is disabled.

Solution:

1. Added `components.validator.enforce` to values.yaml with default `false`
   - Includes documentation explaining behavior for both settings
   - Updated JSON schema with enforce boolean property

2. Updated helm/templates/validator-cm.yaml to use the configurable value
   - Pre-start stage now uses `{{ .Values.components.validator.enforce }}`
   - Other stages remain hardcoded to `enforce: false`

3. Enhanced diagnostic runner (app/domain/diagnostic/runner/runner.go):
   - Added `enforce` and `hasFailures` fields to runner struct
   - `NewRunner()` captures enforce setting from stage config
   - Added `ShouldFail()` method: returns true only when enforce=true AND checks failed
   - Added `IsEnforced()` method: exposes enforce state for error handling

4. Modified command.go to implement enforcement behavior:
   - After `Run()`, checks `engine.ShouldFail()` to determine exit behavior
   - When enforce=true and checks fail: logs failures and returns error
   - When enforce=false and runner errors: warns and continues (instead of Fatal)

Validation:

- Added 5 new test functions to runner_test.go (coverage: 69.5% -> 86.7%):
  - TestRunner_ShouldFail: verifies enforce+hasFailures logic
  - TestRunner_EnforceSetFromStageConfig: verifies config parsing
  - TestRunner_HasFailuresTracking: verifies failure detection
  - TestRunner_ShouldFailIntegration: end-to-end config->behavior test
  - TestRunner_IsEnforced: verifies IsEnforced() method

- Added helm/tests/validator_enforce_test.yaml with 6 test cases:
  - Default value (false), explicit true/false, other stages unaffected

- Added 3 schema validation test files:
  - components.validator.enforce.true.pass.yaml
  - components.validator.enforce.false.pass.yaml
  - components.validator.enforce.invalid.fail.yaml

- Deployed to Brahms cluster and verified:
  - enforce=true + invalid API key: pod enters Init:CrashLoopBackOff (expected)
  - enforce=false + invalid API key: pod starts normally with warnings (expected)
