### PR TITLE
CP-37827: bump Go version to 1.25.7

### DIFF
--- a/.tools/go.mod
+++ b/.tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudzero/cloudzero-agent/.tools
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/homeport/dyff v1.10.3

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG DEPLOY_IMAGE=scratch
 # 5. final: Minimal runtime image with compiled binaries
 
 # Stage 1: Base tools installation
-FROM --platform=$BUILDPLATFORM golang:1.25.6-alpine AS base-tools
+FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine AS base-tools
 ARG TARGETPLATFORM
 ARG TARGETOS TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudzero/cloudzero-agent
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/tests/docker/Dockerfile.collector
+++ b/tests/docker/Dockerfile.collector
@@ -1,4 +1,4 @@
-FROM golang:1.25.6 AS builder
+FROM golang:1.25.7 AS builder
 
 WORKDIR /app
 

--- a/tests/docker/Dockerfile.controller
+++ b/tests/docker/Dockerfile.controller
@@ -1,4 +1,4 @@
-FROM golang:1.25.6 AS builder
+FROM golang:1.25.7 AS builder
 
 WORKDIR /app
 

--- a/tests/docker/Dockerfile.remotewrite
+++ b/tests/docker/Dockerfile.remotewrite
@@ -1,4 +1,4 @@
-FROM golang:1.25.6 AS builder
+FROM golang:1.25.7 AS builder
 
 WORKDIR /app
 

--- a/tests/docker/Dockerfile.shipper
+++ b/tests/docker/Dockerfile.shipper
@@ -1,4 +1,4 @@
-FROM golang:1.25.6 AS builder
+FROM golang:1.25.7 AS builder
 
 # Copy source code
 COPY go.mod go.sum ./

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudzero/cloudzero-agent/tests
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/andybalholm/brotli v1.2.0

--- a/tests/integration/test_server/Dockerfile
+++ b/tests/integration/test_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6
+FROM golang:1.25.7
 
 WORKDIR /app
 

--- a/tests/integration/test_server/go.mod
+++ b/tests/integration/test_server/go.mod
@@ -1,3 +1,3 @@
 module main
 
-go 1.25.6
+go 1.25.7


### PR DESCRIPTION
# Why?

Grype is, well, griping about CVE-2025-68121 and CVE-2025-61732 in Go 1.25.6.

# What

Upgrade to 1.25.7

# How Tested

YOLO
