### PR TITLE
CP-40646: add release notes for 1.2.11

### DIFF
--- a/docs/releases/1.2.11.md
+++ b/docs/releases/1.2.11.md
@@ -1,0 +1,34 @@
+## [1.2.11](https://github.com/Cloudzero/cloudzero-agent/compare/v1.2.10...v1.2.11) (2026-04-23)
+
+Release 1.2.11 is a maintenance release focused on integration with existing observability tooling, better support diagnostics, and a round of dependency and security updates.
+
+### Key Features
+
+- **Prometheus Operator Integration**: The chart now optionally generates `ServiceMonitor` and `PrometheusRule` resources so customers running the Prometheus Operator can monitor the agent out of the box. The bundle includes four ServiceMonitors covering every agent component and 14 alerts spanning critical failures, degraded operation, data quality issues, and container health. Shipper thresholds are derived automatically from `aggregator.database.costMaxInterval` so alerts stay aligned with configured upload cadence. Enable via `components.monitoring.enabled`, which supports an `auto` mode that only renders the resources when the Prometheus Operator CRDs are present on the cluster. See `helm/docs/monitoring-infrastructure.md` for the full alert catalog.
+
+- **User-Supplied Alloy Configuration**: The existing `prometheusConfig.scrapeJobs.additionalScrapeJobs` extension point only applies to Prometheus mode. Clustered (Alloy) mode now has the equivalent capability via a new `prometheusConfig.additionalAlloyConfig` value, which accepts a raw Alloy River string that is merged into the generated pipeline. User components can forward to `prometheus.remote_write.cloudzero.receiver` to ship metrics through the same path as the built-in scrape jobs, making it possible to extend clustered mode with custom scrape targets or transformations.
+
+### Bug Fixes
+
+- **Clustered Mode Startup**: Fixed a startup failure in clustered mode where the Alloy container was unable to initialize its storage path. Clustered mode installations no longer require any values-level workaround.
+
+### Improvements
+
+- **Webhook and TLS Diagnostics**: The `anaximander` support script now collects validating webhook configuration (including certificate bundle validation) and TLS certificate metadata from the agent namespace. Certificate subjects, issuers, expiration dates, fingerprints, and SANs are included; private key material is never collected. This targets one of the most common silent failure modes — a missing or invalid `caBundle` combined with `failurePolicy: Ignore` — so CloudZero support can diagnose webhook issues from a single diagnostic bundle.
+
+### Build and Infrastructure
+
+- Go toolchain updated to 1.26.2
+- Embedded Alloy binary updated to v1.15.1
+- Prometheus library updated to 0.311.2
+- Kubernetes client libraries aligned at v0.36.0
+- Numerous dependency updates across Go modules, GitHub Actions, and tooling
+- Removed a transitive dependency on `github.com/docker/docker` from the production build
+
+### Upgrade Steps
+
+To upgrade to version 1.2.11, run the following command:
+
+```sh
+helm upgrade --install <RELEASE_NAME> cloudzero/cloudzero-agent -n <NAMESPACE> --create-namespace -f configuration.example.yaml --version 1.2.11
+```


### PR DESCRIPTION
# Why?

So we can release 1.2.11

# What

Added release notes.

# How Tested

<img src="https://github.com/user-attachments/assets/7c347d63-cdb5-43ba-8049-aa2dfebf4cd2" />

