### PR TITLE
CP-40647: add KUTTL regression test for Alloy clustered mode

### DIFF
--- a/tests/kuttl/alloy-clustered-test/kuttl-test.yaml
+++ b/tests/kuttl/alloy-clustered-test/kuttl-test.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+metadata:
+  name: alloy-clustered-test
+  annotations:
+    kuttl.dev/type: "test"
+spec:
+  testDirs:
+    - ./steps
+  timeout: 300
+  parallel: 1
+  reportFormat: JSON
+  reportName: alloy-clustered-test-report
+  # The suite installs its own helm release in a dedicated namespace and
+  # uninstalls it in step 99, so we do not let kuttl delete the namespace
+  # (that would leave helm release state orphaned).
+  deleteNamespace: false
+  namespaceLabels:
+    test: alloy-clustered

--- a/tests/kuttl/alloy-clustered-test/steps/01-install-clustered-chart.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/01-install-clustered-chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-clustered-chart
+spec:
+  commands:
+    # Install the chart in clustered mode as a separate release so we do not
+    # disturb the default cz-agent release other KUTTL suites run against.
+    # The dev image tag mirrors the `make helm-install-current` target.
+    - command: sh
+      args:
+        - "-c"
+        - |
+          set -e
+          DEV_TAG="dev-$(git rev-parse HEAD)"
+          .tools/bin/helm upgrade --install cz-alloy-ct ./helm \
+            --namespace cz-alloy-clustered-test \
+            --create-namespace \
+            --values clusters/kind-overrides.yaml \
+            --set components.agent.mode=clustered \
+            --set components.agent.image.tag="$DEV_TAG" \
+            --wait --timeout=3m

--- a/tests/kuttl/alloy-clustered-test/steps/02-verify-alloy-ready.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/02-verify-alloy-ready.yaml
@@ -1,0 +1,60 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: verify-alloy-ready
+spec:
+  commands:
+    # Belt-and-suspenders: step 01's `helm --wait` already blocks on Ready,
+    # but re-assert explicitly here so the failure message points at readiness
+    # rather than at helm timing out.
+    - command: kubectl
+      args:
+        - wait
+        - --for=condition=Ready
+        - pod
+        - -l
+        - app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct
+        - -n
+        - cz-alloy-clustered-test
+        - --timeout=180s
+    # Fail if the Alloy container has restarted at all. The pre-fix failure
+    # is CrashLoopBackOff on first start, so any restart > 0 before Ready
+    # flags the regression even if a later retry somehow succeeded.
+    - command: sh
+      args:
+        - "-c"
+        - |
+          set -e
+          RESTARTS=$(kubectl get pod \
+            -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+            -n cz-alloy-clustered-test \
+            -o jsonpath='{.items[*].status.containerStatuses[?(@.name=="cloudzero-agent-alloy")].restartCount}')
+          echo "Alloy container restart count: $RESTARTS"
+          for r in $RESTARTS; do
+            if [ "$r" -ne 0 ]; then
+              echo "FAIL: Alloy container restarted $r times (expected 0)" >&2
+              kubectl describe pod \
+                -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+                -n cz-alloy-clustered-test >&2 || true
+              exit 1
+            fi
+          done
+    # Fail if the specific /tmp regression signature appears in Alloy logs.
+    # Pins this assertion to CP-40307 so unrelated clustered-mode failures
+    # can't silently green-bar.
+    - command: sh
+      args:
+        - "-c"
+        - |
+          set -e
+          LOGS=$(kubectl logs \
+            -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+            -n cz-alloy-clustered-test \
+            -c cloudzero-agent-alloy \
+            --all-containers=false \
+            --tail=-1 2>&1 || true)
+          if echo "$LOGS" | grep -q 'mkdir /tmp: permission denied'; then
+            echo "FAIL: Alloy logs contain the CP-40307 regression signature" >&2
+            echo "$LOGS" >&2
+            exit 1
+          fi

--- a/tests/kuttl/alloy-clustered-test/steps/99-uninstall.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/99-uninstall.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: uninstall-clustered-chart
+spec:
+  commands:
+    # Uninstall the dedicated release so subsequent kuttl suites and the
+    # `kind-test` teardown are unaffected. `--ignore-not-found` and `|| true`
+    # keep cleanup best-effort even if an earlier step failed.
+    - command: sh
+      args:
+        - "-c"
+        - |
+          .tools/bin/helm uninstall cz-alloy-ct \
+            --namespace cz-alloy-clustered-test \
+            --ignore-not-found || true
+          kubectl delete namespace cz-alloy-clustered-test \
+            --ignore-not-found --wait=false || true


### PR DESCRIPTION
CP-40307 fixed CrashLoopBackOff on clustered-mode installs caused by the distroless agent image having no writable /tmp for Alloy's --storage.path=/tmp/alloy. That regression was reported by customers post-release rather than caught in testing. The fix commit added helm-unittest coverage, which validates template output, but never actually runs the container — meaning a similar runtime-only regression could still slip through.

Functional Change:

Before: Clustered mode had no end-to-end test. A regression that only manifests when the container starts (permission denied, missing mount, misconfigured arg) could pass all pre-merge checks

After: A dedicated KUTTL suite installs the chart in clustered mode, waits for the Alloy pod to become Ready, and asserts the CP-40307-specific log signature is absent.

Implementation Approach:

The suite is self-contained and installs its own helm release in a dedicated namespace rather than reconfiguring the default cz-agent install that other KUTTL suites run against. This avoids the side effects of switching the chart between agent and clustered modes mid-cycle (Server Deployment → Alloy StatefulSet reshape) and keeps the new suite additive.

1. tests/kuttl/alloy-clustered-test/kuttl-test.yaml — TestSuite, deleteNamespace: false so the step 99 helm uninstall can run first.
2. steps/01-install-clustered-chart.yaml — helm upgrade --install with components.agent.mode=clustered and --wait --timeout=3m. The dev image tag mirrors the helm-install-current Makefile target.
3. steps/02-verify-alloy-ready.yaml — kubectl wait for pod Ready, assert Alloy container restartCount == 0, grep logs for the "mkdir /tmp: permission denied" signature and fail if present.
4. steps/99-uninstall.yaml — best-effort helm uninstall and namespace deletion so subsequent suites and kind-test teardown are unaffected.

No Makefile or CI changes are needed. helm-test-kuttl auto-discovers suites via $(wildcard tests/kuttl/*/kuttl-test.yaml), and docker-build already invokes test-matrix-k8s.yaml (which runs make kind-test) across the k8s version matrix on every PR and in the merge queue.

Validation:

- YAML syntax verified for all four step files.
- make -n tests/kuttl/alloy-clustered-test/run confirms the suite is discovered by the existing Makefile machinery.
- Full make kind-test run and revert-the-fix negative test to be executed in CI (this branch's purpose) and locally prior to merge.
