### PR TITLE
CP-37829: update copyright year to 2026

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -38,7 +38,7 @@ linters:
       check-type-assertions: true
     goheader:
       template: |-
-        SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+        SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
         SPDX-License-Identifier: Apache-2.0
     govet:
       enable:

--- a/.tools/tools.go
+++ b/.tools/tools.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build tools

--- a/app/build/build.go
+++ b/app/build/build.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package build contains build information for the application.

--- a/app/build/version.go
+++ b/app/build/version.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package build

--- a/app/build/version_test.go
+++ b/app/build/version_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package build_test

--- a/app/compress/compress.go
+++ b/app/compress/compress.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package compress provides functionality to compress a file into a tar.gz archive.

--- a/app/compress/compress_test.go
+++ b/app/compress/compress_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package compress_test

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package config contains code for all configs to share

--- a/app/config/gator/settings.go
+++ b/app/config/gator/settings.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package config implements the configuration for the aggregator..

--- a/app/config/gator/settings_test.go
+++ b/app/config/gator/settings_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/validator/cloudzero.go
+++ b/app/config/validator/cloudzero.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/validator/cloudzero_test.go
+++ b/app/config/validator/cloudzero_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/validator/context.go
+++ b/app/config/validator/context.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/validator/context_test.go
+++ b/app/config/validator/context_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/validator/deployment.go
+++ b/app/config/validator/deployment.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/validator/deployment_test.go
+++ b/app/config/validator/deployment_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/validator/diagnostics.go
+++ b/app/config/validator/diagnostics.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/validator/diagnostics_test.go
+++ b/app/config/validator/diagnostics_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/validator/error.go
+++ b/app/config/validator/error.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/validator/flags.go
+++ b/app/config/validator/flags.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/validator/logging.go
+++ b/app/config/validator/logging.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/validator/logging_test.go
+++ b/app/config/validator/logging_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/validator/prometheus.go
+++ b/app/config/validator/prometheus.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/validator/prometheus_test.go
+++ b/app/config/validator/prometheus_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/validator/settings.go
+++ b/app/config/validator/settings.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package config contains configuration settings.

--- a/app/config/validator/settings_test.go
+++ b/app/config/validator/settings_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/validator/versions.go
+++ b/app/config/validator/versions.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/validator/versions_test.go
+++ b/app/config/validator/versions_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/webhook/accessor.go
+++ b/app/config/webhook/accessor.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/annotations.go
+++ b/app/config/webhook/annotations.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/certificate.go
+++ b/app/config/webhook/certificate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/config_test.go
+++ b/app/config/webhook/config_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/config/webhook/const.go
+++ b/app/config/webhook/const.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/database.go
+++ b/app/config/webhook/database.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/filters.go
+++ b/app/config/webhook/filters.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/k8s_client.go
+++ b/app/config/webhook/k8s_client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/labels.go
+++ b/app/config/webhook/labels.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/logging.go
+++ b/app/config/webhook/logging.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/resources.go
+++ b/app/config/webhook/resources.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/server.go
+++ b/app/config/webhook/server.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/config/webhook/settings.go
+++ b/app/config/webhook/settings.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package config contains the configuration for the application.

--- a/app/config/webhook/settings_test.go
+++ b/app/config/webhook/settings_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config

--- a/app/domain/certificate/certificate.go
+++ b/app/domain/certificate/certificate.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package certificate provides certificate generation and management functionality

--- a/app/domain/certificate/kubernetes_client.go
+++ b/app/domain/certificate/kubernetes_client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package certificate provides certificate generation and management functionality

--- a/app/domain/diagnostic/catalog/catalog.go
+++ b/app/domain/diagnostic/catalog/catalog.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package catalog contains the registry of diagnostics.

--- a/app/domain/diagnostic/catalog/catalog_test.go
+++ b/app/domain/diagnostic/catalog/catalog_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package catalog_test

--- a/app/domain/diagnostic/cz/check.go
+++ b/app/domain/diagnostic/cz/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package cz contains code for checking a CloudZero API token.

--- a/app/domain/diagnostic/diagnostics.go
+++ b/app/domain/diagnostic/diagnostics.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package diagnostic contains an interface to be implemented by diagnostics providers.

--- a/app/domain/diagnostic/istio/istio.go
+++ b/app/domain/diagnostic/istio/istio.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package istio provides diagnostics for detecting Istio service mesh configuration,

--- a/app/domain/diagnostic/istio/istio_test.go
+++ b/app/domain/diagnostic/istio/istio_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package istio

--- a/app/domain/diagnostic/k8s/namespace/check.go
+++ b/app/domain/diagnostic/k8s/namespace/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package namespace contains code for checking the Kubernetes configuration.

--- a/app/domain/diagnostic/k8s/namespace/check_test.go
+++ b/app/domain/diagnostic/k8s/namespace/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package namespace_test

--- a/app/domain/diagnostic/k8s/provider/check.go
+++ b/app/domain/diagnostic/k8s/provider/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package provider contains code for checking the Kubernetes configuration.

--- a/app/domain/diagnostic/k8s/provider/check_test.go
+++ b/app/domain/diagnostic/k8s/provider/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package provider_test

--- a/app/domain/diagnostic/k8s/version/check.go
+++ b/app/domain/diagnostic/k8s/version/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package version contains code for checking the Kubernetes configuration.

--- a/app/domain/diagnostic/kms/check.go
+++ b/app/domain/diagnostic/kms/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package kms contains code for testing access the Kubernetes Management Service.

--- a/app/domain/diagnostic/prom/config/check.go
+++ b/app/domain/diagnostic/prom/config/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package config contains a diagnostic provider for checking the Prometheus configuration.

--- a/app/domain/diagnostic/prom/config/check_test.go
+++ b/app/domain/diagnostic/prom/config/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/domain/diagnostic/prom/version/check.go
+++ b/app/domain/diagnostic/prom/version/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package version contains a diagnostic provider for checking the Prometheus version.

--- a/app/domain/diagnostic/prom/version/check_test.go
+++ b/app/domain/diagnostic/prom/version/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package version_test

--- a/app/domain/diagnostic/runner/runner.go
+++ b/app/domain/diagnostic/runner/runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package runner contains tools for running diagnostics.

--- a/app/domain/diagnostic/runner/runner_test.go
+++ b/app/domain/diagnostic/runner/runner_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package runner

--- a/app/domain/diagnostic/stage/check_test.go
+++ b/app/domain/diagnostic/stage/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package stage_test

--- a/app/domain/diagnostic/stage/stage.go
+++ b/app/domain/diagnostic/stage/stage.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package stage contains a diagnostic provider for checking the stage.

--- a/app/domain/diagnostic/webhook/check.go
+++ b/app/domain/diagnostic/webhook/check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package webhook contains code for checking a CloudZero API token.

--- a/app/domain/diagnostic/webhook/check_test.go
+++ b/app/domain/diagnostic/webhook/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package webhook_test
 

--- a/app/domain/file_monitor.go
+++ b/app/domain/file_monitor.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package domain

--- a/app/domain/file_monitor_test.go
+++ b/app/domain/file_monitor_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package domain_test

--- a/app/domain/filter/filter_checker.go
+++ b/app/domain/filter/filter_checker.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package filter provides high-performance metric filtering utilities for CloudZero Agent cost allocation.

--- a/app/domain/filter/filter_checker_test.go
+++ b/app/domain/filter/filter_checker_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package filter_test

--- a/app/domain/healthz/health.go
+++ b/app/domain/healthz/health.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package healthz provides a simple and extensible health check mechanism for HTTP services.

--- a/app/domain/healthz/health_test.go
+++ b/app/domain/healthz/health_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package healthz_test

--- a/app/domain/housekeeper/housekeeper.go
+++ b/app/domain/housekeeper/housekeeper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package housekeeper provides a mechanism for cleaning up stale data in a resource store.

--- a/app/domain/housekeeper/housekeeper_test.go
+++ b/app/domain/housekeeper/housekeeper_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package housekeeper_test

--- a/app/domain/k8s/certificate_client.go
+++ b/app/domain/k8s/certificate_client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package k8s

--- a/app/domain/k8s/certificate_test.go
+++ b/app/domain/k8s/certificate_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package k8s_test

--- a/app/domain/k8s/namespace.go
+++ b/app/domain/k8s/namespace.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package k8s gives a unified interface for k8s information to be retrieved.

--- a/app/domain/k8s/pod_name.go
+++ b/app/domain/k8s/pod_name.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package k8s

--- a/app/domain/k8s/provider_id.go
+++ b/app/domain/k8s/provider_id.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package k8s

--- a/app/domain/k8s/utils.go
+++ b/app/domain/k8s/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package k8s

--- a/app/domain/k8s/utils_test.go
+++ b/app/domain/k8s/utils_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package k8s

--- a/app/domain/k8s/version.go
+++ b/app/domain/k8s/version.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package k8s

--- a/app/domain/metric_collector.go
+++ b/app/domain/metric_collector.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package domain contains the Application Core business logic for the CloudZero Agent.

--- a/app/domain/metric_collector_test.go
+++ b/app/domain/metric_collector_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package domain_test

--- a/app/domain/metric_filter.go
+++ b/app/domain/metric_filter.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package domain

--- a/app/domain/metricio/converter.go
+++ b/app/domain/metricio/converter.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/converter_test.go
+++ b/app/domain/metricio/converter_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/csv_reader.go
+++ b/app/domain/metricio/csv_reader.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/csv_reader_test.go
+++ b/app/domain/metricio/csv_reader_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/csv_writer.go
+++ b/app/domain/metricio/csv_writer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/csv_writer_test.go
+++ b/app/domain/metricio/csv_writer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/json_reader.go
+++ b/app/domain/metricio/json_reader.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/json_reader_test.go
+++ b/app/domain/metricio/json_reader_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/json_writer.go
+++ b/app/domain/metricio/json_writer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/json_writer_test.go
+++ b/app/domain/metricio/json_writer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/parquet_writer.go
+++ b/app/domain/metricio/parquet_writer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/parquet_writer_test.go
+++ b/app/domain/metricio/parquet_writer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/reader.go
+++ b/app/domain/metricio/reader.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package metricio provides readers and writers for metric data in various formats

--- a/app/domain/metricio/reader_test.go
+++ b/app/domain/metricio/reader_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/writer.go
+++ b/app/domain/metricio/writer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/metricio/writer_test.go
+++ b/app/domain/metricio/writer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metricio

--- a/app/domain/monitor/secret_monitor.go
+++ b/app/domain/monitor/secret_monitor.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package monitor provides secure dynamic secret management and certificate monitoring for CloudZero Agent operations.

--- a/app/domain/monitor/secret_monitor_test.go
+++ b/app/domain/monitor/secret_monitor_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package monitor_test

--- a/app/domain/monitor/tls_monitor.go
+++ b/app/domain/monitor/tls_monitor.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package monitor provides functionality to manage and reload TLS certificates dynamically.

--- a/app/domain/monitor/tls_monitor_test.go
+++ b/app/domain/monitor/tls_monitor_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package monitor

--- a/app/domain/pusher/pusher.go
+++ b/app/domain/pusher/pusher.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package pusher provides a mechanism for pushing metrics to a remote write endpoint.

--- a/app/domain/pusher/pusher_test.go
+++ b/app/domain/pusher/pusher_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package pusher_test

--- a/app/domain/shipper/abandon.go
+++ b/app/domain/shipper/abandon.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper

--- a/app/domain/shipper/allocate_url.go
+++ b/app/domain/shipper/allocate_url.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper

--- a/app/domain/shipper/disk.go
+++ b/app/domain/shipper/disk.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper

--- a/app/domain/shipper/disk_test.go
+++ b/app/domain/shipper/disk_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper_test

--- a/app/domain/shipper/errors.go
+++ b/app/domain/shipper/errors.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper

--- a/app/domain/shipper/http.go
+++ b/app/domain/shipper/http.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper

--- a/app/domain/shipper/metrics.go
+++ b/app/domain/shipper/metrics.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper

--- a/app/domain/shipper/metrics_test.go
+++ b/app/domain/shipper/metrics_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper

--- a/app/domain/shipper/shipper.go
+++ b/app/domain/shipper/shipper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package shipper provides metric upload and transmission services for the CloudZero Agent.

--- a/app/domain/shipper/shipper_integration_test.go
+++ b/app/domain/shipper/shipper_integration_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper_test

--- a/app/domain/shipper/shipper_test.go
+++ b/app/domain/shipper/shipper_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper_test

--- a/app/domain/shipper/upload.go
+++ b/app/domain/shipper/upload.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper

--- a/app/domain/shipper/utils.go
+++ b/app/domain/shipper/utils.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package shipper provides domain logic for the shipper.

--- a/app/domain/shipper/utils_test.go
+++ b/app/domain/shipper/utils_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper_test

--- a/app/domain/shipper/vars.go
+++ b/app/domain/shipper/vars.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package shipper

--- a/app/domain/transform/catalog/catalog.go
+++ b/app/domain/transform/catalog/catalog.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package catalog provides a catalog-based metric transformer that routes

--- a/app/domain/transform/dcgm/transformer.go
+++ b/app/domain/transform/dcgm/transformer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package dcgm provides NVIDIA DCGM metric transformation for cost allocation.

--- a/app/domain/transform/dcgm/transformer_test.go
+++ b/app/domain/transform/dcgm/transformer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package dcgm

--- a/app/domain/transform/transform.go
+++ b/app/domain/transform/transform.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package transform provides metric transformation capabilities for

--- a/app/domain/webhook/backfiller/backfill_test.go
+++ b/app/domain/webhook/backfiller/backfill_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc. or its affiliates.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package backfiller_test

--- a/app/domain/webhook/backfiller/backfiller.go
+++ b/app/domain/webhook/backfiller/backfiller.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package backfiller provides functionality to backfill Kubernetes Resource objects, and if enabled invokes the webhook domain logic

--- a/app/domain/webhook/handler/configmap.go
+++ b/app/domain/webhook/handler/configmap.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package handler admission webhook handlers (hook.Handler) for various resource types.

--- a/app/domain/webhook/handler/cron.go
+++ b/app/domain/webhook/handler/cron.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/cron_test.go
+++ b/app/domain/webhook/handler/cron_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/customresourcedefinition.go
+++ b/app/domain/webhook/handler/customresourcedefinition.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/customresourcedefinition_test.go
+++ b/app/domain/webhook/handler/customresourcedefinition_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/daemonset.go
+++ b/app/domain/webhook/handler/daemonset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/daemonset_test.go
+++ b/app/domain/webhook/handler/daemonset_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/deployment.go
+++ b/app/domain/webhook/handler/deployment.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/deployment_test.go
+++ b/app/domain/webhook/handler/deployment_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/gateway.go
+++ b/app/domain/webhook/handler/gateway.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/gateway_test.go
+++ b/app/domain/webhook/handler/gateway_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/gatewayclass.go
+++ b/app/domain/webhook/handler/gatewayclass.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/gatewayclass_test.go
+++ b/app/domain/webhook/handler/gatewayclass_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/generic.go
+++ b/app/domain/webhook/handler/generic.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/generic_handler.go
+++ b/app/domain/webhook/handler/generic_handler.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // There is currently substantial duplication in the handlers :(

--- a/app/domain/webhook/handler/ingress.go
+++ b/app/domain/webhook/handler/ingress.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/ingress_test.go
+++ b/app/domain/webhook/handler/ingress_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/ingressclass.go
+++ b/app/domain/webhook/handler/ingressclass.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/ingressclass_test.go
+++ b/app/domain/webhook/handler/ingressclass_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/job.go
+++ b/app/domain/webhook/handler/job.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/job_test.go
+++ b/app/domain/webhook/handler/job_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/namespace.go
+++ b/app/domain/webhook/handler/namespace.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/namespace_test.go
+++ b/app/domain/webhook/handler/namespace_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/node.go
+++ b/app/domain/webhook/handler/node.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/node_test.go
+++ b/app/domain/webhook/handler/node_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/pod.go
+++ b/app/domain/webhook/handler/pod.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/pod_test.go
+++ b/app/domain/webhook/handler/pod_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/pv.go
+++ b/app/domain/webhook/handler/pv.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/pv_test.go
+++ b/app/domain/webhook/handler/pv_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/pvc.go
+++ b/app/domain/webhook/handler/pvc.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/pvc_test.go
+++ b/app/domain/webhook/handler/pvc_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/quota.go
+++ b/app/domain/webhook/handler/quota.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/replicaset.go
+++ b/app/domain/webhook/handler/replicaset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/replicaset_test.go
+++ b/app/domain/webhook/handler/replicaset_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/role.go
+++ b/app/domain/webhook/handler/role.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/secret.go
+++ b/app/domain/webhook/handler/secret.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/service.go
+++ b/app/domain/webhook/handler/service.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/service_test.go
+++ b/app/domain/webhook/handler/service_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/serviceacct.go
+++ b/app/domain/webhook/handler/serviceacct.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/statefulset.go
+++ b/app/domain/webhook/handler/statefulset.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //nolint:dupl // Duplication is acceptable we expect to extend the definitions later

--- a/app/domain/webhook/handler/statefulset_test.go
+++ b/app/domain/webhook/handler/statefulset_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/handler/storageclass.go
+++ b/app/domain/webhook/handler/storageclass.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler

--- a/app/domain/webhook/handler/storageclass_test.go
+++ b/app/domain/webhook/handler/storageclass_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handler_test

--- a/app/domain/webhook/helper/helper.go
+++ b/app/domain/webhook/helper/helper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package helper contains decode helper methods for transforming kubernetes metav1.Objects into K8sObjects

--- a/app/domain/webhook/helper/helpers_test.go
+++ b/app/domain/webhook/helper/helpers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package helper_test contains tests

--- a/app/domain/webhook/helper/schema.go
+++ b/app/domain/webhook/helper/schema.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package helper

--- a/app/domain/webhook/helper/schema_test.go
+++ b/app/domain/webhook/helper/schema_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package helper_test

--- a/app/domain/webhook/hook/hook.go
+++ b/app/domain/webhook/hook/hook.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package hook contains structures and interfaces for implementing admission webhooks handlers.

--- a/app/domain/webhook/hook/hook_test.go
+++ b/app/domain/webhook/hook/hook_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package hook_test

--- a/app/domain/webhook/webhook.go
+++ b/app/domain/webhook/webhook.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package webhook provides Kubernetes admission webhook business logic for CloudZero Agent cost allocation.

--- a/app/domain/webhook/webhook_test.go
+++ b/app/domain/webhook/webhook_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2024, CloudZero, Inc.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package webhook_test
 

--- a/app/functions/agent-inspector/cmd.go
+++ b/app/functions/agent-inspector/cmd.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/agent-inspector/main.go
+++ b/app/functions/agent-inspector/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/agent-validator/config/command.go
+++ b/app/functions/agent-validator/config/command.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package config contains a CLI for managing configuration files.

--- a/app/functions/agent-validator/config/command_test.go
+++ b/app/functions/agent-validator/config/command_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test

--- a/app/functions/agent-validator/diagnose/command.go
+++ b/app/functions/agent-validator/diagnose/command.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package diagnose contains a CLI for running diagnostics.

--- a/app/functions/agent-validator/install/command.go
+++ b/app/functions/agent-validator/install/command.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package install contains a CLI for copying the executable to a destination.

--- a/app/functions/agent-validator/main.go
+++ b/app/functions/agent-validator/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/certifik8s/main.go
+++ b/app/functions/certifik8s/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/cluster-config/loader/command.go
+++ b/app/functions/cluster-config/loader/command.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package loader provides code to load all the different config types

--- a/app/functions/cluster-config/main.go
+++ b/app/functions/cluster-config/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/collector/main.go
+++ b/app/functions/collector/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/collector/main_test.go
+++ b/app/functions/collector/main_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/helmless/integration_test.go
+++ b/app/functions/helmless/integration_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/helmless/overrides/extractor.go
+++ b/app/functions/helmless/overrides/extractor.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package overrides provides functionality for extracting configuration overrides

--- a/app/functions/helmless/overrides/extractor_test.go
+++ b/app/functions/helmless/overrides/extractor_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package overrides

--- a/app/functions/helmless/root.go
+++ b/app/functions/helmless/root.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package main implements a tool for comparing configured values against

--- a/app/functions/regurgitator/main.go
+++ b/app/functions/regurgitator/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package main provides the regurgitator CLI tool for transcoding metrics between formats.

--- a/app/functions/scout/scout.go
+++ b/app/functions/scout/scout.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/shipper/main.go
+++ b/app/functions/shipper/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/shipper/main_test.go
+++ b/app/functions/shipper/main_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/functions/webhook/main.go
+++ b/app/functions/webhook/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/app/handlers/profiling.go
+++ b/app/handlers/profiling.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package handlers provides HTTP request handlers for CloudZero Agent Primary Adapter implementations.

--- a/app/handlers/prom_metrics.go
+++ b/app/handlers/prom_metrics.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package handlers provides HTTP request handlers for CloudZero Agent Primary Adapter implementations.

--- a/app/handlers/remote_write.go
+++ b/app/handlers/remote_write.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package handlers provides HTTP request handlers for CloudZero Agent Primary Adapter implementations.

--- a/app/handlers/remote_write_test.go
+++ b/app/handlers/remote_write_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package handlers_test

--- a/app/handlers/shipper.go
+++ b/app/handlers/shipper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package handlers provides HTTP request handlers for CloudZero Agent Primary Adapter implementations.

--- a/app/handlers/webhook.go
+++ b/app/handlers/webhook.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package handlers provides HTTP request handlers for CloudZero Agent Primary Adapter implementations.

--- a/app/handlers/webhook_test.go
+++ b/app/handlers/webhook_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package handlers_test implements unit tests for handlers

--- a/app/http/client/error.go
+++ b/app/http/client/error.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package http provides HTTP client utilities for CloudZero Agent external API integrations.

--- a/app/http/client/error_test.go
+++ b/app/http/client/error_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package http_test
 

--- a/app/http/client/header.go
+++ b/app/http/client/header.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package http provides HTTP client utilities for CloudZero Agent external API integrations.

--- a/app/http/client/http.go
+++ b/app/http/client/http.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package http provides HTTP client utilities for CloudZero Agent external API integrations.

--- a/app/http/client/query.go
+++ b/app/http/client/query.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package http

--- a/app/http/middleware/middleware.go
+++ b/app/http/middleware/middleware.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package middleware provides standard app middlware implementations

--- a/app/http/middleware/middleware_test.go
+++ b/app/http/middleware/middleware_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package middleware_test

--- a/app/inspector/common_headers.go
+++ b/app/inspector/common_headers.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package inspector

--- a/app/inspector/common_headers_test.go
+++ b/app/inspector/common_headers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package inspector

--- a/app/inspector/inspector.go
+++ b/app/inspector/inspector.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package inspector provides a way to inspect HTTP responses from the CloudZero

--- a/app/inspector/inspector_test.go
+++ b/app/inspector/inspector_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package inspector_test

--- a/app/inspector/query.go
+++ b/app/inspector/query.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package inspector

--- a/app/inspector/query_test.go
+++ b/app/inspector/query_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package inspector

--- a/app/inspector/response.go
+++ b/app/inspector/response.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package inspector

--- a/app/inspector/response_test.go
+++ b/app/inspector/response_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package inspector

--- a/app/inspector/status_code_inspectors.go
+++ b/app/inspector/status_code_inspectors.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package inspector

--- a/app/logging/filtered_writer.go
+++ b/app/logging/filtered_writer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package logging provides structured logging infrastructure for CloudZero Agent operations.

--- a/app/logging/instr/context.go
+++ b/app/logging/instr/context.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package instr provides instrumentation utilities.

--- a/app/logging/instr/metrics.go
+++ b/app/logging/instr/metrics.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package instr

--- a/app/logging/instr/metrics_test.go
+++ b/app/logging/instr/metrics_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package instr

--- a/app/logging/instr/middleware.go
+++ b/app/logging/instr/middleware.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package instr

--- a/app/logging/instr/span.go
+++ b/app/logging/instr/span.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package instr

--- a/app/logging/instr/span_test.go
+++ b/app/logging/instr/span_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package instr

--- a/app/logging/logger.go
+++ b/app/logging/logger.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package logging provides structured logging infrastructure for CloudZero Agent operations.

--- a/app/logging/logger_test.go
+++ b/app/logging/logger_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package logging_test

--- a/app/logging/store_sink.go
+++ b/app/logging/store_sink.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package logging provides structured logging infrastructure for CloudZero Agent operations.

--- a/app/logging/store_sink_test.go
+++ b/app/logging/store_sink_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package logging_test

--- a/app/logging/validator/lf.go
+++ b/app/logging/validator/lf.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package logging

--- a/app/logging/validator/logging.go
+++ b/app/logging/validator/logging.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package logging contains utilities for logging.

--- a/app/logging/validator/logging_test.go
+++ b/app/logging/validator/logging_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package logging_test
 

--- a/app/logging/validator/sequence.go
+++ b/app/logging/validator/sequence.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package logging

--- a/app/logging/validator/text_format.go
+++ b/app/logging/validator/text_format.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package logging

--- a/app/logging/validator/text_format_test.go
+++ b/app/logging/validator/text_format_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package logging
 

--- a/app/storage/core/baseimpl.go
+++ b/app/storage/core/baseimpl.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package core provides foundational database repository infrastructure for CloudZero Agent storage operations.

--- a/app/storage/core/baseimpl_test.go
+++ b/app/storage/core/baseimpl_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package core_test

--- a/app/storage/core/errors.go
+++ b/app/storage/core/errors.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/app/storage/core/errors_test.go
+++ b/app/storage/core/errors_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package core_test

--- a/app/storage/core/gorm.go
+++ b/app/storage/core/gorm.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/app/storage/core/id.go
+++ b/app/storage/core/id.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package core

--- a/app/storage/core/id_test.go
+++ b/app/storage/core/id_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package core_test

--- a/app/storage/core/log_adapter.go
+++ b/app/storage/core/log_adapter.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package core provides core functionalities for database repository implementations.

--- a/app/storage/core/log_adapter_test.go
+++ b/app/storage/core/log_adapter_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package core_test

--- a/app/storage/disk/disk.go
+++ b/app/storage/disk/disk.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package disk implements the secondary adapter for persistent storage in hexagonal architecture.

--- a/app/storage/disk/disk_test.go
+++ b/app/storage/disk/disk_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package disk_test

--- a/app/storage/disk/metric_file.go
+++ b/app/storage/disk/metric_file.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package disk

--- a/app/storage/disk/metric_file_test.go
+++ b/app/storage/disk/metric_file_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package disk_test

--- a/app/storage/disk/parquet_streamer.go
+++ b/app/storage/disk/parquet_streamer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package disk provides storage functionality.

--- a/app/storage/disk/parquet_streamer_test.go
+++ b/app/storage/disk/parquet_streamer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package disk_test

--- a/app/storage/repo/resource_store_impl.go
+++ b/app/storage/repo/resource_store_impl.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package repo provides concrete repository implementations for CloudZero Agent resource metadata storage.

--- a/app/storage/repo/resource_store_impl_test.go
+++ b/app/storage/repo/resource_store_impl_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package repo_test

--- a/app/storage/sqlite/driver.go
+++ b/app/storage/sqlite/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package sqlite provides SQLite database driver implementation for CloudZero Agent data persistence.

--- a/app/storage/sqlite/driver_test.go
+++ b/app/storage/sqlite/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package sqlite_test

--- a/app/types/bus.go
+++ b/app/types/bus.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines event bus abstractions for inter-component communication in the CloudZero Agent.

--- a/app/types/clusterconfig/clusterconfig.go
+++ b/app/types/clusterconfig/clusterconfig.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package clusterconfig provides protobuf-based cluster configuration management for the CloudZero Agent.

--- a/app/types/errors.go
+++ b/app/types/errors.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types provides foundational data structures, interfaces, and error definitions for the CloudZero Agent.

--- a/app/types/file.go
+++ b/app/types/file.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines file abstraction interfaces for CloudZero Agent storage operations.

--- a/app/types/k8s_object.go
+++ b/app/types/k8s_object.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines Kubernetes API resource constants and interfaces for the CloudZero Agent webhook system.

--- a/app/types/metric.go
+++ b/app/types/metric.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines core metric data structures for the CloudZero Agent's cost allocation pipeline.

--- a/app/types/metric_test.go
+++ b/app/types/metric_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //coverage:ignore

--- a/app/types/metric_transformer.go
+++ b/app/types/metric_transformer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package types

--- a/app/types/metrics_test.go
+++ b/app/types/metrics_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package types_test

--- a/app/types/mocks/mock_time_provider.go
+++ b/app/types/mocks/mock_time_provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package mocks

--- a/app/types/prom_metrics_names.go
+++ b/app/types/prom_metrics_names.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types provides Prometheus metric naming utilities for the CloudZero Agent.

--- a/app/types/resource.go
+++ b/app/types/resource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines Kubernetes resource metadata structures for cost allocation.

--- a/app/types/resource_store.go
+++ b/app/types/resource_store.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package types

--- a/app/types/review.go
+++ b/app/types/review.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package types

--- a/app/types/runnable.go
+++ b/app/types/runnable.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines common lifecycle management interfaces for CloudZero Agent components.

--- a/app/types/set.go
+++ b/app/types/set.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package types

--- a/app/types/set_test.go
+++ b/app/types/set_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package types_test

--- a/app/types/status/cluster_status.pb_test.go
+++ b/app/types/status/cluster_status.pb_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package status_test

--- a/app/types/status/report.go
+++ b/app/types/status/report.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package status provides thread-safe access to CloudZero Agent cluster health reporting.

--- a/app/types/status/report_test.go
+++ b/app/types/status/report_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package status_test

--- a/app/types/storage.go
+++ b/app/types/storage.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package types

--- a/app/types/store.go
+++ b/app/types/store.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines storage interfaces and contracts for the CloudZero Agent persistence layer.

--- a/app/types/storeMonitor.go
+++ b/app/types/storeMonitor.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines storage monitoring types for disk usage tracking and alerting.

--- a/app/types/storeMonitor_test.go
+++ b/app/types/storeMonitor_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package types_test

--- a/app/types/time_provider.go
+++ b/app/types/time_provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines time abstraction interfaces for testable time-dependent operations.

--- a/app/utils/chunk.go
+++ b/app/utils/chunk.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package utils provides utility functions and types for CloudZero Agent operational support.

--- a/app/utils/clock.go
+++ b/app/utils/clock.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package utils provides utility functions and types for CloudZero Agent operational support.

--- a/app/utils/clock_test.go
+++ b/app/utils/clock_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package utils_test

--- a/app/utils/k8s/services.go
+++ b/app/utils/k8s/services.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package k8s contains helpers for working with the Kubernetes Client.

--- a/app/utils/k8s/services_test.go
+++ b/app/utils/k8s/services_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package k8s_test

--- a/app/utils/lock/filelock.go
+++ b/app/utils/lock/filelock.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package lock provides an interface for file-based locking.

--- a/app/utils/lock/filelock_test.go
+++ b/app/utils/lock/filelock_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package lock

--- a/app/utils/lock/handle.go
+++ b/app/utils/lock/handle.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package lock

--- a/app/utils/lock/handle_test.go
+++ b/app/utils/lock/handle_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package lock

--- a/app/utils/parallel/parallel.go
+++ b/app/utils/parallel/parallel.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package parallel provides utilities for running tasks in parallel.

--- a/app/utils/parallel/parallel_test.go
+++ b/app/utils/parallel/parallel_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package parallel_test

--- a/app/utils/scout/auto/auto.go
+++ b/app/utils/scout/auto/auto.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package auto provides auto-detection capabilities for the CloudZero Scout.

--- a/app/utils/scout/auto/auto_test.go
+++ b/app/utils/scout/auto/auto_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package auto

--- a/app/utils/scout/aws/aws.go
+++ b/app/utils/scout/aws/aws.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package aws provides AWS cloud environment detection and metadata retrieval

--- a/app/utils/scout/aws/aws_test.go
+++ b/app/utils/scout/aws/aws_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package aws

--- a/app/utils/scout/azure/azure.go
+++ b/app/utils/scout/azure/azure.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package azure provides Azure cloud environment detection and metadata retrieval

--- a/app/utils/scout/azure/azure_test.go
+++ b/app/utils/scout/azure/azure_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package azure

--- a/app/utils/scout/detect_configuration.go
+++ b/app/utils/scout/detect_configuration.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package scout

--- a/app/utils/scout/detect_configuration_test.go
+++ b/app/utils/scout/detect_configuration_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package scout_test

--- a/app/utils/scout/example_basic_test.go
+++ b/app/utils/scout/example_basic_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package scout_test

--- a/app/utils/scout/google/google.go
+++ b/app/utils/scout/google/google.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package google provides functionality for detecting and gathering environment

--- a/app/utils/scout/google/google_test.go
+++ b/app/utils/scout/google/google_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package google

--- a/app/utils/scout/scout.go
+++ b/app/utils/scout/scout.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package scout provides cloud environment detection and metadata retrieval

--- a/app/utils/scout/types/scout.go
+++ b/app/utils/scout/types/scout.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines core types and interfaces for cloud environment detection

--- a/app/utils/scout/types/types.go
+++ b/app/utils/scout/types/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package types defines core types and interfaces for cloud environment detection

--- a/app/utils/telemetry/post.go
+++ b/app/utils/telemetry/post.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package telemetry contains code for posting telemetry data to the CloudZero API.

--- a/app/utils/telemetry/post_test.go
+++ b/app/utils/telemetry/post_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package telemetry_test
 

--- a/mock/controller/controller/mock_insights_controller.go
+++ b/mock/controller/controller/mock_insights_controller.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package controller provides a mock insights controller.

--- a/mock/metrics/cpu.go
+++ b/mock/metrics/cpu.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/mock/metrics/memory.go
+++ b/mock/metrics/memory.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/mock/metrics/metrics.go
+++ b/mock/metrics/metrics.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package metrics provides utilities for generating metrics.

--- a/mock/metrics/metrics_test.go
+++ b/mock/metrics/metrics_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/mock/metrics/node_history.go
+++ b/mock/metrics/node_history.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/mock/metrics/pod_history.go
+++ b/mock/metrics/pod_history.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/mock/metrics/summary_record.go
+++ b/mock/metrics/summary_record.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package metrics

--- a/mock/remotewrite/main.go
+++ b/mock/remotewrite/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/mock/remotewrite/pkg/abandon.go
+++ b/mock/remotewrite/pkg/abandon.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package remotewrite

--- a/mock/remotewrite/pkg/helper.go
+++ b/mock/remotewrite/pkg/helper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package remotewrite provides a mock remote write server.

--- a/mock/remotewrite/pkg/middleware.go
+++ b/mock/remotewrite/pkg/middleware.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package remotewrite

--- a/mock/remotewrite/pkg/minio.go
+++ b/mock/remotewrite/pkg/minio.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package remotewrite

--- a/mock/remotewrite/pkg/remotewrite.go
+++ b/mock/remotewrite/pkg/remotewrite.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package remotewrite

--- a/mock/remotewrite/pkg/status.go
+++ b/mock/remotewrite/pkg/status.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package remotewrite

--- a/mock/remotewrite/pkg/upload.go
+++ b/mock/remotewrite/pkg/upload.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package remotewrite

--- a/tests/app/domain/diagnostic/cz/check_test.go
+++ b/tests/app/domain/diagnostic/cz/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package cz_test
 

--- a/tests/app/domain/diagnostic/k8s/version/check_test.go
+++ b/tests/app/domain/diagnostic/k8s/version/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package version_test

--- a/tests/app/domain/diagnostic/kms/check_test.go
+++ b/tests/app/domain/diagnostic/kms/check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package kms_test

--- a/tests/app/http/client/http_test.go
+++ b/tests/app/http/client/http_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package http_test

--- a/tests/app/logging/validator/sequence_test.go
+++ b/tests/app/logging/validator/sequence_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package logging_test
 

--- a/tests/backfiller/backfiller_integration_test.go
+++ b/tests/backfiller/backfiller_integration_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration

--- a/tests/backfiller/mock_collector.go
+++ b/tests/backfiller/mock_collector.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package backfiller provides utilities for testing label backfiller integrations.

--- a/tests/integration/config.go
+++ b/tests/integration/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package integration provides integration tests.

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 // +build integration
 
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration

--- a/tests/integration/shutdown_coordination_test.go
+++ b/tests/integration/shutdown_coordination_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 // +build integration
 
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration

--- a/tests/kind/cluster.go
+++ b/tests/kind/cluster.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package kind provides utilities for managing Kind clusters in tests.

--- a/tests/smoke/client_test.go
+++ b/tests/smoke/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package smoke

--- a/tests/smoke/collector.go
+++ b/tests/smoke/collector.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package smoke

--- a/tests/smoke/collector_test.go
+++ b/tests/smoke/collector_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package smoke

--- a/tests/smoke/remotewrite.go
+++ b/tests/smoke/remotewrite.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package smoke

--- a/tests/smoke/remotewrite_test.go
+++ b/tests/smoke/remotewrite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package smoke

--- a/tests/smoke/shipper.go
+++ b/tests/smoke/shipper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package smoke

--- a/tests/smoke/shipper_test.go
+++ b/tests/smoke/shipper_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package smoke

--- a/tests/smoke/smoke.go
+++ b/tests/smoke/smoke.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package smoke provides smoke tests.

--- a/tests/utils/condition.go
+++ b/tests/utils/condition.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package utils

--- a/tests/utils/container.go
+++ b/tests/utils/container.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package utils provides utilities supporting the smoke tests.

--- a/tests/utils/logging.go
+++ b/tests/utils/logging.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package utils

--- a/tests/utils/logging_test.go
+++ b/tests/utils/logging_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package utils_test
 

--- a/tests/utils/roundtripper.go
+++ b/tests/utils/roundtripper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package utils contains higher-level (e.g., integration) tests.

--- a/tests/webhook/webhook_chart_integration_test.go
+++ b/tests/webhook/webhook_chart_integration_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration


### PR DESCRIPTION
# Why?

Gotta do it eventually, may as well get it over with before the amount of time since 2026-01-01 gets embarassing...

# What

`find . -name '*.go' -exec sed -i '' 's/SPDX-FileCopyrightText: Copyright (c) 2016-2025, CloudZero, Inc. or its affiliates. All Rights Reserved./SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved./g' {} +`

Plus some other variants

# How Tested

CI
