### PR TITLE
CP-37512: add additionalAlloyConfig for user-supplied Alloy components

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -1019,7 +1019,16 @@ prometheusConfig:
       # Scrape interval for GPU metrics job
       scrapeInterval: 30s
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
+    # Only used when components.agent.mode is "agent" (Prometheus mode). For
+    # clustered (Alloy) mode, use prometheusConfig.additionalAlloyConfig.
     additionalScrapeJobs: []
+  # -- Raw Alloy River configuration appended to the generated config when
+  # components.agent.mode is "clustered" (Alloy mode). Use this to add custom
+  # scrape jobs or other pipeline components. Your components should forward to
+  # prometheus.remote_write.cloudzero.receiver to ship metrics to the
+  # CloudZero aggregator. Ignored in non-clustered (Prometheus) mode; use
+  # prometheusConfig.scrapeJobs.additionalScrapeJobs there instead.
+  additionalAlloyConfig: ""
 
 # General server settings that apply to both the prometheus agent server and the webhook server
 serverConfig:

--- a/helm/templates/_alloy_helpers.tpl
+++ b/helm/templates/_alloy_helpers.tpl
@@ -175,6 +175,19 @@ Usage: {{ include "cloudzero-agent.alloy.riverConfig" . }}
 {{ include "cloudzero-agent.alloy.scrapeGPU" . }}
 {{- end }}
 
+{{- if .Values.prometheusConfig.additionalAlloyConfig }}
+// ============================================================================
+// USER-PROVIDED ALLOY CONFIGURATION
+// ============================================================================
+//
+// Custom Alloy components defined via prometheusConfig.additionalAlloyConfig.
+// These components typically forward to prometheus.remote_write.cloudzero.receiver
+// to ship metrics through the same pipeline as the built-in scrape jobs.
+// ============================================================================
+
+{{ .Values.prometheusConfig.additionalAlloyConfig }}
+{{- end }}
+
 {{ include "cloudzero-agent.alloy.remoteWrite" . }}
 {{- end -}}
 

--- a/helm/tests/alloy_configmap_test.yaml
+++ b/helm/tests/alloy_configmap_test.yaml
@@ -157,3 +157,69 @@ tests:
       - notMatchRegex:
           path: data["alloy-config.river"]
           pattern: 'prometheus.scrape "dcgm"'
+
+  # Test that additionalAlloyConfig is injected when provided
+  - it: should inject additionalAlloyConfig when set
+    set:
+      components.agent.mode: clustered
+      prometheusConfig.additionalAlloyConfig: |
+        prometheus.scrape "external_cadvisor" {
+          targets = [{__address__ = "external-cadvisor.svc:4196"}]
+          forward_to = [prometheus.remote_write.cloudzero.receiver]
+        }
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "external_cadvisor"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: "external-cadvisor.svc:4196"
+
+  # Test that additionalAlloyConfig section header is absent when empty
+  - it: should not include additionalAlloyConfig section when empty
+    set:
+      components.agent.mode: clustered
+    asserts:
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: "USER-PROVIDED ALLOY CONFIGURATION"
+
+  # Test that the built-in cAdvisor scrape job can be disabled via
+  # integrations.cAdvisor.enabled=false in Alloy mode
+  - it: should not include built-in cAdvisor scrape when integrations.cAdvisor.enabled is false
+    set:
+      components.agent.mode: clustered
+      integrations.cAdvisor.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'discovery.kubernetes "cadvisor"'
+
+  # Test that the built-in cAdvisor scrape job can be disabled via the
+  # deprecated prometheusConfig.scrapeJobs.cadvisor.enabled=false in Alloy mode
+  - it: should not include built-in cAdvisor scrape when deprecated cadvisor.enabled is false
+    set:
+      components.agent.mode: clustered
+      prometheusConfig.scrapeJobs.cadvisor.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+      - notMatchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'discovery.kubernetes "cadvisor"'
+
+  # Test that the built-in cAdvisor scrape is present by default in Alloy mode
+  - it: should include built-in cAdvisor scrape by default in Alloy mode
+    set:
+      components.agent.mode: clustered
+    asserts:
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'prometheus.scrape "cadvisor"'
+      - matchRegex:
+          path: data["alloy-config.river"]
+          pattern: 'discovery.kubernetes "cadvisor"'

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -7024,6 +7024,10 @@
     "prometheusConfig": {
       "additionalProperties": false,
       "properties": {
+        "additionalAlloyConfig": {
+          "default": "",
+          "type": "string"
+        },
         "configMapAnnotations": {
           "additionalProperties": true,
           "type": "object"

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1664,9 +1664,27 @@ properties:
           additionalScrapeJobs:
             description: |
               Additional scrape jobs to add to the configuration.
+
+              Only used when components.agent.mode is "agent" (Prometheus mode).
+              For clustered (Alloy) mode, use
+              prometheusConfig.additionalAlloyConfig.
             type: array
             items:
               type: object
+      additionalAlloyConfig:
+        description: |
+          Raw Alloy River configuration appended to the generated config when
+          components.agent.mode is "clustered" (Alloy mode).
+
+          Use this to add custom scrape jobs or other pipeline components.
+          Components should forward to
+          prometheus.remote_write.cloudzero.receiver to ship metrics to the
+          CloudZero aggregator.
+
+          Ignored in non-clustered (Prometheus) mode; use
+          prometheusConfig.scrapeJobs.additionalScrapeJobs there instead.
+        type: string
+        default: ""
 
   commonMetaLabels:
     $ref: "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1019,7 +1019,16 @@ prometheusConfig:
       # Scrape interval for GPU metrics job
       scrapeInterval: 30s
     # -- Any items added to this list will be added to the Prometheus scrape configuration.
+    # Only used when components.agent.mode is "agent" (Prometheus mode). For
+    # clustered (Alloy) mode, use prometheusConfig.additionalAlloyConfig.
     additionalScrapeJobs: []
+  # -- Raw Alloy River configuration appended to the generated config when
+  # components.agent.mode is "clustered" (Alloy mode). Use this to add custom
+  # scrape jobs or other pipeline components. Your components should forward to
+  # prometheus.remote_write.cloudzero.receiver to ship metrics to the
+  # CloudZero aggregator. Ignored in non-clustered (Prometheus) mode; use
+  # prometheusConfig.scrapeJobs.additionalScrapeJobs there instead.
+  additionalAlloyConfig: ""
 
 # General server settings that apply to both the prometheus agent server and the webhook server
 serverConfig:

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -1612,6 +1612,7 @@ data:
       volumeMounts: []
       volumes: []
     prometheusConfig:
+      additionalAlloyConfig: ""
       configMapAnnotations: {}
       configMapNameOverride: ""
       configOverride: ""

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -1527,6 +1527,7 @@ data:
       volumeMounts: []
       volumes: []
     prometheusConfig:
+      additionalAlloyConfig: ""
       configMapAnnotations: {}
       configMapNameOverride: ""
       configOverride: ""

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -1615,6 +1615,7 @@ data:
       volumeMounts: []
       volumes: []
     prometheusConfig:
+      additionalAlloyConfig: ""
       configMapAnnotations: {}
       configMapNameOverride: ""
       configOverride: ""

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -1542,6 +1542,7 @@ data:
       volumeMounts: []
       volumes: []
     prometheusConfig:
+      additionalAlloyConfig: ""
       configMapAnnotations: {}
       configMapNameOverride: ""
       configOverride: ""

--- a/tests/helm/template/kubestate.yaml
+++ b/tests/helm/template/kubestate.yaml
@@ -1357,6 +1357,7 @@ data:
         port: 8080
       tolerations: []
     prometheusConfig:
+      additionalAlloyConfig: ""
       configMapAnnotations: {}
       configMapNameOverride: ""
       configOverride: ""

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1542,6 +1542,7 @@ data:
       volumeMounts: []
       volumes: []
     prometheusConfig:
+      additionalAlloyConfig: ""
       configMapAnnotations: {}
       configMapNameOverride: ""
       configOverride: ""


### PR DESCRIPTION
The agent chart already exposes `prometheusConfig.scrapeJobs.additionalScrapeJobs` for users who need to scrape targets beyond the built-in jobs. In Prometheus mode this list is appended verbatim to the generated scrape_configs. In Alloy (clustered) mode, nothing read it, so users switching to Alloy lost the extension point. A customer is relying on this hook today to scrape an external cAdvisor DaemonSet, and the gap blocks their migration to clustered mode.

Alloy's River configuration is not a drop-in replacement for Prometheus YAML, so rather than silently translating a subset of Prometheus scrape fields (which risks quietly dropping unsupported options), this change adds a parallel value that accepts raw River text. It is intentionally explicit: users port their config once, and we don't have to maintain a partial translator.

Functional Change:

Before: In clustered (Alloy) mode, there was no supported way to add custom scrape jobs or other Alloy pipeline components. `additionalScrapeJobs` (Prometheus YAML) was silently ignored.

After: `prometheusConfig.additionalAlloyConfig` accepts a raw River string that is inserted into the generated Alloy config immediately before the `prometheus.remote_write "cloudzero"` block. User components can forward to `prometheus.remote_write.cloudzero.receiver` to ship metrics through the same pipeline as the built-in scrape jobs. The value is ignored in non-clustered mode. The existing `additionalScrapeJobs` field remains unchanged and its description now points Alloy users to the new field.

Solution:

1. Added `prometheusConfig.additionalAlloyConfig` (string, default "") to helm/values.yaml with documentation cross-referencing `additionalScrapeJobs` for Prometheus mode.

2. Added the corresponding schema entry in helm/values.schema.yaml under `prometheusConfig`. Regenerated helm/values.schema.json and app/functions/helmless/default-values.yaml via `make generate`.

3. Wired the new value into helm/templates/_alloy_helpers.tpl in the `cloudzero-agent.alloy.riverConfig` entry point. When non-empty, the raw config is emitted under a "USER-PROVIDED ALLOY CONFIGURATION" section header placed after the optional GPU scrape job and before the remote_write sink.

4. Added 5 new cases to helm/tests/alloy_configmap_test.yaml:
   - injects additionalAlloyConfig when set
   - omits the user-config section header when empty
   - built-in cAdvisor scrape is removed via `integrations.cAdvisor.enabled=false` in Alloy mode
   - built-in cAdvisor scrape is removed via the deprecated `prometheusConfig.scrapeJobs.cadvisor.enabled=false` in Alloy mode
   - built-in cAdvisor scrape is present by default in Alloy mode The last three lock in regression coverage for an existing behavior (the `cloudzero-agent.Values.integrations.cAdvisor.enabled` helper was already respected by the Alloy template at line 158 of _alloy_helpers.tpl, but had no dedicated tests).

Validation:

- All 503 helm unit tests pass (498 before, +5 new), including the existing alloy_configmap_test.yaml suite.
- `make helm-lint` and `make helm-test-schema` pass.
- Manually rendered the chart with a sample `additionalAlloyConfig` containing a `prometheus.scrape` block; verified the raw River text appears in the ConfigMap with correct indentation, section header, and adjacency to the remote_write block.
- Manually rendered the chart with `integrations.cAdvisor.enabled=false` and with `prometheusConfig.scrapeJobs.cadvisor.enabled=false` in clustered mode; verified `prometheus.scrape "cadvisor"` and `discovery.kubernetes "cadvisor"` are both absent in each case, and both present in the default configuration.
- Not validated on a live cluster; customer will confirm end-to-end in their environment before we close CP-40646.

# Why?

> This awesome thing improves my smile brightness

# What

> Outline the actions you took to achieve a brighter smile

# How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile
