### PR TITLE
CP-37272: Replace Endpoint SD with EndpointSlice for Prometheus/Alloy

### DIFF
--- a/helm/templates/_alloy_helpers.tpl
+++ b/helm/templates/_alloy_helpers.tpl
@@ -61,9 +61,9 @@ CADVISOR:
                                --> prometheus.remote_write
 
 WEBHOOK:
-  discovery.kubernetes (endpoints) --> prometheus.scrape (HTTPS)
-                                   --> prometheus.relabel (metrics filter)
-                                   --> prometheus.remote_write
+  discovery.kubernetes (endpointslice) --> prometheus.scrape (HTTPS)
+                                       --> prometheus.relabel (metrics filter)
+                                       --> prometheus.remote_write
 
 AGGREGATOR:
   Static target --> prometheus.scrape --> prometheus.relabel (metrics filter)
@@ -493,7 +493,7 @@ cost metrics.
 Pipeline flow:
   +---------------------+     +---------------------+     +---------------------+
   | discovery.kubernetes| --> | prometheus.scrape   | --> | prometheus.relabel  |
-  | (endpoints)         |     | (HTTPS, skip verify)|     | (filter metrics)    |
+  | (endpointslice)     |     | (HTTPS, skip verify)|     | (filter metrics)    |
   +---------------------+     +---------------------+     +---------------------+
                                                                    |
                                                                    v
@@ -511,18 +511,18 @@ Usage: {{ include "cloudzero-agent.alloy.scrapeWebhook" . }}
 // Purpose: Monitor CloudZero webhook server health (observability metrics)
 //
 // Data flow:
-//   discover endpoints -> scrape (HTTPS) -> filter metrics -> remote_write
+//   discover endpointslice -> scrape (HTTPS) -> filter metrics -> remote_write
 //
 // Note: Uses HTTPS with insecure_skip_verify because the webhook server
 // uses a self-signed certificate generated at deployment time.
 // ============================================================================
 
-// STEP 1: Discover webhook service endpoints
+// STEP 1: Discover webhook service via EndpointSlice
 discovery.kubernetes "webhook" {
-  role = "endpoints"
+  role = "endpointslice"
 
   selectors {
-    role  = "endpoints"
+    role  = "endpointslice"
     field = "metadata.name={{ include "cloudzero-agent.insightsController.server.webhookFullname" . }}"
   }
 }

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -599,7 +599,7 @@ visibility. These are observability metrics, not cost metrics.
 
 Data flow:
   kubernetes_sd    -->   relabel_configs     -->   SCRAPE
-  (endpoints)           (filter to webhook)       (HTTPS)
+  (endpointslice)       (filter to webhook)       (HTTPS)
                                                        |
                                                        v
                                              metric_relabel_configs
@@ -636,14 +636,14 @@ Usage: {{ include "cloudzero-agent.prometheus.scrapeWebhookJob" . }}
   tls_config:
     insecure_skip_verify: true
 
-  # Discover webhook service endpoints
+  # Discover webhook service via EndpointSlice
   kubernetes_sd_configs:
-    - role: endpoints
+    - role: endpointslice
       kubeconfig_file: ""
 
   # Filter to only the webhook service
   relabel_configs:
-    - source_labels: [__meta_kubernetes_endpoints_name]
+    - source_labels: [__meta_kubernetes_endpointslice_name]
       action: keep
       regex: {{ include "cloudzero-agent.insightsController.server.webhookFullname" . }}
 
@@ -667,7 +667,7 @@ observability metrics that help track the health of the data pipeline.
 
 Data flow:
   kubernetes_sd    -->   relabel_configs     -->   SCRAPE
-  (endpoints)           (filter to agg ports)     (HTTP)
+  (endpointslice)       (filter to agg ports)     (HTTP)
                                                        |
                                                        v
                                              metric_relabel_configs
@@ -696,9 +696,9 @@ Usage: {{ include "cloudzero-agent.prometheus.scrapeAggregator" . }}
 - job_name: cloudzero-aggregator-job
   scrape_interval: {{ .Values.prometheusConfig.scrapeJobs.prometheus.scrapeInterval }}
 
-  # Discover aggregator endpoints in this namespace
+  # Discover aggregator via EndpointSlice in this namespace
   kubernetes_sd_configs:
-    - role: endpoints
+    - role: endpointslice
       kubeconfig_file: ""
       namespaces:
         names:

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -359,18 +359,18 @@ data:
     // Purpose: Monitor CloudZero webhook server health (observability metrics)
     //
     // Data flow:
-    //   discover endpoints -> scrape (HTTPS) -> filter metrics -> remote_write
+    //   discover endpointslice -> scrape (HTTPS) -> filter metrics -> remote_write
     //
     // Note: Uses HTTPS with insecure_skip_verify because the webhook server
     // uses a self-signed certificate generated at deployment time.
     // ============================================================================
     
-    // STEP 1: Discover webhook service endpoints
+    // STEP 1: Discover webhook service via EndpointSlice
     discovery.kubernetes "webhook" {
-      role = "endpoints"
+      role = "endpointslice"
     
       selectors {
-        role  = "endpoints"
+        role  = "endpointslice"
         field = "metadata.name=cz-agent-cz-webhook"
       }
     }

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -353,14 +353,14 @@ data:
         tls_config:
           insecure_skip_verify: true
       
-        # Discover webhook service endpoints
+        # Discover webhook service via EndpointSlice
         kubernetes_sd_configs:
-          - role: endpoints
+          - role: endpointslice
             kubeconfig_file: ""
       
         # Filter to only the webhook service
         relabel_configs:
-          - source_labels: [__meta_kubernetes_endpoints_name]
+          - source_labels: [__meta_kubernetes_endpointslice_name]
             action: keep
             regex: cz-agent-cz-webhook
       
@@ -383,9 +383,9 @@ data:
       - job_name: cloudzero-aggregator-job
         scrape_interval: 120s
       
-        # Discover aggregator endpoints in this namespace
+        # Discover aggregator via EndpointSlice in this namespace
         kubernetes_sd_configs:
-          - role: endpoints
+          - role: endpointslice
             kubeconfig_file: ""
             namespaces:
               names:

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -282,14 +282,14 @@ data:
         tls_config:
           insecure_skip_verify: true
       
-        # Discover webhook service endpoints
+        # Discover webhook service via EndpointSlice
         kubernetes_sd_configs:
-          - role: endpoints
+          - role: endpointslice
             kubeconfig_file: ""
       
         # Filter to only the webhook service
         relabel_configs:
-          - source_labels: [__meta_kubernetes_endpoints_name]
+          - source_labels: [__meta_kubernetes_endpointslice_name]
             action: keep
             regex: cz-agent-cz-webhook
       
@@ -312,9 +312,9 @@ data:
       - job_name: cloudzero-aggregator-job
         scrape_interval: 120s
       
-        # Discover aggregator endpoints in this namespace
+        # Discover aggregator via EndpointSlice in this namespace
         kubernetes_sd_configs:
-          - role: endpoints
+          - role: endpointslice
             kubeconfig_file: ""
             namespaces:
               names:

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -368,14 +368,14 @@ data:
         tls_config:
           insecure_skip_verify: true
       
-        # Discover webhook service endpoints
+        # Discover webhook service via EndpointSlice
         kubernetes_sd_configs:
-          - role: endpoints
+          - role: endpointslice
             kubeconfig_file: ""
       
         # Filter to only the webhook service
         relabel_configs:
-          - source_labels: [__meta_kubernetes_endpoints_name]
+          - source_labels: [__meta_kubernetes_endpointslice_name]
             action: keep
             regex: cz-agent-cz-webhook
       
@@ -398,9 +398,9 @@ data:
       - job_name: cloudzero-aggregator-job
         scrape_interval: 120s
       
-        # Discover aggregator endpoints in this namespace
+        # Discover aggregator via EndpointSlice in this namespace
         kubernetes_sd_configs:
-          - role: endpoints
+          - role: endpointslice
             kubeconfig_file: ""
             namespaces:
               names:

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -368,14 +368,14 @@ data:
         tls_config:
           insecure_skip_verify: true
       
-        # Discover webhook service endpoints
+        # Discover webhook service via EndpointSlice
         kubernetes_sd_configs:
-          - role: endpoints
+          - role: endpointslice
             kubeconfig_file: ""
       
         # Filter to only the webhook service
         relabel_configs:
-          - source_labels: [__meta_kubernetes_endpoints_name]
+          - source_labels: [__meta_kubernetes_endpointslice_name]
             action: keep
             regex: cz-agent-cz-webhook
       
@@ -398,9 +398,9 @@ data:
       - job_name: cloudzero-aggregator-job
         scrape_interval: 120s
       
-        # Discover aggregator endpoints in this namespace
+        # Discover aggregator via EndpointSlice in this namespace
         kubernetes_sd_configs:
-          - role: endpoints
+          - role: endpointslice
             kubeconfig_file: ""
             namespaces:
               names:


### PR DESCRIPTION
The Kubernetes Endpoints API is deprecated starting in Kubernetes v1.33 (announced April 2025). EndpointSlice has been the recommended replacement since Kubernetes 1.21, providing better scalability and support for dual-stack networking.

The CloudZero Agent uses Prometheus/Alloy kubernetes_sd_configs with `role: endpoints` for service discovery of internal components (webhook and aggregator). This change migrates to `role: endpointslice` to ensure compatibility with future Kubernetes versions and eliminate deprecation warnings.

Functional Change:

Before: Prometheus and Alloy service discovery used `role: endpoints`, which will trigger deprecation warnings in Kubernetes 1.33+ and eventually stop working.

After: Service discovery uses `role: endpointslice`, ensuring forward compatibility with all supported Kubernetes versions (1.21+).

Solution:

1. Updated Prometheus webhook scrape job in _cm_helpers.tpl:
   - Changed `role: endpoints` to `role: endpointslice`
   - Changed `__meta_kubernetes_endpoints_name` to `__meta_kubernetes_endpointslice_name`

2. Updated Prometheus aggregator scrape job in _cm_helpers.tpl:
   - Changed `role: endpoints` to `role: endpointslice`
   - No label changes needed (uses `__meta_kubernetes_service_name` which is available with both roles)

3. Updated Alloy webhook discovery in _alloy_helpers.tpl:
   - Changed `role = "endpoints"` to `role = "endpointslice"` in discovery.kubernetes
   - Changed selector `role = "endpoints"` to `role = "endpointslice"`

4. Updated documentation diagrams and comments in both files to reflect the new endpointslice terminology.

Validation:

- Helm linting passed (`make helm-lint`)
- All 481 Helm unit tests passed (`make helm-test`)
- Deployed to cluster in Alloy (clustered) mode:
  - EndpointSlice discovery working correctly
  - No deprecation warnings in logs
  - All expected metrics collected (container_cpu, container_memory, kube_pod_info, cloudzero_pod_labels, observability metrics)
- Deployed to cluster in Prometheus (server) mode:
  - ConfigMap shows correct `role: endpointslice` configuration
  - Metrics flowing correctly through the pipeline
