### PR TITLE
CP-40663: Fix DiskStore permanent failure loop after brotli compressor error

### DIFF
--- a/app/storage/disk/disk.go
+++ b/app/storage/disk/disk.go
@@ -176,6 +176,12 @@ func (d *DiskStore) Put(ctx context.Context, metrics ...types.Metric) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	if d.writer == nil {
+		if err := d.newFileWriter(); err != nil {
+			return fmt.Errorf("failed to recover writer: %w", err)
+		}
+	}
+
 	for _, metric := range metrics {
 		encodedMetric, err := json.Marshal(metric)
 		if err != nil {
@@ -217,11 +223,34 @@ func (d *DiskStore) Flush() error {
 	return nil
 }
 
-// flushUnlocked finalizes the current writer, writes all buffered data to disk, and renames the file
-func (d *DiskStore) flushUnlocked() error {
+// flushUnlocked finalizes the current writer, writes all buffered data to disk, and renames the file.
+// On error, all state is cleaned up so the store can recover on the next Put() call.
+func (d *DiskStore) flushUnlocked() (retErr error) {
 	if d.writer == nil {
 		return nil
 	}
+
+	defer func() {
+		if retErr != nil {
+			// Abandon the corrupt file and reset state so the store can recover.
+			// Data in the current buffer is lost, but Prometheus will retry.
+			if d.compressor != nil {
+				d.compressor.Close()
+			}
+			if d.file != nil {
+				d.file.Close()
+			}
+			os.Remove(d.activeFilePath)
+
+			d.writer = nil
+			d.arrayState = nil
+			d.file = nil
+			d.compressor = nil
+			d.rowCount = 0
+
+			log.Warn().Err(retErr).Msg("flush failed, abandoned file to allow recovery")
+		}
+	}()
 
 	// End the JSON array
 	d.arrayState.End()
@@ -275,7 +304,8 @@ func (d *DiskStore) flushUnlocked() error {
 	d.writer = nil
 	d.arrayState = nil
 	d.file = nil
-	d.rowCount = 0 // Reset row count after flush
+	d.compressor = nil
+	d.rowCount = 0
 	return nil
 }
 

--- a/app/storage/disk/disk_test.go
+++ b/app/storage/disk/disk_test.go
@@ -245,6 +245,106 @@ func TestDiskStore_GetFiles(t *testing.T) {
 	})
 }
 
+func TestDiskStore_RecoveryAfterFlushFailure(t *testing.T) {
+	dirPath := t.TempDir()
+	rowLimit := 5
+
+	ps, err := disk.NewDiskStore(config.Database{StoragePath: dirPath, MaxRecords: rowLimit}, disk.WithContentIdentifier(disk.CostContentIdentifier))
+	require.NoError(t, err)
+
+	mockClock := mocks.NewMockClock(time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC))
+	metric := types.Metric{
+		ID:             uuid.New(),
+		ClusterName:    "cluster",
+		CloudAccountID: "cloudaccount",
+		MetricName:     "test_metric",
+		NodeName:       "node1",
+		CreatedAt:      mockClock.GetCurrentTime(),
+		TimeStamp:      mockClock.GetCurrentTime(),
+		Labels:         map[string]string{"label": "test"},
+		Value:          "123.45",
+	}
+	ctx := context.Background()
+
+	// Put some metrics (below row limit)
+	err = ps.Put(ctx, metric, metric)
+	require.NoError(t, err)
+	assert.Equal(t, 2, ps.Pending())
+
+	// Make directory read-only so os.Rename fails during flush
+	require.NoError(t, os.Chmod(dirPath, 0o444))
+
+	// Put enough metrics to trigger row-limit flush — this should fail
+	err = ps.Put(ctx, metric, metric, metric, metric)
+	assert.Error(t, err, "flush should fail when directory is read-only")
+
+	// Restore directory permissions
+	require.NoError(t, os.Chmod(dirPath, 0o755))
+
+	// The store should recover: new Put() should succeed
+	err = ps.Put(ctx, metric)
+	require.NoError(t, err, "Put should recover after failed flush")
+	assert.Equal(t, 1, ps.Pending())
+
+	// Flush should also work
+	err = ps.Flush()
+	require.NoError(t, err, "Flush should succeed after recovery")
+	assert.Equal(t, 0, ps.Pending())
+
+	// Verify the flushed file exists and is readable
+	files, err := ps.GetFiles()
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(files), "should have exactly one completed file")
+}
+
+func TestDiskStore_CorruptFileCleanedUpAfterFlushFailure(t *testing.T) {
+	dirPath := t.TempDir()
+	rowLimit := 5
+
+	ps, err := disk.NewDiskStore(config.Database{StoragePath: dirPath, MaxRecords: rowLimit}, disk.WithContentIdentifier(disk.CostContentIdentifier))
+	require.NoError(t, err)
+
+	mockClock := mocks.NewMockClock(time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC))
+	metric := types.Metric{
+		ID:             uuid.New(),
+		ClusterName:    "cluster",
+		CloudAccountID: "cloudaccount",
+		MetricName:     "test_metric",
+		NodeName:       "node1",
+		CreatedAt:      mockClock.GetCurrentTime(),
+		TimeStamp:      mockClock.GetCurrentTime(),
+		Labels:         map[string]string{"label": "test"},
+		Value:          "123.45",
+	}
+	ctx := context.Background()
+
+	// Put some metrics
+	err = ps.Put(ctx, metric, metric)
+	require.NoError(t, err)
+
+	// Make directory read-only to cause flush failure
+	require.NoError(t, os.Chmod(dirPath, 0o444))
+
+	// Trigger flush failure
+	err = ps.Put(ctx, metric, metric, metric, metric)
+	assert.Error(t, err)
+
+	// Restore permissions
+	require.NoError(t, os.Chmod(dirPath, 0o755))
+
+	// Verify no incomplete active files remain (only the new active file from recovery)
+	entries, err := os.ReadDir(dirPath)
+	require.NoError(t, err)
+
+	completedFiles := 0
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".br" {
+			completedFiles++
+		}
+	}
+	assert.Equal(t, 0, completedFiles, "no completed .br files should exist from the failed flush")
+}
+
 func TestDiskStore_GetUsage(t *testing.T) {
 	tmpDir := t.TempDir()
 	d, err := disk.NewDiskStore(config.Database{StoragePath: tmpDir, MaxRecords: 100}, disk.WithContentIdentifier(disk.CostContentIdentifier))


### PR DESCRIPTION
# Why?

The brotli library permanently kills its Writer on `Close()` (`w.dst = nil`). If `flushUnlocked()` fails after the compressor is closed (e.g., file rename error), the state is never cleaned up. Every subsequent `Put()` and `Flush()` hits the dead writer and returns 500 indefinitely; recovery requires a pod restart.

# What

- `flushUnlocked():` Added named return + deferred cleanup that fires on error: closes resources, removes the incomplete file, and resets all state so the store can recover.
- `Put()`: Added nil writer check to recreate the file writer after a failed flush.
- Also nil d.compressor on the success path (was previously missed).

# How Tested

- `TestDiskStore_RecoveryAfterFlushFailure`: triggers flush failure via read-only directory, restores permissions, verifies `Put()` and `Flush()` recover.
- `TestDiskStore_CorruptFileCleanedUpAfterFlushFailure`: verifies incomplete active file is removed after failed flush.
- All existing tests pass