### PR TITLE
CP-37371: Use distroless Prometheus image by default

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -8,7 +8,7 @@ kubeVersion: ">= 1.21.0-0"
 maintainers:
   - name: CloudZero
     email: support@cloudzero.com
-appVersion: "v3.7.3"
+appVersion: "v3.10.0"
 dependencies:
   - name: kube-state-metrics
     version: "5.36.*"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1390,6 +1390,23 @@ prometheus.yml
 {{- end -}}
 
 {{/*
+Resolve the Prometheus image tag.
+
+Resolves the tag from components.prometheus.image.tag, falling back to
+Chart.AppVersion with "-distroless" appended to use the official distroless
+image variant (no shell, minimal attack surface).
+
+Note: the deprecated server.image.tag compat override is handled by
+generateImage's compat layer at the call site, not here.
+
+Usage: {{ include "cloudzero-agent.Values.components.prometheus.image.tag" . }}
+Returns: string (e.g., "v3.10.0-distroless", "v3.7.3")
+*/}}
+{{- define "cloudzero-agent.Values.components.prometheus.image.tag" -}}
+  {{- .Values.components.prometheus.image.tag | default (printf "%s-distroless" .Chart.AppVersion) -}}
+{{- end -}}
+
+{{/*
 Get the appropriate Prometheus agent mode flag based on version and mode
 
 Determines whether Prometheus should run in agent mode and which flag to use:
@@ -1401,8 +1418,8 @@ The cloudzero-agent.Values.components.agent.mode helper already handles all the
 complex mode derivation logic, so we just check if it returns "agent" or "federated"
 and then determine the appropriate version-specific flag.
 
-Uses the same tag fallback chain as image generation:
-server.image.tag -> components.prometheus.image.tag -> Chart.AppVersion
+Uses the same tag fallback chain as image generation via
+cloudzero-agent.Values.components.prometheus.image.tag
 
 Usage: {{ include "cloudzero-agent.prometheusAgentFlag" . }}
 Returns: string (either "--agent", "--enable-feature=agent", or empty string)
@@ -1410,8 +1427,7 @@ Returns: string (either "--agent", "--enable-feature=agent", or empty string)
 {{- define "cloudzero-agent.prometheusAgentFlag" -}}
   {{- $mode := include "cloudzero-agent.Values.components.agent.mode" . -}}
   {{- if or (eq $mode "agent") (eq $mode "federated") -}}
-    {{- /* Use same fallback chain as image generation: server.image.tag -> components.prometheus.image.tag -> Chart.AppVersion */ -}}
-    {{- $tag := .Values.server.image.tag | default .Values.components.prometheus.image.tag | default .Chart.AppVersion -}}
+    {{- $tag := include "cloudzero-agent.Values.components.prometheus.image.tag" . -}}
     {{- if hasPrefix "v2." $tag -}}
       --enable-feature=agent
     {{- else -}}

--- a/helm/templates/agent-daemonset.yaml
+++ b/helm/templates/agent-daemonset.yaml
@@ -127,8 +127,7 @@ spec:
               readOnly: true
         {{- end }}
         - name: {{ template "cloudzero-agent.name" . }}-server
-          {{/* This is a little special because we want to fall back on the .Chart.AppVersion */}}
-          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.prometheus.image "compat" (dict "repository" .Values.server.image.repository "tag" (.Values.server.image.tag | default .Values.components.prometheus.image.tag | default .Chart.AppVersion) "digest" .Values.server.image.digest "pullPolicy" .Values.server.image.pullPolicy)) | nindent 10 }}
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.prometheus.image "compat" (dict "repository" .Values.server.image.repository "tag" (include "cloudzero-agent.Values.components.prometheus.image.tag" .) "digest" .Values.server.image.digest "pullPolicy" .Values.server.image.pullPolicy)) | nindent 10 }}
           env:
             - name: NODE_NAME
               valueFrom:
@@ -145,6 +144,9 @@ spec:
             {{- $agentFlag := include "cloudzero-agent.prometheusAgentFlag" . }}
             {{- if $agentFlag }}
             - {{ $agentFlag }}
+            - --storage.agent.path=/data
+            {{- else }}
+            - --storage.tsdb.path=/data
             {{- end }}
           ports:
             - containerPort: 9090

--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -153,8 +153,14 @@ spec:
         {{- if ne (include "cloudzero-agent.Values.components.agent.mode" .) "clustered" }}
         # Prometheus server container
         - name: {{ template "cloudzero-agent.name" . }}-server
-          {{/* This is a little special because we want to fall back on the .Chart.AppVersion */}}
-          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.prometheus.image "compat" (dict "repository" .Values.server.image.repository "tag" (.Values.server.image.tag | default .Values.components.prometheus.image.tag | default .Chart.AppVersion) "digest" .Values.server.image.digest "pullPolicy" .Values.server.image.pullPolicy)) | nindent 10 }}
+          {{- include "cloudzero-agent.generateImage" (dict
+            "defaults" .Values.defaults.image
+            "image" .Values.components.prometheus.image
+            "compat" (dict
+              "repository" .Values.server.image.repository
+              "tag" (include "cloudzero-agent.Values.components.prometheus.image.tag" .)
+              "digest" .Values.server.image.digest
+              "pullPolicy" .Values.server.image.pullPolicy)) | nindent 10 }}
           {{- if .Values.server.env }}
           env:
 {{ toYaml .Values.server.env | indent 12}}
@@ -182,6 +188,9 @@ spec:
             {{- $agentFlag := include "cloudzero-agent.prometheusAgentFlag" . }}
             {{- if $agentFlag }}
             - {{ $agentFlag }}
+            - --storage.agent.path={{ .Values.server.persistentVolume.mountPath }}
+            {{- else }}
+            - --storage.tsdb.path={{ .Values.server.persistentVolume.mountPath }}
             {{- end }}
             - --log.level={{ .Values.server.logging.level | default "info" }}
           ports:

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -51,7 +51,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -107,7 +107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -137,7 +137,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-api-key
@@ -154,7 +154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-tls
@@ -169,7 +169,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-configuration
   namespace: cz-agent
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -900,7 +900,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -1739,7 +1739,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-validator-configuration
   namespace: cz-agent
@@ -1846,7 +1846,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-webhook-configuration
   namespace: cz-agent
@@ -2075,7 +2075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-server
 rules:
@@ -2166,7 +2166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     checkov.io/skip_1: CKV_K8S_155
@@ -2233,7 +2233,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2255,7 +2255,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -2306,7 +2306,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -2329,7 +2329,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
@@ -2445,7 +2445,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2463,7 +2463,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -2738,7 +2738,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   selector:
@@ -2755,7 +2755,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: aggregator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
     spec:
       serviceAccountName: cz-agent-cz-server
@@ -2894,7 +2894,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Deployment annotations: Merge defaults with webhook-specific annotations
   # Supports monitoring, backup policies, and operational tooling integration
@@ -2912,7 +2912,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: webhook-server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
@@ -3013,7 +3013,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: onetime
     job-type: backfill
@@ -3027,7 +3027,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: backfill
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
         job-category: onetime
         job-type: backfill
@@ -3095,7 +3095,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3107,7 +3107,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: validator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3225,7 +3225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3237,7 +3237,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: helmless
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3293,7 +3293,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3304,7 +3304,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: init-cert
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3358,7 +3358,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: cronjob
     job-type: backfill
@@ -3378,7 +3378,7 @@ spec:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: backfill
             app.kubernetes.io/part-of: cloudzero-agent
-            app.kubernetes.io/version: v3.7.3
+            app.kubernetes.io/version: v3.10.0
             helm.sh/chart: cloudzero-agent-1.1.0-dev
             job-category: cronjob
             job-type: backfill
@@ -3444,7 +3444,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Certificate management annotations for automatic TLS certificate injection
   # When cert-manager is enabled, automatically injects CA bundle for webhook TLS validation

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -51,7 +51,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -107,7 +107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -137,7 +137,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-api-key
@@ -154,7 +154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-configuration
   namespace: cz-agent
@@ -463,7 +463,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -817,7 +817,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -1655,7 +1655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-validator-configuration
   namespace: cz-agent
@@ -1762,7 +1762,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-webhook-configuration
   namespace: cz-agent
@@ -1991,7 +1991,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-server
 rules:
@@ -2082,7 +2082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     checkov.io/skip_1: CKV_K8S_155
@@ -2149,7 +2149,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2171,7 +2171,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -2222,7 +2222,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -2245,7 +2245,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
@@ -2361,7 +2361,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2379,7 +2379,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -2521,8 +2521,7 @@ spec:
               readOnly: true
         # Prometheus server container
         - name: cloudzero-agent-server
-          
-          image: "quay.io/prometheus/prometheus:v3.7.3"
+          image: "quay.io/prometheus/prometheus:v3.10.0-distroless"
           imagePullPolicy: "IfNotPresent"
           lifecycle:
             postStart:
@@ -2548,6 +2547,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --agent
+            - --storage.agent.path=/data
             - --log.level=info
           ports:
             - containerPort: 9090
@@ -2639,7 +2639,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   selector:
@@ -2656,7 +2656,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: aggregator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
     spec:
       serviceAccountName: cz-agent-cz-server
@@ -2795,7 +2795,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Deployment annotations: Merge defaults with webhook-specific annotations
   # Supports monitoring, backup policies, and operational tooling integration
@@ -2813,7 +2813,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: webhook-server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
@@ -2914,7 +2914,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: onetime
     job-type: backfill
@@ -2928,7 +2928,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: backfill
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
         job-category: onetime
         job-type: backfill
@@ -2996,7 +2996,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3008,7 +3008,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: validator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3126,7 +3126,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3138,7 +3138,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: helmless
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3194,7 +3194,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: cronjob
     job-type: backfill
@@ -3214,7 +3214,7 @@ spec:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: backfill
             app.kubernetes.io/part-of: cloudzero-agent
-            app.kubernetes.io/version: v3.7.3
+            app.kubernetes.io/version: v3.10.0
             helm.sh/chart: cloudzero-agent-1.1.0-dev
             job-category: cronjob
             job-type: backfill
@@ -3280,7 +3280,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -3291,7 +3291,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/name: webhook-server
       app.kubernetes.io/part-of: cloudzero-agent
-      app.kubernetes.io/version: v3.7.3
+      app.kubernetes.io/version: v3.10.0
       helm.sh/chart: cloudzero-agent-1.1.0-dev
   privateKey:
     algorithm: RSA
@@ -3318,7 +3318,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -3335,7 +3335,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Certificate management annotations for automatic TLS certificate injection
   # When cert-manager is enabled, automatically injects CA bundle for webhook TLS validation

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -51,7 +51,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -107,7 +107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -137,7 +137,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-api-key
@@ -154,7 +154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-tls
@@ -169,7 +169,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-configuration
   namespace: cz-agent
@@ -390,7 +390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-daemonset-cm
   namespace: cz-agent
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -905,7 +905,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -1743,7 +1743,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-validator-configuration
   namespace: cz-agent
@@ -1850,7 +1850,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-webhook-configuration
   namespace: cz-agent
@@ -2079,7 +2079,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-server
 rules:
@@ -2170,7 +2170,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     checkov.io/skip_1: CKV_K8S_155
@@ -2237,7 +2237,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2259,7 +2259,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -2310,7 +2310,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -2333,7 +2333,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
@@ -2358,7 +2358,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-daemonset
@@ -2375,7 +2375,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -2460,8 +2460,7 @@ spec:
               mountPath: /etc/config
               readOnly: true
         - name: cloudzero-agent-server
-          
-          image: "quay.io/prometheus/prometheus:v3.7.3"
+          image: "quay.io/prometheus/prometheus:v3.10.0-distroless"
           imagePullPolicy: "IfNotPresent"
           env:
             - name: NODE_NAME
@@ -2474,6 +2473,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --agent
+            - --storage.agent.path=/data
           ports:
             - containerPort: 9090
           readinessProbe:
@@ -2644,7 +2644,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2662,7 +2662,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -2804,8 +2804,7 @@ spec:
               readOnly: true
         # Prometheus server container
         - name: cloudzero-agent-server
-          
-          image: "quay.io/prometheus/prometheus:v3.7.3"
+          image: "quay.io/prometheus/prometheus:v3.10.0-distroless"
           imagePullPolicy: "IfNotPresent"
           lifecycle:
             postStart:
@@ -2831,6 +2830,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --agent
+            - --storage.agent.path=/data
             - --log.level=info
           ports:
             - containerPort: 9090
@@ -2922,7 +2922,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   selector:
@@ -2939,7 +2939,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: aggregator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
     spec:
       serviceAccountName: cz-agent-cz-server
@@ -3078,7 +3078,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Deployment annotations: Merge defaults with webhook-specific annotations
   # Supports monitoring, backup policies, and operational tooling integration
@@ -3096,7 +3096,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: webhook-server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
@@ -3197,7 +3197,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: onetime
     job-type: backfill
@@ -3211,7 +3211,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: backfill
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
         job-category: onetime
         job-type: backfill
@@ -3279,7 +3279,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3291,7 +3291,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: validator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3409,7 +3409,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3421,7 +3421,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: helmless
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3477,7 +3477,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3488,7 +3488,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: init-cert
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3542,7 +3542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: cronjob
     job-type: backfill
@@ -3562,7 +3562,7 @@ spec:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: backfill
             app.kubernetes.io/part-of: cloudzero-agent
-            app.kubernetes.io/version: v3.7.3
+            app.kubernetes.io/version: v3.10.0
             helm.sh/chart: cloudzero-agent-1.1.0-dev
             job-category: cronjob
             job-type: backfill
@@ -3628,7 +3628,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Certificate management annotations for automatic TLS certificate injection
   # When cert-manager is enabled, automatically injects CA bundle for webhook TLS validation

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -51,7 +51,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -107,7 +107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -137,7 +137,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-api-key
@@ -154,7 +154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-tls
@@ -169,7 +169,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-configuration
   namespace: cz-agent
@@ -478,7 +478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -832,7 +832,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -1670,7 +1670,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-validator-configuration
   namespace: cz-agent
@@ -1777,7 +1777,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-webhook-configuration
   namespace: cz-agent
@@ -2006,7 +2006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-server
 rules:
@@ -2097,7 +2097,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     checkov.io/skip_1: CKV_K8S_155
@@ -2164,7 +2164,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2186,7 +2186,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -2237,7 +2237,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -2260,7 +2260,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
@@ -2376,7 +2376,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2394,7 +2394,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -2536,8 +2536,7 @@ spec:
               readOnly: true
         # Prometheus server container
         - name: cloudzero-agent-server
-          
-          image: "quay.io/prometheus/prometheus:v3.7.3"
+          image: "quay.io/prometheus/prometheus:v3.10.0-distroless"
           imagePullPolicy: "IfNotPresent"
           lifecycle:
             postStart:
@@ -2563,6 +2562,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --agent
+            - --storage.agent.path=/data
             - --log.level=info
           ports:
             - containerPort: 9090
@@ -2654,7 +2654,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   selector:
@@ -2671,7 +2671,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: aggregator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
     spec:
       serviceAccountName: cz-agent-cz-server
@@ -2810,7 +2810,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Deployment annotations: Merge defaults with webhook-specific annotations
   # Supports monitoring, backup policies, and operational tooling integration
@@ -2828,7 +2828,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: webhook-server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
@@ -2930,7 +2930,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: onetime
     job-type: backfill
@@ -2944,7 +2944,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: backfill
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
         job-category: onetime
         job-type: backfill
@@ -3013,7 +3013,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3025,7 +3025,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: validator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3143,7 +3143,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3155,7 +3155,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: helmless
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3211,7 +3211,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3222,7 +3222,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: init-cert
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3276,7 +3276,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: cronjob
     job-type: backfill
@@ -3296,7 +3296,7 @@ spec:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: backfill
             app.kubernetes.io/part-of: cloudzero-agent
-            app.kubernetes.io/version: v3.7.3
+            app.kubernetes.io/version: v3.10.0
             helm.sh/chart: cloudzero-agent-1.1.0-dev
             job-category: cronjob
             job-type: backfill
@@ -3364,7 +3364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cz-agent-cz-aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -3389,7 +3389,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Certificate management annotations for automatic TLS certificate injection
   # When cert-manager is enabled, automatically injects CA bundle for webhook TLS validation
@@ -3450,7 +3450,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cz-agent-cz-aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -51,7 +51,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -107,7 +107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -122,7 +122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -137,7 +137,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-api-key
@@ -154,7 +154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-tls
@@ -169,7 +169,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-configuration
   namespace: cz-agent
@@ -478,7 +478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -832,7 +832,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 data:
@@ -1670,7 +1670,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-validator-configuration
   namespace: cz-agent
@@ -1777,7 +1777,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-webhook-configuration
   namespace: cz-agent
@@ -2006,7 +2006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   name: cz-agent-cz-server
 rules:
@@ -2097,7 +2097,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     checkov.io/skip_1: CKV_K8S_155
@@ -2164,7 +2164,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2186,7 +2186,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-webhook-init-cert
@@ -2237,7 +2237,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
 spec:
@@ -2260,7 +2260,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
@@ -2376,7 +2376,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   
   name: cz-agent-cz-server
@@ -2394,7 +2394,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -2536,8 +2536,7 @@ spec:
               readOnly: true
         # Prometheus server container
         - name: cloudzero-agent-server
-          
-          image: "quay.io/prometheus/prometheus:v3.7.3"
+          image: "quay.io/prometheus/prometheus:v3.10.0-distroless"
           imagePullPolicy: "IfNotPresent"
           lifecycle:
             postStart:
@@ -2563,6 +2562,7 @@ spec:
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --agent
+            - --storage.agent.path=/data
             - --log.level=info
           ports:
             - containerPort: 9090
@@ -2654,7 +2654,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aggregator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   selector:
@@ -2671,7 +2671,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: aggregator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
     spec:
       serviceAccountName: cz-agent-cz-server
@@ -2810,7 +2810,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Deployment annotations: Merge defaults with webhook-specific annotations
   # Supports monitoring, backup policies, and operational tooling integration
@@ -2828,7 +2828,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: webhook-server
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       annotations:
         checksum/config: DEADBEEF-FEED-FACE-CAFE-FEE10D15EA5E
@@ -2929,7 +2929,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: onetime
     job-type: backfill
@@ -2943,7 +2943,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: backfill
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
         job-category: onetime
         job-type: backfill
@@ -3011,7 +3011,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: validator
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3023,7 +3023,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: validator
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3141,7 +3141,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: helmless
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3153,7 +3153,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: helmless
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3209,7 +3209,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: init-cert
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
 spec:
   template:
@@ -3220,7 +3220,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: init-cert
         app.kubernetes.io/part-of: cloudzero-agent
-        app.kubernetes.io/version: v3.7.3
+        app.kubernetes.io/version: v3.10.0
         helm.sh/chart: cloudzero-agent-1.1.0-dev
       
     spec:
@@ -3274,7 +3274,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: backfill
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
     job-category: cronjob
     job-type: backfill
@@ -3294,7 +3294,7 @@ spec:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: backfill
             app.kubernetes.io/part-of: cloudzero-agent
-            app.kubernetes.io/version: v3.7.3
+            app.kubernetes.io/version: v3.10.0
             helm.sh/chart: cloudzero-agent-1.1.0-dev
             job-category: cronjob
             job-type: backfill
@@ -3360,7 +3360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook-server
     app.kubernetes.io/part-of: cloudzero-agent
-    app.kubernetes.io/version: v3.7.3
+    app.kubernetes.io/version: v3.10.0
     helm.sh/chart: cloudzero-agent-1.1.0-dev
   # Certificate management annotations for automatic TLS certificate injection
   # When cert-manager is enabled, automatically injects CA bundle for webhook TLS validation


### PR DESCRIPTION
Prometheus 3.10.0 introduced an official distroless image variant that eliminates shells, package managers, and other utilities from the container. This significantly reduces the attack surface of the Prometheus container, addressing security concerns around the nodes/proxy RBAC permission (see docs/wiki/The-nodes-proxy-Problem.md).

Functional Change:

Before: The Helm chart defaulted to the standard Prometheus image (busybox-based, includes shell and utilities) at version v3.7.3. The Prometheus image tag was resolved by the `cloudzero-agent.prometheusImageTag` helper with an inline fallback chain duplicated across templates.

After: The Helm chart defaults to the distroless Prometheus image at version v3.10.0. The image tag is resolved by a new `cloudzero-agent.Values.components.prometheus.image.tag` helper that appends "-distroless" to Chart.AppVersion when no explicit tag is set. The deprecated server.image.tag compat override is handled by generateImage's compat layer, not the helper itself.

Solution:

1. Bumped Chart.AppVersion from v3.7.3 to v3.10.0 in helm/Chart.yaml

2. Added `cloudzero-agent.Values.components.prometheus.image.tag` helper in helm/templates/_helpers.tpl that resolves components.prometheus.image.tag with a fallback to `{Chart.AppVersion}-distroless`

3. Removed the old `cloudzero-agent.prometheusImageTag` helper and updated all call sites (agent-deploy.yaml, agent-daemonset.yaml, prometheusAgentFlag) to use the new helper

4. Removed outdated inline comments about version-specific distroless logic from agent-deploy.yaml and agent-daemonset.yaml

5. Regenerated Helm template test snapshots (alloy.yaml, cert-manager.yaml, federated.yaml, istio.yaml, manifest.yaml) to reflect the new default image tag

Validation:

- Helm template snapshots regenerated and verified