### PR TITLE
Remove Trivy vulnerability scanning from Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -293,16 +293,6 @@ jobs:
           fail-build: true
           severity-cutoff: high
 
-      - name: SECURITY - Trivy Docker Image Scan
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: ${{ env.REGISTRY_PROD_ADDR }}/${{ env.UNTESTED_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
-          format: "table"
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
-
   k8s-version-matrix-tests:
     # These should match the permissions in the called workflow.
     permissions:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,9 +21,8 @@ We employ multiple layers of automated security scanning to maintain a strong se
 
 #### Container Image Scanning
 
-All container images are automatically scanned for vulnerabilities using two complementary tools:
+All container images are automatically scanned for vulnerabilities:
 
-- **[Trivy](https://trivy.dev/latest/)**: Comprehensive vulnerability scanner that detects OS and library vulnerabilities
 - **[Grype](https://github.com/anchore/grype)**: Fast vulnerability scanner with high accuracy
 
 **Scanning Configuration**:


### PR DESCRIPTION
Remove Trivy vulnerability scanning from Docker build workflow