### PR TITLE
CP-40307: mount emptyDir at /tmp in Alloy container for clustered mode

### DIFF
--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -312,6 +312,8 @@ spec:
               mountPath: /checks/
             - name: validator-config-volume
               mountPath: /checks/app/config/
+            - name: alloy-tmp
+              mountPath: /tmp
             {{- include "cloudzero-agent.apiKeyVolumeMount" . | nindent 12 }}
         {{- end }}{{/* End Alloy container */}}
       {{- include "cloudzero-agent.generatePodSecurityContext" (mergeOverwrite
@@ -337,6 +339,10 @@ spec:
             name: {{ template "cloudzero-agent.validatorConfigMapName" . }}
         - name: lifecycle-volume
           emptyDir: {}
+        {{- if eq (include "cloudzero-agent.Values.components.agent.mode" .) "clustered" }}
+        - name: alloy-tmp
+          emptyDir: {}
+        {{- end }}
         {{- if or .Values.existingSecretName .Values.apiKey }}
         - name: cloudzero-api-key
           secret:

--- a/helm/tests/alloy_deployment_test.yaml
+++ b/helm/tests/alloy_deployment_test.yaml
@@ -134,6 +134,40 @@ tests:
             readOnly: true
         template: templates/agent-deploy.yaml
 
+  # Test that /tmp is mounted as an emptyDir in the Alloy container
+  # The agent image is distroless/scratch and has no /tmp directory; the Alloy
+  # process requires a writable /tmp to create its storage path (/tmp/alloy).
+  # Without this mount, the container crashes immediately with:
+  #   Error: failed to create the remotecfg service: mkdir /tmp: permission denied
+  - it: should mount an emptyDir at /tmp in the Alloy container
+    set:
+      components.agent.mode: clustered
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: alloy-tmp
+            mountPath: /tmp
+        template: templates/agent-deploy.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: alloy-tmp
+            emptyDir: {}
+        template: templates/agent-deploy.yaml
+
+  # Verify alloy-tmp volume is NOT created in non-clustered modes
+  - it: should not create alloy-tmp volume when not in clustered mode
+    set:
+      components.agent.mode: agent
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: alloy-tmp
+            emptyDir: {}
+        template: templates/agent-deploy.yaml
+
   # Test Alloy environment variables
   - it: should set HOSTNAME environment variable for Alloy
     set:

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -2698,6 +2698,8 @@ spec:
               mountPath: /checks/
             - name: validator-config-volume
               mountPath: /checks/app/config/
+            - name: alloy-tmp
+              mountPath: /tmp
             - name: cloudzero-api-key
               mountPath: /etc/config/secrets/
               subPath: ""
@@ -2721,6 +2723,8 @@ spec:
           configMap:
             name: cz-agent-validator-configuration
         - name: lifecycle-volume
+          emptyDir: {}
+        - name: alloy-tmp
           emptyDir: {}
         - name: cloudzero-api-key
           secret:

--- a/tests/helm/template/kubestate.yaml
+++ b/tests/helm/template/kubestate.yaml
@@ -2148,6 +2148,8 @@ spec:
               mountPath: /checks/
             - name: validator-config-volume
               mountPath: /checks/app/config/
+            - name: alloy-tmp
+              mountPath: /tmp
             - name: cloudzero-api-key
               mountPath: /etc/config/secrets/
               subPath: ""
@@ -2171,6 +2173,8 @@ spec:
           configMap:
             name: cz-agent-validator-configuration
         - name: lifecycle-volume
+          emptyDir: {}
+        - name: alloy-tmp
           emptyDir: {}
         - name: cloudzero-api-key
           secret:

--- a/tests/kuttl/alloy-clustered-test/kuttl-test.yaml
+++ b/tests/kuttl/alloy-clustered-test/kuttl-test.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+metadata:
+  name: alloy-clustered-test
+  annotations:
+    kuttl.dev/type: "test"
+spec:
+  testDirs:
+    - ./steps
+  timeout: 300
+  parallel: 1
+  reportFormat: JSON
+  reportName: alloy-clustered-test-report
+  # The suite installs its own helm release in a dedicated namespace and
+  # uninstalls it in step 99, so we do not let kuttl delete the namespace
+  # (that would leave helm release state orphaned).
+  deleteNamespace: false
+  namespaceLabels:
+    test: alloy-clustered

--- a/tests/kuttl/alloy-clustered-test/steps/01-install-clustered-chart.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/01-install-clustered-chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-clustered-chart
+spec:
+  commands:
+    # Install the chart in clustered mode as a separate release so we do not
+    # disturb the default cz-agent release other KUTTL suites run against.
+    # The dev image tag mirrors the `make helm-install-current` target.
+    - command: sh
+      args:
+        - "-c"
+        - |
+          set -e
+          DEV_TAG="dev-$(git rev-parse HEAD)"
+          .tools/bin/helm upgrade --install cz-alloy-ct ./helm \
+            --namespace cz-alloy-clustered-test \
+            --create-namespace \
+            --values clusters/kind-overrides.yaml \
+            --set components.agent.mode=clustered \
+            --set components.agent.image.tag="$DEV_TAG" \
+            --wait --timeout=3m

--- a/tests/kuttl/alloy-clustered-test/steps/02-verify-alloy-ready.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/02-verify-alloy-ready.yaml
@@ -1,0 +1,60 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: verify-alloy-ready
+spec:
+  commands:
+    # Belt-and-suspenders: step 01's `helm --wait` already blocks on Ready,
+    # but re-assert explicitly here so the failure message points at readiness
+    # rather than at helm timing out.
+    - command: kubectl
+      args:
+        - wait
+        - --for=condition=Ready
+        - pod
+        - -l
+        - app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct
+        - -n
+        - cz-alloy-clustered-test
+        - --timeout=180s
+    # Fail if the Alloy container has restarted at all. The pre-fix failure
+    # is CrashLoopBackOff on first start, so any restart > 0 before Ready
+    # flags the regression even if a later retry somehow succeeded.
+    - command: sh
+      args:
+        - "-c"
+        - |
+          set -e
+          RESTARTS=$(kubectl get pod \
+            -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+            -n cz-alloy-clustered-test \
+            -o jsonpath='{.items[*].status.containerStatuses[?(@.name=="cloudzero-agent-alloy")].restartCount}')
+          echo "Alloy container restart count: $RESTARTS"
+          for r in $RESTARTS; do
+            if [ "$r" -ne 0 ]; then
+              echo "FAIL: Alloy container restarted $r times (expected 0)" >&2
+              kubectl describe pod \
+                -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+                -n cz-alloy-clustered-test >&2 || true
+              exit 1
+            fi
+          done
+    # Fail if the specific /tmp regression signature appears in Alloy logs.
+    # Pins this assertion to CP-40307 so unrelated clustered-mode failures
+    # can't silently green-bar.
+    - command: sh
+      args:
+        - "-c"
+        - |
+          set -e
+          LOGS=$(kubectl logs \
+            -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+            -n cz-alloy-clustered-test \
+            -c cloudzero-agent-alloy \
+            --all-containers=false \
+            --tail=-1 2>&1 || true)
+          if echo "$LOGS" | grep -q 'mkdir /tmp: permission denied'; then
+            echo "FAIL: Alloy logs contain the CP-40307 regression signature" >&2
+            echo "$LOGS" >&2
+            exit 1
+          fi

--- a/tests/kuttl/alloy-clustered-test/steps/99-uninstall.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/99-uninstall.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: uninstall-clustered-chart
+spec:
+  commands:
+    # Uninstall the dedicated release so subsequent kuttl suites and the
+    # `kind-test` teardown are unaffected. `--ignore-not-found` and `|| true`
+    # keep cleanup best-effort even if an earlier step failed.
+    - command: sh
+      args:
+        - "-c"
+        - |
+          .tools/bin/helm uninstall cz-alloy-ct \
+            --namespace cz-alloy-clustered-test \
+            --ignore-not-found || true
+          kubectl delete namespace cz-alloy-clustered-test \
+            --ignore-not-found --wait=false || true


### PR DESCRIPTION
# Why?

When `components.agent.mode` is set to `clustered`, the Alloy sidecar crashes immediately on every installation using the default image. The agent image is a distroless/scratch build with no `/tmp` directory. The Alloy process is started with `--storage.path=/tmp/alloy` hardcoded in the container args, but no volume is mounted at `/tmp`. The default security context runs as uid `65534` (nobody), which cannot create `/tmp` at the root of a read-only filesystem, causing:

```
Error: failed to create the remotecfg service: mkdir /tmp: permission denied
```

There is no workaround via values overrides — the chart exposes no `extraVolumes`, `extraVolumeMounts`, or `storagePath` config for the Alloy container — making clustered mode completely non-functional out of the box since it was introduced.

# What

- Added an `emptyDir` volume (`alloy-tmp`) mounted at `/tmp` in the Alloy container
- Pod-level volume is gated on `clustered` mode so it does not appear in other deployment modes
- Added two regression tests to `helm/tests/alloy_deployment_test.yaml`:
  - Asserts `alloy-tmp` volumeMount and pod volume are both present in clustered mode
  - Asserts `alloy-tmp` volume is absent in non-clustered mode

# How Tested

- `make helm-test-unittest` — all 500 unit tests pass
- `helm template` with `components.agent.mode=clustered` confirms `alloy-tmp` appears in both `volumeMounts` and `volumes`
- `helm template` with `components.agent.mode=agent` confirms `alloy-tmp` is absent

Jira: [CP-40307](https://cloudzero.atlassian.net/browse/CP-40307)

[CP-40307]: https://cloudzero.atlassian.net/browse/CP-40307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ