### PR TITLE
CP-37468: Add direct kubelet cAdvisor metrics collection option

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -242,6 +242,42 @@ integrations:
     #     -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CLUSTER_ID")].value}'
     clusterID: null
 
+  # cAdvisor container metrics integration settings.
+  cAdvisor:
+    # Enable cAdvisor metrics collection.
+    # Default: true
+    enabled: true
+
+    # Kubelet port for direct kubelet connections.
+    # Used by both federated mode and direct node access mode.
+    # The standard default is 10250, but can be changed via --port on kubelet.
+    port: 10250
+
+    # TLS configuration for cAdvisor metrics collection.
+    tls:
+      # Skip TLS certificate verification when scraping cAdvisor metrics.
+      #
+      # Default: true (required for most clusters where certificates may not
+      # have proper SANs or are self-signed).
+      #
+      # Set to false only if you have proper TLS certificates configured and
+      # want strict certificate verification.
+      insecureSkipVerify: true
+
+    # Direct node access configuration for cAdvisor metrics collection.
+    #
+    # When enabled, the agent connects directly to node kubelets instead of
+    # routing through the Kubernetes API server proxy. This removes the
+    # dangerous nodes/proxy RBAC permission from the ClusterRole.
+    #
+    # Requirements:
+    # - Network connectivity from collector pod to all nodes on the kubelet port
+    # - Will not work with strict NetworkPolicies blocking pod-to-node traffic
+    directNodeAccess:
+      # Enable direct node access mode.
+      # Default: false (uses API server proxy for maximum compatibility)
+      enabled: false
+
 # Component-specific configuration settings.
 components:
   # The agent here refers to the CloudZero Agent, which is the component that
@@ -811,9 +847,12 @@ prometheusConfig:
       enabled: true
       # Scrape interval for kubeStateMetrics job
       scrapeInterval: 60s
-    # -- Enables the cadvisor scrape job.
+    # -- DEPRECATED: Use integrations.cAdvisor.enabled instead.
+    # Enables the cadvisor scrape job. If set to a boolean value, it takes
+    # precedence over integrations.cAdvisor.enabled. If null (default), falls
+    # back to integrations.cAdvisor.enabled.
     cadvisor:
-      enabled: true
+      enabled: null
       # Scrape interval for nodesCadvisor job
       scrapeInterval: 60s
     # -- Enables the prometheus scrape job.

--- a/helm/templates/_alloy_helpers.tpl
+++ b/helm/templates/_alloy_helpers.tpl
@@ -31,7 +31,7 @@ Usage: {{ include "cloudzero-agent.alloy.riverConfig" . }}
 {{- include "cloudzero-agent.alloy.scrapeKubeStateMetrics" . }}
 {{- end }}
 
-{{- if .Values.prometheusConfig.scrapeJobs.cadvisor.enabled }}
+{{- if include "cloudzero-agent.Values.integrations.cAdvisor.enabled" . }}
 {{- include "cloudzero-agent.alloy.scrapeCAdvisor" . }}
 {{- end }}
 
@@ -111,6 +111,9 @@ Generates River configuration for scraping cAdvisor metrics from Kubernetes node
 Usage: {{ include "cloudzero-agent.alloy.scrapeCAdvisor" . }}
 */}}
 {{- define "cloudzero-agent.alloy.scrapeCAdvisor" -}}
+{{- $directNodeAccess := .Values.integrations.cAdvisor.directNodeAccess.enabled | default false -}}
+{{- $kubeletPort := .Values.integrations.cAdvisor.port | default 10250 -}}
+{{- $insecureSkipVerify := .Values.integrations.cAdvisor.tls.insecureSkipVerify -}}
 // cAdvisor Scrape Job
 // Collects container resource usage metrics
 
@@ -118,8 +121,34 @@ discovery.kubernetes "cadvisor" {
   role = "node"
 }
 
+{{- if $directNodeAccess }}
+// Direct node access mode - connect directly to kubelets on port {{ $kubeletPort }}
+// Bypasses API server proxy, only requires nodes/metrics RBAC
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.cadvisor.targets
+
+  // Rewrite target address to node's internal IP on kubelet port
+  rule {
+    source_labels = ["__meta_kubernetes_node_address_InternalIP"]
+    target_label  = "__address__"
+    replacement   = "$1:{{ $kubeletPort }}"
+  }
+
+  // Map node labels
+  rule {
+    regex  = "__meta_kubernetes_node_label_(.+)"
+    action = "labelmap"
+  }
+
+  // Map node name
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    target_label  = "node"
+  }
+}
+
 prometheus.scrape "cadvisor" {
-  targets    = discovery.kubernetes.cadvisor.targets
+  targets    = discovery.relabel.cadvisor.output
   forward_to = [prometheus.relabel.cadvisor.receiver]
   scrape_interval = "{{ .Values.prometheusConfig.scrapeJobs.cadvisor.scrapeInterval }}"
   metrics_path = "/metrics/cadvisor"
@@ -129,13 +158,63 @@ prometheus.scrape "cadvisor" {
 
   tls_config {
     ca_file              = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-    insecure_skip_verify = false
+    insecure_skip_verify = {{ $insecureSkipVerify }}
   }
 
   clustering {
     enabled = true
   }
 }
+{{- else }}
+// API server proxy mode (default) - route through Kubernetes API server
+// Requires nodes/proxy RBAC permission
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.cadvisor.targets
+
+  // Route through API server
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+
+  // Set metrics path to API proxy endpoint
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    target_label  = "__metrics_path__"
+    replacement   = "/api/v1/nodes/$1/proxy/metrics/cadvisor"
+  }
+
+  // Map node labels
+  rule {
+    regex  = "__meta_kubernetes_node_label_(.+)"
+    action = "labelmap"
+  }
+
+  // Map node name
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    target_label  = "node"
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  targets    = discovery.relabel.cadvisor.output
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+  scrape_interval = "{{ .Values.prometheusConfig.scrapeJobs.cadvisor.scrapeInterval }}"
+  scheme = "https"
+
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  tls_config {
+    ca_file              = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    insecure_skip_verify = {{ $insecureSkipVerify }}
+  }
+
+  clustering {
+    enabled = true
+  }
+}
+{{- end }}
 
 // Filter cAdvisor metrics - keep only CloudZero cost metrics
 prometheus.relabel "cadvisor" {
@@ -152,12 +231,6 @@ prometheus.relabel "cadvisor" {
   rule {
     regex  = "^({{ include "cloudzero-agent.requiredMetricLabels" . }})$"
     action = "labelkeep"
-  }
-
-  // Map node name for cost allocation
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    target_label  = "node"
   }
 }
 {{- end -}}

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -491,8 +491,9 @@ Container metrics collected:
 - Storage usage: Container filesystem usage for storage cost analysis
 
 Scraping modes supported:
-- Local node scraping: DaemonSet mode scraping only the local node's cAdvisor
-- Cluster-wide scraping: Central scraping of all nodes via Kubernetes API proxy
+- Federated mode: Local node scraping only (each pod scrapes its own node)
+- Direct node access: Scrape all nodes directly via kubelet (bypasses API proxy)
+- API server proxy: Scrape all nodes via Kubernetes API proxy (default)
 - Authentication: ServiceAccount token-based authentication for secure access
 - TLS configuration: Proper certificate handling for secure cAdvisor endpoints
 
@@ -508,6 +509,9 @@ and optimization recommendations across Kubernetes workloads.
 */}}
 {{- define "cloudzero-agent.prometheus.scrapeCAdvisor" -}}
 {{- $scrapeLocal := .scrapeLocalNodeOnly | default false -}}
+{{- $directNodeAccess := .root.Values.integrations.cAdvisor.directNodeAccess.enabled | default false -}}
+{{- $kubeletPort := .root.Values.integrations.cAdvisor.port | default 10250 -}}
+{{- $insecureSkipVerify := .root.Values.integrations.cAdvisor.tls.insecureSkipVerify -}}
 # cAdvisor Scrape Job cloudzero-nodes-cadvisor
 #
 # This job scrapes metrics about container resource usage (CPU, memory,
@@ -524,10 +528,10 @@ and optimization recommendations across Kubernetes workloads.
     credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
+    insecure_skip_verify: {{ $insecureSkipVerify }}
 
   {{- if $scrapeLocal }}
-  # Scrape metrics directly from cAdvisor endpoint.
+  # Scrape metrics directly from local node's cAdvisor endpoint (federated mode).
   metrics_path: /metrics/cadvisor
 
   # Scrape metrics from cAdvisor
@@ -551,10 +555,22 @@ and optimization recommendations across Kubernetes workloads.
     # Add port number to __address__ in "__meta_kubernetes_node_address_InternalIP"
     - source_labels: [__meta_kubernetes_node_address_InternalIP]
       target_label: __address__
-      replacement: ${1}:10250
-  {{- else }}
+      replacement: ${1}:{{ $kubeletPort }}
+  {{- else if $directNodeAccess }}
+  # Scrape metrics directly from all node kubelets (direct node access mode).
+  # This bypasses the API server proxy and only requires nodes/metrics RBAC.
+  # Requires network connectivity from collector pod to all nodes on port {{ $kubeletPort }}.
+  metrics_path: /metrics/cadvisor
 
-  # Scrape metrics from cAdvisor.
+  relabel_configs:
+
+    # Connect directly to node's internal IP on kubelet port
+    - source_labels: [__meta_kubernetes_node_address_InternalIP]
+      target_label: __address__
+      replacement: ${1}:{{ $kubeletPort }}
+  {{- else }}
+  # Scrape metrics via API server proxy (default mode).
+  # Requires nodes/proxy RBAC permission.
   relabel_configs:
 
     # Replace the value of __address__ labels with "kubernetes.default.svc.cluster.local:443"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1456,6 +1456,21 @@ Returns: "true" (truthy) when enabled, empty string (falsy) when disabled
 {{- end -}}
 
 {{/*
+cAdvisor Integration Enabled Helper
+
+Returns "true" if enabled, empty string if disabled (for use in conditionals).
+- prometheusConfig.scrapeJobs.cadvisor.enabled takes priority if explicitly set
+- integrations.cAdvisor.enabled is the fallback when null
+*/}}
+{{- define "cloudzero-agent.Values.integrations.cAdvisor.enabled" -}}
+{{- $enabled := .Values.integrations.cAdvisor.enabled -}}
+{{- if not (kindIs "invalid" .Values.prometheusConfig.scrapeJobs.cadvisor.enabled) -}}
+{{- $enabled = .Values.prometheusConfig.scrapeJobs.cadvisor.enabled -}}
+{{- end -}}
+{{- if $enabled }}true{{- end -}}
+{{- end -}}
+
+{{/*
 Istio Cluster ID Helper
 
 Returns the Istio cluster ID to use for multicluster mesh configurations.

--- a/helm/templates/agent-clusterrole.yaml
+++ b/helm/templates/agent-clusterrole.yaml
@@ -43,7 +43,9 @@ rules:
       - endpoints
       - namespaces
       - nodes
+      {{- if not .Values.integrations.cAdvisor.directNodeAccess.enabled }}
       - nodes/proxy
+      {{- end }}
       - nodes/metrics
       - services
       - pods

--- a/helm/templates/agent-cm.yaml
+++ b/helm/templates/agent-cm.yaml
@@ -44,7 +44,7 @@ data:
       {{- include "cloudzero-agent.prometheus.scrapeKubeStateMetrics" . | nindent 6 }}
       {{- end }}{{/* End kubeStateMetrics scrape job */}}
 
-      {{- if and (ne (include "cloudzero-agent.Values.components.agent.mode" .) "federated") .Values.prometheusConfig.scrapeJobs.cadvisor.enabled }}
+      {{- if and (ne (include "cloudzero-agent.Values.components.agent.mode" .) "federated") (include "cloudzero-agent.Values.integrations.cAdvisor.enabled" .) }}
       {{- include "cloudzero-agent.prometheus.scrapeCAdvisor" (dict "root" . "scrapeLocalNodeOnly" false) | nindent 6 }}
       {{- end }}{{/* End cadvisor scrape job */}}
 

--- a/helm/templates/agent-daemonset-cm.yaml
+++ b/helm/templates/agent-daemonset-cm.yaml
@@ -32,7 +32,7 @@ data:
       scrape_interval: {{ .Values.prometheusConfig.globalScrapeInterval }}
 
     scrape_configs:
-      {{- if .Values.prometheusConfig.scrapeJobs.cadvisor.enabled }}
+      {{- if include "cloudzero-agent.Values.integrations.cAdvisor.enabled" . }}
       {{- include "cloudzero-agent.prometheus.scrapeCAdvisor" (dict "root" . "scrapeLocalNodeOnly" true) | nindent 6 }}
       {{- end }}{{/* End cadvisor scrape job */}}
 

--- a/helm/tests/cadvisor_direct_node_access_test.yaml
+++ b/helm/tests/cadvisor_direct_node_access_test.yaml
@@ -1,0 +1,452 @@
+suite: test cAdvisor direct node access configuration
+templates:
+  - agent-cm.yaml
+  - agent-clusterrole.yaml
+tests:
+  # ============================================================================
+  # Default behavior tests (API server proxy mode)
+  # ============================================================================
+
+  - it: should use API server proxy by default
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: cloudzero-nodes-cadvisor"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "kubernetes.default.svc.cluster.local:443"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "/api/v1/nodes/\\$1/proxy/metrics/cadvisor"
+
+  - it: should NOT use direct node access when directNodeAccess.enabled is false
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: false
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "kubernetes.default.svc.cluster.local:443"
+      - notMatchRegex:
+          path: data["prometheus.yml"]
+          pattern: "__meta_kubernetes_node_address_InternalIP.*10250"
+
+  # ============================================================================
+  # Direct node access mode tests
+  # ============================================================================
+
+  - it: should use direct kubelet access when directNodeAccess.enabled is true
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: cloudzero-nodes-cadvisor"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "metrics_path: /metrics/cadvisor"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "__meta_kubernetes_node_address_InternalIP"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "replacement: \\$\\{1\\}:10250"
+
+  - it: should NOT use API server proxy when directNodeAccess.enabled is true
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["prometheus.yml"]
+          pattern: "kubernetes.default.svc.cluster.local:443"
+      - notMatchRegex:
+          path: data["prometheus.yml"]
+          pattern: "/api/v1/nodes/\\$1/proxy/metrics/cadvisor"
+
+  # ============================================================================
+  # Custom port configuration tests
+  # ============================================================================
+
+  - it: should use custom kubelet port when specified
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+      integrations.cAdvisor.port: 10255
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "replacement: \\$\\{1\\}:10255"
+      - notMatchRegex:
+          path: data["prometheus.yml"]
+          pattern: "replacement: \\$\\{1\\}:10250"
+
+  - it: should use default port 10250 when not specified
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "replacement: \\$\\{1\\}:10250"
+
+  # ============================================================================
+  # Common configuration tests (both modes)
+  # ============================================================================
+
+  - it: should use bearer token authentication in both modes
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  - it: should use kubernetes node service discovery
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "role: node"
+
+  - it: should apply metric filtering in direct mode
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "metric_relabel_configs"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "action: labelkeep"
+
+  # ============================================================================
+  # Alloy configuration tests
+  # ============================================================================
+
+  - it: should use API server proxy in Alloy config by default
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "kubernetes.default.svc.cluster.local:443"
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "/api/v1/nodes/\\$1/proxy/metrics/cadvisor"
+
+  - it: should use direct kubelet access in Alloy config when directNodeAccess.enabled is true
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'discovery.relabel "cadvisor"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "__meta_kubernetes_node_address_InternalIP"
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "\\$1:10250"
+
+  - it: should NOT use API server proxy in Alloy config when directNodeAccess.enabled is true
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: "kubernetes.default.svc.cluster.local:443"
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: "/api/v1/nodes/\\$1/proxy/metrics/cadvisor"
+
+  - it: should preserve clustering in Alloy config with direct node access
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "clustering \\{"
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "enabled = true"
+
+  - it: should use custom kubelet port in Alloy config when specified
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+      integrations.cAdvisor.port: 10255
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "\\$1:10255"
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: "\\$1:10250"
+
+  # ============================================================================
+  # integrations.cAdvisor.enabled fallback tests
+  # ============================================================================
+
+  - it: should enable cadvisor scraping by default (integrations.cAdvisor.enabled=true)
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      # prometheusConfig.scrapeJobs.cadvisor.enabled is null by default
+      # integrations.cAdvisor.enabled is true by default
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: cloudzero-nodes-cadvisor"
+
+  - it: should disable cadvisor scraping when integrations.cAdvisor.enabled=false
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      integrations.cAdvisor.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: cloudzero-nodes-cadvisor"
+
+  - it: should allow prometheusConfig.scrapeJobs.cadvisor.enabled=true to override integrations.cAdvisor.enabled=false
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      integrations.cAdvisor.enabled: false
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: cloudzero-nodes-cadvisor"
+
+  - it: should allow prometheusConfig.scrapeJobs.cadvisor.enabled=false to override integrations.cAdvisor.enabled=true
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      integrations.cAdvisor.enabled: true
+      prometheusConfig.scrapeJobs.cadvisor.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: cloudzero-nodes-cadvisor"
+
+  - it: should enable cadvisor in Alloy config by default (integrations.cAdvisor.enabled=true)
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      # prometheusConfig.scrapeJobs.cadvisor.enabled is null by default
+      # integrations.cAdvisor.enabled is true by default
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+
+  - it: should disable cadvisor in Alloy config when integrations.cAdvisor.enabled=false
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      integrations.cAdvisor.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+
+  # ============================================================================
+  # TLS insecureSkipVerify tests
+  # ============================================================================
+
+  - it: should use insecure_skip_verify=true by default (Prometheus)
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: cloudzero-nodes-cadvisor"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "insecure_skip_verify: true"
+
+  - it: should use insecure_skip_verify=true by default in direct node access mode (Prometheus)
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "job_name: cloudzero-nodes-cadvisor"
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "insecure_skip_verify: true"
+
+  - it: should allow explicit insecureSkipVerify=false override (Prometheus)
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.tls.insecureSkipVerify: false
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "insecure_skip_verify: false"
+
+  - it: should use insecure_skip_verify=true by default (Alloy)
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "insecure_skip_verify = true"
+
+  - it: should use insecure_skip_verify=true by default in direct node access mode (Alloy)
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "insecure_skip_verify = true"
+
+  - it: should allow explicit insecureSkipVerify=false override (Alloy)
+    template: agent-cm.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.cadvisor.enabled: true
+      integrations.cAdvisor.tls.insecureSkipVerify: false
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "insecure_skip_verify = false"
+
+  # ============================================================================
+  # RBAC tests - nodes/proxy permission
+  # ============================================================================
+
+  - it: should include nodes/proxy permission by default (API server proxy mode)
+    template: agent-clusterrole.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+    asserts:
+      - contains:
+          path: rules[2].resources
+          content: nodes/proxy
+
+  - it: should NOT include nodes/proxy permission when directNodeAccess.enabled is true
+    template: agent-clusterrole.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - notContains:
+          path: rules[2].resources
+          content: nodes/proxy
+
+  - it: should always include nodes/metrics permission regardless of mode
+    template: agent-clusterrole.yaml
+    set:
+      apiKey: "test-key"
+      existingSecretName: null
+      integrations.cAdvisor.directNodeAccess.enabled: true
+    asserts:
+      - contains:
+          path: rules[2].resources
+          content: nodes/metrics

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -6767,6 +6767,42 @@
     "integrations": {
       "additionalProperties": false,
       "properties": {
+        "cAdvisor": {
+          "additionalProperties": false,
+          "properties": {
+            "directNodeAccess": {
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "type": "boolean"
+            },
+            "port": {
+              "default": 10250,
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "tls": {
+              "additionalProperties": false,
+              "properties": {
+                "insecureSkipVerify": {
+                  "default": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
         "istio": {
           "additionalProperties": false,
           "properties": {
@@ -6846,13 +6882,21 @@
               "additionalProperties": false,
               "properties": {
                 "enabled": {
-                  "type": "boolean"
+                  "default": null,
+                  "deprecated": true,
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ]
                 },
                 "scrapeInterval": {
                   "$ref": "#/$defs/com.cloudzero.agent.duration"
                 }
               },
-              "required": ["enabled"],
               "type": "object"
             },
             "gpu": {

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1294,13 +1294,19 @@ properties:
               cadvisor scrape job configuration.
             type: object
             additionalProperties: false
-            required:
-              - enabled
             properties:
               enabled:
                 description: |
-                  Whether to enable the cadvisor scrape job.
-                type: boolean
+                  DEPRECATED: Use integrations.cAdvisor.enabled instead.
+
+                  Whether to enable the cadvisor scrape job. If set to a boolean
+                  value, it takes precedence over integrations.cAdvisor.enabled.
+                  If null (default), falls back to integrations.cAdvisor.enabled.
+                oneOf:
+                  - type: "null"
+                  - type: boolean
+                default: null
+                deprecated: true
               scrapeInterval:
                 description: |
                   Scrape interval for nodesCadvisor job.
@@ -2053,6 +2059,66 @@ properties:
 
                 kubectl -n istio-system get deploy istiod \
                   -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CLUSTER_ID")].value}'
+      cAdvisor:
+        type: object
+        additionalProperties: false
+        description: |
+          cAdvisor container metrics integration settings.
+
+          Controls how cAdvisor metrics are collected from cluster nodes.
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: |
+              Enable cAdvisor metrics collection.
+              Default: true
+          port:
+            type: integer
+            default: 10250
+            minimum: 1
+            maximum: 65535
+            description: |
+              Kubelet port for direct kubelet connections.
+              Used by both federated mode and direct node access mode.
+              The standard default is 10250, but can be changed via --port on kubelet.
+          tls:
+            type: object
+            additionalProperties: false
+            description: |
+              TLS configuration for cAdvisor metrics collection.
+            properties:
+              insecureSkipVerify:
+                type: boolean
+                default: true
+                description: |
+                  Skip TLS certificate verification when scraping cAdvisor metrics.
+
+                  Default: true (required for most clusters where certificates may not
+                  have proper SANs or are self-signed).
+
+                  Set to false only if you have proper TLS certificates configured and
+                  want strict certificate verification.
+          directNodeAccess:
+            type: object
+            additionalProperties: false
+            description: |
+              Direct node access configuration for cAdvisor metrics collection.
+
+              When enabled, the agent connects directly to node kubelets instead of
+              routing through the Kubernetes API server proxy. This removes the need
+              for the dangerous nodes/proxy RBAC permission.
+
+              Requirements:
+              - Network connectivity from collector pod to all nodes on the kubelet port
+              - Will not work with strict NetworkPolicies blocking pod-to-node traffic
+            properties:
+              enabled:
+                type: boolean
+                default: false
+                description: |
+                  Enable direct node access mode.
+                  Default: false (uses API server proxy for maximum compatibility)
 
   kubeStateMetrics:
     type: object

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -242,6 +242,42 @@ integrations:
     #     -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CLUSTER_ID")].value}'
     clusterID: null
 
+  # cAdvisor container metrics integration settings.
+  cAdvisor:
+    # Enable cAdvisor metrics collection.
+    # Default: true
+    enabled: true
+
+    # Kubelet port for direct kubelet connections.
+    # Used by both federated mode and direct node access mode.
+    # The standard default is 10250, but can be changed via --port on kubelet.
+    port: 10250
+
+    # TLS configuration for cAdvisor metrics collection.
+    tls:
+      # Skip TLS certificate verification when scraping cAdvisor metrics.
+      #
+      # Default: true (required for most clusters where certificates may not
+      # have proper SANs or are self-signed).
+      #
+      # Set to false only if you have proper TLS certificates configured and
+      # want strict certificate verification.
+      insecureSkipVerify: true
+
+    # Direct node access configuration for cAdvisor metrics collection.
+    #
+    # When enabled, the agent connects directly to node kubelets instead of
+    # routing through the Kubernetes API server proxy. This removes the
+    # dangerous nodes/proxy RBAC permission from the ClusterRole.
+    #
+    # Requirements:
+    # - Network connectivity from collector pod to all nodes on the kubelet port
+    # - Will not work with strict NetworkPolicies blocking pod-to-node traffic
+    directNodeAccess:
+      # Enable direct node access mode.
+      # Default: false (uses API server proxy for maximum compatibility)
+      enabled: false
+
 # Component-specific configuration settings.
 components:
   # The agent here refers to the CloudZero Agent, which is the component that
@@ -811,9 +847,12 @@ prometheusConfig:
       enabled: true
       # Scrape interval for kubeStateMetrics job
       scrapeInterval: 60s
-    # -- Enables the cadvisor scrape job.
+    # -- DEPRECATED: Use integrations.cAdvisor.enabled instead.
+    # Enables the cadvisor scrape job. If set to a boolean value, it takes
+    # precedence over integrations.cAdvisor.enabled. If null (default), falls
+    # back to integrations.cAdvisor.enabled.
     cadvisor:
-      enabled: true
+      enabled: null
       # Scrape interval for nodesCadvisor job
       scrapeInterval: 60s
     # -- Enables the prometheus scrape job.

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -220,19 +220,48 @@ data:
     discovery.kubernetes "cadvisor" {
       role = "node"
     }
+    // API server proxy mode (default) - route through Kubernetes API server
+    // Requires nodes/proxy RBAC permission
+    discovery.relabel "cadvisor" {
+      targets = discovery.kubernetes.cadvisor.targets
+    
+      // Route through API server
+      rule {
+        target_label = "__address__"
+        replacement  = "kubernetes.default.svc.cluster.local:443"
+      }
+    
+      // Set metrics path to API proxy endpoint
+      rule {
+        source_labels = ["__meta_kubernetes_node_name"]
+        target_label  = "__metrics_path__"
+        replacement   = "/api/v1/nodes/$1/proxy/metrics/cadvisor"
+      }
+    
+      // Map node labels
+      rule {
+        regex  = "__meta_kubernetes_node_label_(.+)"
+        action = "labelmap"
+      }
+    
+      // Map node name
+      rule {
+        source_labels = ["__meta_kubernetes_node_name"]
+        target_label  = "node"
+      }
+    }
     
     prometheus.scrape "cadvisor" {
-      targets    = discovery.kubernetes.cadvisor.targets
+      targets    = discovery.relabel.cadvisor.output
       forward_to = [prometheus.relabel.cadvisor.receiver]
       scrape_interval = "60s"
-      metrics_path = "/metrics/cadvisor"
       scheme = "https"
     
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
       tls_config {
         ca_file              = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-        insecure_skip_verify = false
+        insecure_skip_verify = true
       }
     
       clustering {
@@ -255,12 +284,6 @@ data:
       rule {
         regex  = "^(board_asset_tag|container|created_by_kind|created_by_name|image|instance|name|namespace|node|node_kubernetes_io_instance_type|pod|product_name|provider_id|resource|unit|uid|_.*|label_.*|app.kubernetes.io/*|k8s.*)$"
         action = "labelkeep"
-      }
-    
-      // Map node name for cost allocation
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        target_label  = "node"
       }
     }// CloudZero Webhook Scrape Job
     // Monitors webhook server performance and health
@@ -1168,6 +1191,13 @@ data:
         path: /validate
         timeoutSeconds: 1
     integrations:
+      cAdvisor:
+        directNodeAccess:
+          enabled: false
+        enabled: true
+        port: 10250
+        tls:
+          insecureSkipVerify: true
       istio:
         clusterID: null
         enabled: null
@@ -1434,7 +1464,7 @@ data:
           enabled: true
           scrapeInterval: 120s
         cadvisor:
-          enabled: true
+          enabled: null
           scrapeInterval: 60s
         gpu:
           enabled: false

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -252,8 +252,8 @@ data:
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           insecure_skip_verify: true
-      
-        # Scrape metrics from cAdvisor.
+        # Scrape metrics via API server proxy (default mode).
+        # Requires nodes/proxy RBAC permission.
         relabel_configs:
       
           # Replace the value of __address__ labels with "kubernetes.default.svc.cluster.local:443"
@@ -1129,6 +1129,13 @@ data:
         path: /validate
         timeoutSeconds: 1
     integrations:
+      cAdvisor:
+        directNodeAccess:
+          enabled: false
+        enabled: true
+        port: 10250
+        tls:
+          insecureSkipVerify: true
       istio:
         clusterID: null
         enabled: null
@@ -1395,7 +1402,7 @@ data:
           enabled: true
           scrapeInterval: 120s
         cadvisor:
-          enabled: true
+          enabled: null
           scrapeInterval: 60s
         gpu:
           enabled: false

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -346,7 +346,7 @@ data:
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           insecure_skip_verify: true
-        # Scrape metrics directly from cAdvisor endpoint.
+        # Scrape metrics directly from local node's cAdvisor endpoint (federated mode).
         metrics_path: /metrics/cadvisor
       
         # Scrape metrics from cAdvisor
@@ -1196,6 +1196,13 @@ data:
         path: /validate
         timeoutSeconds: 1
     integrations:
+      cAdvisor:
+        directNodeAccess:
+          enabled: false
+        enabled: true
+        port: 10250
+        tls:
+          insecureSkipVerify: true
       istio:
         clusterID: null
         enabled: null
@@ -1462,7 +1469,7 @@ data:
           enabled: true
           scrapeInterval: 120s
         cadvisor:
-          enabled: true
+          enabled: null
           scrapeInterval: 60s
         gpu:
           enabled: false

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -267,8 +267,8 @@ data:
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           insecure_skip_verify: true
-      
-        # Scrape metrics from cAdvisor.
+        # Scrape metrics via API server proxy (default mode).
+        # Requires nodes/proxy RBAC permission.
         relabel_configs:
       
           # Replace the value of __address__ labels with "kubernetes.default.svc.cluster.local:443"
@@ -1144,6 +1144,13 @@ data:
         path: /validate
         timeoutSeconds: 1
     integrations:
+      cAdvisor:
+        directNodeAccess:
+          enabled: false
+        enabled: true
+        port: 10250
+        tls:
+          insecureSkipVerify: true
       istio:
         clusterID: istio-cluster-id-for-testing
         enabled: true
@@ -1410,7 +1417,7 @@ data:
           enabled: true
           scrapeInterval: 120s
         cadvisor:
-          enabled: true
+          enabled: null
           scrapeInterval: 60s
         gpu:
           enabled: false

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -267,8 +267,8 @@ data:
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           insecure_skip_verify: true
-      
-        # Scrape metrics from cAdvisor.
+        # Scrape metrics via API server proxy (default mode).
+        # Requires nodes/proxy RBAC permission.
         relabel_configs:
       
           # Replace the value of __address__ labels with "kubernetes.default.svc.cluster.local:443"
@@ -1144,6 +1144,13 @@ data:
         path: /validate
         timeoutSeconds: 1
     integrations:
+      cAdvisor:
+        directNodeAccess:
+          enabled: false
+        enabled: true
+        port: 10250
+        tls:
+          insecureSkipVerify: true
       istio:
         clusterID: null
         enabled: null
@@ -1410,7 +1417,7 @@ data:
           enabled: true
           scrapeInterval: 120s
         cadvisor:
-          enabled: true
+          enabled: null
           scrapeInterval: 60s
         gpu:
           enabled: false


### PR DESCRIPTION
This change adds an optional configuration to collect cAdvisor metrics directly from node kubelets instead of through the Kubernetes API server proxy. The primary motivation is security: the API server proxy mode requires the dangerous `nodes/proxy` RBAC permission, which grants cluster-wide RCE capability. Direct node access only requires the safer `nodes/metrics` permission.

The feature is opt-in and defaults to the existing API server proxy behavior to maintain backward compatibility. Direct node access requires network connectivity from collector pods to all nodes on port 10250, which may not be available in all environments (strict NetworkPolicies, private node networks).

Functional Change:

Before: cAdvisor metrics could only be collected via API server proxy (`kubernetes.default.svc:443/api/v1/nodes/{node}/proxy/metrics/cadvisor`), requiring the `nodes/proxy` RBAC permission.

After: Users can optionally enable direct kubelet access (`{node-ip}:10250/metrics/cadvisor`) by setting
`integrations.cAdvisor.directNodeAccess.enabled: true`, which removes the `nodes/proxy` permission from the ClusterRole.

Solution:

1. Added `integrations.cAdvisor` configuration block in values.yaml with:
   - `enabled` (bool, default: true) - primary control for cAdvisor scraping
   - `port` (int, default: 10250) - kubelet port for direct/federated modes
   - `tls.insecureSkipVerify` (bool, default: true) - TLS verification setting
   - `directNodeAccess.enabled` (bool, default: false) - opt-in for direct mode

2. Made `prometheusConfig.scrapeJobs.cadvisor.enabled` nullable with fallback to `integrations.cAdvisor.enabled` via new helper in _helpers.tpl:1458-1472

3. Updated _cm_helpers.tpl to support three cAdvisor scrape modes:
   - Federated mode (scrapeLocalNodeOnly): direct kubelet on local node
   - Direct node access mode: direct kubelet via node discovery
   - API proxy mode (default): via kubernetes API server

4. Updated _alloy_helpers.tpl with equivalent River configuration support for both API proxy and direct node access modes

5. Made `nodes/proxy` RBAC permission conditional in agent-clusterrole.yaml:40-47
   - Included when `directNodeAccess.enabled: false` (default)
   - Excluded when `directNodeAccess.enabled: true`

6. Updated values.schema.yaml with full schema for new configuration options and nullable `prometheusConfig.scrapeJobs.cadvisor.enabled`

Validation:

- Created comprehensive test suite in helm/tests/cadvisor_direct_node_access_test.yaml with 29 tests covering:
  - Default behavior (API server proxy mode)
  - Direct node access mode configuration
  - Custom kubelet port configuration
  - Alloy River configuration for both modes
  - `integrations.cAdvisor.enabled` fallback logic
  - TLS `insecureSkipVerify` default and override behavior
  - RBAC `nodes/proxy` permission conditional inclusion
- All 29 helm-unittest tests pass
- Deployed and verified on GKE cluster in all four configurations:
  - Prometheus mode + API proxy: cAdvisor metrics received (container_cpu, memory, network)
  - Prometheus mode + direct access: cAdvisor metrics received, nodes/proxy removed from ClusterRole
  - Alloy mode + API proxy: cAdvisor metrics received
  - Alloy mode + direct access: cAdvisor metrics received, nodes/proxy removed from ClusterRole
