### PR TITLE
CP-40749: auto-recover aggregator pods from persistent 5xx state

### DIFF
--- a/app/functions/collector/main.go
+++ b/app/functions/collector/main.go
@@ -6,14 +6,17 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/go-obvious/server"
+	"github.com/go-obvious/server/healthz"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -26,6 +29,29 @@ import (
 	"github.com/cloudzero/cloudzero-agent/app/storage/disk"
 	"github.com/cloudzero/cloudzero-agent/app/types"
 	"github.com/cloudzero/cloudzero-agent/app/utils"
+)
+
+// Error-rate health-check parameters for the /collector endpoint. These are
+// starting points chosen to match the analysis in CP-40749 and should be
+// revisited if real traffic patterns call for different thresholds.
+//
+//   - errorRateWindow: how much recent /collector traffic to consider.
+//   - errorRateThreshold: the 5xx fraction above which the health check trips
+//     (0.20 = 20%).
+//   - errorRateMinFailures: absolute floor on failures required before the
+//     threshold is evaluated, so a single transient blip doesn't trip the
+//     probe.
+//   - errorRateLivenessCooldown: how long /livez stays latched unhealthy
+//     after the last unhealthy evaluation. Must be at least as long as the
+//     liveness probe's total budget (failureThreshold × periodSeconds) so
+//     the probe actually fires a restart instead of the latch releasing
+//     first; the chart default of failureThreshold=10 × periodSeconds=30s
+//     = 5m matches this constant.
+const (
+	errorRateWindow           = 60 * time.Second
+	errorRateThreshold        = 0.20
+	errorRateMinFailures      = 3
+	errorRateLivenessCooldown = 5 * time.Minute
 )
 
 func main() {
@@ -115,9 +141,33 @@ func main() {
 		middleware.PromHTTPMiddleware,
 	}
 
+	// Track recent /collector response statuses so two different probes can
+	// react on different timescales:
+	//
+	//   - /healthz (readiness): instantaneous — fails fast, recovers fast.
+	//     When the rate crosses the threshold, Kubernetes removes the pod
+	//     from the Service endpoint list. If the pod subsequently stops
+	//     seeing traffic and the window ages out, /healthz goes back to 200
+	//     and the pod rejoins the Service.
+	//
+	//   - /livez (liveness): sticky latch — once the tracker has observed an
+	//     unhealthy evaluation, /livez stays 503 for errorRateLivenessCooldown
+	//     even if /healthz has since returned to 200. This prevents a
+	//     readiness-eviction → no-traffic → window-ages-out → readmit flap
+	//     loop and guarantees that a persistently bad pod is eventually
+	//     restarted rather than bouncing between Ready and NotReady forever.
+	collectorErrorRate := middleware.NewErrorRateTracker(errorRateWindow)
+	healthz.Register("collector-error-rate", func() error {
+		if !collectorErrorRate.Healthy(errorRateThreshold, errorRateMinFailures) {
+			return errors.New("/collector 5xx rate exceeds threshold")
+		}
+		return nil
+	})
+
 	apis := []server.API{
-		handlers.NewRemoteWriteAPI("/collector", domain),
+		handlers.NewRemoteWriteAPI("/collector", domain, handlers.WithErrorRateTracker(collectorErrorRate)),
 		handlers.NewPromMetricsAPI("/metrics"),
+		handlers.NewLivezAPI("/livez", collectorErrorRate, errorRateThreshold, errorRateMinFailures, errorRateLivenessCooldown),
 	}
 
 	if settings.Server.Profiling {

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -1578,6 +1578,24 @@ aggregator:
   # load across the various collector replicas. 0=never, otherwise 1/N
   # probability.
   reconnectFrequency: 16
+  # Kubernetes readiness probe configuration for both the collector and shipper
+  # containers. Readiness is kept aggressive so that a pod returning 5xx is
+  # removed from the Service endpoint list quickly (within ~30s at defaults).
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+  # Kubernetes liveness probe configuration for both the collector and shipper
+  # containers. Liveness is deliberately more tolerant than readiness: a pod
+  # that the health check reports as unhealthy gets removed from the Service
+  # quickly, but only restarted after sustained failure. This gives the pod a
+  # chance to self-heal (for example via connection rotation) before
+  # Kubernetes kills it. At periodSeconds=30, failureThreshold=10 yields ~5
+  # minutes of sustained unhealth before restart.
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    failureThreshold: 10
   # Container image configuration for the aggregator components.
   #
   # Deprecated. Please use components.aggregator.image instead.
@@ -1683,6 +1701,11 @@ aggregator:
       limits:
         memory: ""
         cpu: ""
+    # Per-container probe overrides merged on top of aggregator.readinessProbe
+    # and aggregator.livenessProbe. Empty by default — the collector uses the
+    # shared aggregator probe settings.
+    readinessProbe: {}
+    livenessProbe: {}
   # Configuration for the shipper component of the aggregator.
   shipper:
     # Port that the shipper listens on for internal communication.
@@ -1700,6 +1723,13 @@ aggregator:
       limits:
         memory: ""
         cpu: ""
+    # Per-container probe overrides merged on top of aggregator.readinessProbe
+    # and aggregator.livenessProbe. The shipper does not run the error-rate
+    # tracker that extends the collector's restart budget, so its liveness
+    # uses a tighter failureThreshold.
+    readinessProbe: {}
+    livenessProbe:
+      failureThreshold: 3
   # Node selector configuration for the aggregator pods.
   #
   # See the Kubernetes documentation for details:

--- a/app/handlers/livez.go
+++ b/app/handlers/livez.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-obvious/server"
+	"github.com/go-obvious/server/api"
+
+	"github.com/cloudzero/cloudzero-agent/app/http/middleware"
+)
+
+// LivezAPI exposes an HTTP endpoint suitable for use as a Kubernetes liveness
+// probe. It differs from the general /healthz endpoint in one important way:
+// it has sticky-latch semantics.
+//
+// /healthz reflects the instantaneous state of the ErrorRateTracker: if
+// traffic stops arriving or recent failures age out of the sliding window,
+// it immediately goes back to reporting healthy. That's the right behavior
+// for readiness — a pod that has recovered should rejoin the Service
+// quickly.
+//
+// /livez, in contrast, reports unhealthy for `cooldown` after the last
+// time the tracker's evaluation returned unhealthy, even if subsequent
+// evaluations (with events aged out) would pass. This prevents a
+// readiness-eviction → no-traffic → window-ages-out → readmit flap loop:
+// once the pod has been demonstrated to fail, liveness will fire and
+// restart it instead.
+type LivezAPI struct {
+	// api.Service provides the foundational HTTP server infrastructure from go-obvious/server.
+	api.Service
+
+	tracker       *middleware.ErrorRateTracker
+	rateThreshold float64
+	minFailures   int
+	cooldown      time.Duration
+}
+
+// NewLivezAPI constructs a LivezAPI bound to the given tracker and threshold
+// parameters. The same tracker should be passed to the collector's request
+// middleware so the two see the same stream of response statuses.
+func NewLivezAPI(base string, tracker *middleware.ErrorRateTracker, rateThreshold float64, minFailures int, cooldown time.Duration) *LivezAPI {
+	a := &LivezAPI{
+		tracker:       tracker,
+		rateThreshold: rateThreshold,
+		minFailures:   minFailures,
+		cooldown:      cooldown,
+		Service: api.Service{
+			APIName: "livez",
+			Mounts:  map[string]*chi.Mux{},
+		},
+	}
+	a.Mounts[base] = a.Routes()
+	return a
+}
+
+// Register integrates the LivezAPI with the CloudZero Agent HTTP server.
+func (a *LivezAPI) Register(app server.Server) error {
+	return a.Service.Register(app)
+}
+
+// Routes configures HTTP request routing for the liveness endpoint.
+func (a *LivezAPI) Routes() *chi.Mux {
+	r := chi.NewRouter()
+	r.Get("/", a.GetLivez)
+	return r
+}
+
+// GetLivez returns 200 OK if the tracker reports healthy with respect to the
+// configured cooldown, and 503 Service Unavailable otherwise.
+func (a *LivezAPI) GetLivez(w http.ResponseWriter, _ *http.Request) {
+	if a.tracker.HealthyWithinCooldown(a.rateThreshold, a.minFailures, a.cooldown) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	http.Error(w, "error rate exceeded within cooldown", http.StatusServiceUnavailable)
+}

--- a/app/handlers/livez_test.go
+++ b/app/handlers/livez_test.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-obvious/server/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudzero/cloudzero-agent/app/handlers"
+	"github.com/cloudzero/cloudzero-agent/app/http/middleware"
+)
+
+const (
+	livezTestRateThreshold = 0.20
+	livezTestMinFailures   = 3
+	livezTestWindow        = 60 * time.Second
+	livezTestCooldown      = 5 * time.Minute
+)
+
+// TestLivez_HealthyWhenTrackerEmpty: a fresh tracker with no recorded responses
+// should produce an OK response.
+func TestLivez_HealthyWhenTrackerEmpty(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(livezTestWindow)
+
+	api := handlers.NewLivezAPI("/", tracker, livezTestRateThreshold, livezTestMinFailures, livezTestCooldown)
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	resp, err := test.InvokeService(api.Service, "/", *req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"empty tracker should produce a healthy livez response")
+}
+
+// TestLivez_UnavailableWhenInstantaneouslyUnhealthy: after the tracker has
+// recorded enough 5xx to trip the rate threshold, /livez should return 503.
+func TestLivez_UnavailableWhenInstantaneouslyUnhealthy(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(livezTestWindow)
+	for i := 0; i < livezTestMinFailures; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+
+	api := handlers.NewLivezAPI("/", tracker, livezTestRateThreshold, livezTestMinFailures, livezTestCooldown)
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	resp, err := test.InvokeService(api.Service, "/", *req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"after threshold-crossing failures, livez should be 503")
+}
+
+// TestLivez_LatchKeepsUnhealthyAfterEventsAgeOut: the key property that
+// distinguishes /livez from /healthz — once the tracker has observed an
+// unhealthy evaluation, subsequent livez calls stay 503 through the cooldown
+// window even if the sliding window's events have all aged out.
+func TestLivez_LatchKeepsUnhealthyAfterEventsAgeOut(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	tracker := middleware.NewErrorRateTrackerWithClock(livezTestWindow, clock)
+
+	for i := 0; i < livezTestMinFailures; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+
+	api := handlers.NewLivezAPI("/", tracker, livezTestRateThreshold, livezTestMinFailures, livezTestCooldown)
+
+	// Trip the latch.
+	{
+		req, _ := http.NewRequest("GET", "/", nil)
+		resp, err := test.InvokeService(api.Service, "/", *req)
+		assert.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	}
+
+	// Age out the sliding window's events but stay within the cooldown.
+	now = now.Add(livezTestWindow + time.Second)
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	resp, err := test.InvokeService(api.Service, "/", *req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"events aged out but cooldown still active — livez must remain 503 so liveness can fire")
+}
+
+// TestLivez_HealthyAfterCooldownElapses: once the cooldown has elapsed with no
+// further unhealthy evaluations, the latch releases and /livez goes back to
+// 200. This matches the "restart and rejoin" case — a fresh pod should not
+// inherit the previous pod's latch state because the tracker is per-process.
+func TestLivez_HealthyAfterCooldownElapses(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	tracker := middleware.NewErrorRateTrackerWithClock(livezTestWindow, clock)
+
+	for i := 0; i < livezTestMinFailures; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+
+	api := handlers.NewLivezAPI("/", tracker, livezTestRateThreshold, livezTestMinFailures, livezTestCooldown)
+
+	// Trip the latch via a probe call.
+	{
+		req, _ := http.NewRequest("GET", "/", nil)
+		resp, err := test.InvokeService(api.Service, "/", *req)
+		assert.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	}
+
+	// Advance past the cooldown — with no new failures, the latch releases.
+	now = now.Add(livezTestCooldown + time.Second)
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	resp, err := test.InvokeService(api.Service, "/", *req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"after cooldown elapses with no new unhealthy evaluations, livez should release")
+}

--- a/app/handlers/remote_write.go
+++ b/app/handlers/remote_write.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/cloudzero/cloudzero-agent/app/domain"
+	"github.com/cloudzero/cloudzero-agent/app/http/middleware"
 )
 
 // MaxPayloadSize defines the maximum allowed size for Prometheus remote_write requests.
@@ -87,6 +88,23 @@ type RemoteWriteAPI struct {
 	// By maintaining this abstraction, the RemoteWriteAPI can handle HTTP concerns
 	// while keeping the metric processing logic testable and reusable.
 	metrics *domain.MetricCollector
+
+	// errorRateTracker, if non-nil, receives the status code of every response
+	// served by this API so that a readiness health check can observe a
+	// sustained 5xx rate without any code inside this handler needing to know
+	// about the health check itself.
+	errorRateTracker *middleware.ErrorRateTracker
+}
+
+// RemoteWriteAPIOption configures optional behavior on a RemoteWriteAPI.
+type RemoteWriteAPIOption func(*RemoteWriteAPI)
+
+// WithErrorRateTracker attaches an ErrorRateTracker so that response statuses
+// flowing through the API are recorded for use by a health check.
+func WithErrorRateTracker(t *middleware.ErrorRateTracker) RemoteWriteAPIOption {
+	return func(a *RemoteWriteAPI) {
+		a.errorRateTracker = t
+	}
 }
 
 // NewRemoteWriteAPI creates a new HTTP API server for Prometheus remote_write metric ingestion.
@@ -115,13 +133,16 @@ type RemoteWriteAPI struct {
 //
 // The returned RemoteWriteAPI can be registered with the CloudZero Agent HTTP server
 // to begin receiving Prometheus metrics for cost allocation processing.
-func NewRemoteWriteAPI(base string, d *domain.MetricCollector) *RemoteWriteAPI {
+func NewRemoteWriteAPI(base string, d *domain.MetricCollector, opts ...RemoteWriteAPIOption) *RemoteWriteAPI {
 	a := &RemoteWriteAPI{
 		metrics: d,
 		Service: api.Service{
 			APIName: "remotewrite",
 			Mounts:  map[string]*chi.Mux{},
 		},
+	}
+	for _, opt := range opts {
+		opt(a)
 	}
 	a.Mounts[base] = a.Routes()
 	return a
@@ -186,6 +207,9 @@ func (a *RemoteWriteAPI) Register(app server.Server) error {
 // while maintaining high throughput and reliability for CloudZero metric processing.
 func (a *RemoteWriteAPI) Routes() *chi.Mux {
 	r := chi.NewRouter()
+	if a.errorRateTracker != nil {
+		r.Use(middleware.ErrorRateMiddleware(a.errorRateTracker))
+	}
 	r.Post("/", a.PostMetrics)
 	return r
 }
@@ -267,6 +291,17 @@ func (a *RemoteWriteAPI) PostMetrics(w http.ResponseWriter, r *http.Request) {
 	stats, err := a.metrics.PutMetrics(r.Context(), contentType, encodingType, data)
 	if err != nil {
 		log.Ctx(ctx).Err(err).Msg("failed to put metrics")
+		// On 5xx, force HTTP/1.x clients to tear down the TCP connection so
+		// the next request is re-balanced by kube-proxy instead of staying
+		// pinned to a pod that is persistently failing.
+		//
+		// Unfortunately this won't work for HTTP/2 (the `Connection` header
+		// is not allowed on HTTP/2 per RFC 9113 §8.2.2, and HTTP/2 does not
+		// automatically close the underlying TCP connection on 5xx), but
+		// currently all traffic we're seeing from Prometheus is HTTP/1.1.
+		if r.ProtoMajor == 1 {
+			w.Header().Set("Connection", "close")
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/app/handlers/remote_write_test.go
+++ b/app/handlers/remote_write_test.go
@@ -5,6 +5,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/cloudzero/cloudzero-agent/app/domain"
 	"github.com/cloudzero/cloudzero-agent/app/domain/testdata"
 	"github.com/cloudzero/cloudzero-agent/app/handlers"
+	"github.com/cloudzero/cloudzero-agent/app/http/middleware"
 	"github.com/cloudzero/cloudzero-agent/app/types/mocks"
 )
 
@@ -74,4 +76,110 @@ func TestRemoteWriteMethods(t *testing.T) {
 	defer resp.Body.Close()
 
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+// TestRemoteWrite_ConnectionCloseOn500 verifies that when the handler returns
+// a 5xx response, it sets the Connection: close header on HTTP/1.x responses.
+// This forces the client to tear down the TCP connection, so that any
+// subsequent request will be freshly load-balanced by kube-proxy (instead of
+// staying pinned to a pod that is persistently returning errors).
+func TestRemoteWrite_ConnectionCloseOn500(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	storage := mocks.NewMockStore(ctrl)
+
+	cfg := config.Settings{
+		CloudAccountID: "123456789012",
+		Region:         "us-west-2",
+		ClusterName:    "testcluster",
+		Cloudzero: config.Cloudzero{
+			Host:           "api.cloudzero.com",
+			RotateInterval: 10 * time.Minute,
+		},
+	}
+
+	d, err := domain.NewMetricCollector(&cfg, mockClock, storage, nil)
+	assert.NoError(t, err)
+	defer d.Close()
+
+	handler := handlers.NewRemoteWriteAPI(MountBase, d)
+
+	// Force the store to error so PutMetrics returns an error, which makes the
+	// handler respond 500.
+	storage.EXPECT().Put(gomock.Any(), gomock.Any()).Return(errors.New("boom"))
+
+	payload, _, _, err := testdata.BuildWriteRequest(testdata.WriteRequestFixture.Timeseries, nil, nil, nil, nil, "snappy")
+	assert.NoError(t, err)
+
+	req := createRequest("POST", "/", bytes.NewReader(payload))
+
+	q := req.URL.Query()
+	q.Add("region", "us-west-2")
+	q.Add("cloud_account_id", "123456789012")
+	q.Add("cluster_name", "testcluster")
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := test.InvokeService(handler.Service, "/", *req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	// Go's net/http strips Connection: close from resp.Header and surfaces it
+	// as resp.Close. On a 5xx, we want the server to have told the client to
+	// close the TCP connection so the next request is re-balanced by
+	// kube-proxy instead of staying pinned to a failing pod.
+	assert.True(t, resp.Close,
+		"5xx responses on HTTP/1.x should set Connection: close so the client reconnects and is re-balanced")
+}
+
+// TestRemoteWrite_ErrorRateTrackerWiring verifies that when a RemoteWriteAPI
+// is constructed with an ErrorRateTracker, responses flowing through the
+// handler are recorded into the tracker. This is the wiring a health check
+// relies on.
+func TestRemoteWrite_ErrorRateTrackerWiring(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	initialTime := time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC)
+	mockClock := mocks.NewMockClock(initialTime)
+
+	storage := mocks.NewMockStore(ctrl)
+
+	cfg := config.Settings{
+		CloudAccountID: "123456789012",
+		Region:         "us-west-2",
+		ClusterName:    "testcluster",
+		Cloudzero: config.Cloudzero{
+			Host:           "api.cloudzero.com",
+			RotateInterval: 10 * time.Minute,
+		},
+	}
+
+	d, err := domain.NewMetricCollector(&cfg, mockClock, storage, nil)
+	assert.NoError(t, err)
+	defer d.Close()
+
+	tracker := middleware.NewErrorRateTracker(60 * time.Second)
+	handler := handlers.NewRemoteWriteAPI(MountBase, d, handlers.WithErrorRateTracker(tracker))
+
+	// 3 failing requests so we clear the minFailures=3 floor.
+	storage.EXPECT().Put(gomock.Any(), gomock.Any()).Return(errors.New("boom")).Times(3)
+
+	payload, _, _, err := testdata.BuildWriteRequest(testdata.WriteRequestFixture.Timeseries, nil, nil, nil, nil, "snappy")
+	assert.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		req := createRequest("POST", "/", bytes.NewReader(payload))
+		resp, err := test.InvokeService(handler.Service, "/", *req)
+		assert.NoError(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	}
+
+	assert.False(t, tracker.Healthy(0.20, 3),
+		"after 3 × 500 through the RemoteWriteAPI, the tracker should report unhealthy")
 }

--- a/app/http/middleware/errorrate.go
+++ b/app/http/middleware/errorrate.go
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// ErrorRateTracker maintains a bounded, time-windowed view of HTTP response
+// statuses so a health check can ask "is the rate of 5xx responses on this
+// endpoint exceeding some threshold?" — without hair-trigger flapping on a
+// single transient error.
+//
+// The tracker classifies any status code in [500, 600) as a failure. All other
+// codes count as a success.
+//
+// Two views are exposed:
+//
+//   - Healthy: instantaneous rate, ideal for readiness. As soon as failures
+//     age out of the window or are drowned in successes, it returns true.
+//     This lets a pod that's recovered rejoin the Service quickly.
+//   - HealthyWithinCooldown: sticky-latch view, ideal for liveness. Once an
+//     evaluation returns unhealthy, the tracker remembers the time, and
+//     HealthyWithinCooldown keeps returning false until the cooldown has
+//     elapsed since the last unhealthy evaluation. This prevents a
+//     readiness-eviction → no-traffic → window-ages-out → readmit flap loop
+//     and ensures a persistently-bad pod actually gets restarted.
+//
+// Pruning of old events happens lazily on each Record and Healthy call. No
+// background goroutine.
+type ErrorRateTracker struct {
+	mu              sync.Mutex
+	window          time.Duration
+	now             func() time.Time
+	events          []errorRateEvent
+	lastUnhealthyAt time.Time
+}
+
+type errorRateEvent struct {
+	at      time.Time
+	failure bool
+}
+
+// NewErrorRateTracker creates a tracker that retains response events for the
+// given window. Events older than the window are pruned on the next call.
+func NewErrorRateTracker(window time.Duration) *ErrorRateTracker {
+	return NewErrorRateTrackerWithClock(window, time.Now)
+}
+
+// NewErrorRateTrackerWithClock is a test seam for injecting a deterministic
+// clock.
+func NewErrorRateTrackerWithClock(window time.Duration, now func() time.Time) *ErrorRateTracker {
+	return &ErrorRateTracker{
+		window: window,
+		now:    now,
+	}
+}
+
+// Record adds an observation of one HTTP response to the window.
+func (t *ErrorRateTracker) Record(statusCode int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+	t.prune(now)
+	t.events = append(t.events, errorRateEvent{
+		at:      now,
+		failure: isFailureStatus(statusCode),
+	})
+}
+
+// Healthy reports whether the tracker's recent window is within acceptable
+// bounds: the failure rate must be at or below rateThreshold, or the absolute
+// number of failures must be below minFailures. The minFailures floor prevents
+// a single transient error (or a small burst on a quiet endpoint) from
+// marking the endpoint unhealthy.
+//
+// This is the instantaneous view; use it for readiness probes so a pod that
+// has recovered rejoins the Service as soon as its recent responses are
+// healthy again.
+func (t *ErrorRateTracker) Healthy(rateThreshold float64, minFailures int) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.evaluateLocked(rateThreshold, minFailures)
+}
+
+// HealthyWithinCooldown is the sticky-latch view on top of Healthy. It returns
+// false if either:
+//   - the instantaneous evaluation is unhealthy, or
+//   - some earlier evaluation tripped the threshold within the last cooldown.
+//
+// Use this for liveness probes so a pod that has been demonstrated unhealthy
+// cannot look healthy again just because traffic stopped arriving (which
+// would cause the sliding window to empty and Healthy to flip back to true).
+// The latch guarantees that if a pod is persistently bad, liveness eventually
+// fires and the pod is restarted instead of flapping Ready / NotReady.
+func (t *ErrorRateTracker) HealthyWithinCooldown(rateThreshold float64, minFailures int, cooldown time.Duration) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.evaluateLocked(rateThreshold, minFailures) {
+		return false
+	}
+	if t.lastUnhealthyAt.IsZero() {
+		return true
+	}
+	return t.now().Sub(t.lastUnhealthyAt) > cooldown
+}
+
+// evaluateLocked performs the instantaneous health check and, as a side
+// effect, records `now` as the most recent unhealthy evaluation when the
+// verdict is false. Caller must hold t.mu.
+func (t *ErrorRateTracker) evaluateLocked(rateThreshold float64, minFailures int) bool {
+	now := t.now()
+	t.prune(now)
+
+	total := len(t.events)
+	if total == 0 {
+		return true
+	}
+
+	failures := 0
+	for _, e := range t.events {
+		if e.failure {
+			failures++
+		}
+	}
+
+	if failures < minFailures {
+		return true
+	}
+	if float64(failures)/float64(total) <= rateThreshold {
+		return true
+	}
+	t.lastUnhealthyAt = now
+	return false
+}
+
+// prune drops events whose timestamp is older than the window boundary.
+// Caller must hold t.mu.
+func (t *ErrorRateTracker) prune(now time.Time) {
+	cutoff := now.Add(-t.window)
+	i := 0
+	for ; i < len(t.events); i++ {
+		if t.events[i].at.After(cutoff) {
+			break
+		}
+	}
+	t.events = t.events[i:]
+}
+
+// statusCodesEnd marks the first value past the HTTP 5xx range. Any code in
+// [StatusInternalServerError, statusCodesEnd) is treated as a server-side
+// failure by the tracker; anything at or above this (non-standard) is not.
+const statusCodesEnd = 600
+
+func isFailureStatus(code int) bool {
+	return code >= http.StatusInternalServerError && code < statusCodesEnd
+}
+
+// ErrorRateMiddleware returns HTTP middleware that records the outgoing
+// response status on each request into the given ErrorRateTracker. The
+// tracker can then be read by a readiness / liveness health check to decide
+// whether this instance is still serving requests successfully.
+//
+// If the wrapped handler does not call WriteHeader, the response defaults to
+// 200 OK (matching Go's net/http behavior) and is recorded as a non-failure.
+//
+// If the wrapped handler panics, the panic is first recorded as a 500 in the
+// tracker (so the health check sees it) and then re-raised for the outer
+// panic-recovery middleware to translate into an HTTP 500 response. Without
+// this, a panicking endpoint would never register as failing on the health
+// check.
+func ErrorRateMiddleware(tracker *ErrorRateTracker) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			defer func() {
+				if rvr := recover(); rvr != nil {
+					tracker.Record(http.StatusInternalServerError)
+					panic(rvr)
+				}
+			}()
+			next.ServeHTTP(rec, r)
+			tracker.Record(rec.status)
+		})
+	}
+}

--- a/app/http/middleware/errorrate_test.go
+++ b/app/http/middleware/errorrate_test.go
@@ -1,0 +1,397 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware_test
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-obvious/server/healthz"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cloudzero/cloudzero-agent/app/http/middleware"
+)
+
+const (
+	testWindow        = 60 * time.Second
+	testRateThreshold = 0.20
+	testMinFailures   = 3
+)
+
+func TestErrorRateTracker_Empty_IsHealthy(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	assert.True(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"a tracker with no recorded responses should be healthy")
+}
+
+func TestErrorRateTracker_SuccessesOnly_IsHealthy(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	for i := 0; i < 20; i++ {
+		tracker.Record(http.StatusNoContent)
+	}
+
+	assert.True(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"a tracker containing only 2xx responses should be healthy")
+}
+
+func TestErrorRateTracker_SingleFailure_IsHealthyBelowMinFailures(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	tracker.Record(http.StatusInternalServerError)
+
+	assert.True(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"one 5xx response is below the minFailures floor and should not trip unhealthy")
+}
+
+func TestErrorRateTracker_ThreeFailuresOutOfThree_IsUnhealthy(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	for i := 0; i < 3; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+
+	assert.False(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"3 of 3 responses being 5xx is 100% failure rate, well above 20% threshold")
+}
+
+func TestErrorRateTracker_MixedBelowRateThreshold_IsHealthy(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	// 3 failures out of 20 = 15%, below the 20% threshold
+	for i := 0; i < 3; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+	for i := 0; i < 17; i++ {
+		tracker.Record(http.StatusNoContent)
+	}
+
+	assert.True(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"3 failures in 20 requests is 15%, below the 20% threshold")
+}
+
+func TestErrorRateTracker_MixedAboveRateThreshold_IsUnhealthy(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	// 5 failures out of 20 = 25%, above the 20% threshold, at least 3 absolute
+	for i := 0; i < 5; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+	for i := 0; i < 15; i++ {
+		tracker.Record(http.StatusNoContent)
+	}
+
+	assert.False(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"5 failures in 20 requests is 25%, above the 20% threshold")
+}
+
+func TestErrorRateTracker_StatusCodeClassification(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantFail   bool
+	}{
+		{"2xx success", http.StatusNoContent, false},
+		{"3xx redirect", http.StatusMovedPermanently, false},
+		{"4xx client error", http.StatusBadRequest, false},
+		{"5xx server error", http.StatusInternalServerError, true},
+		{"503 unavailable", http.StatusServiceUnavailable, true},
+		{"599", 599, true},
+		{"600 non-standard", 600, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := middleware.NewErrorRateTracker(testWindow)
+
+			// Record three of the code under test so we clear the minFailures floor
+			// if it is classified as a failure.
+			for i := 0; i < 3; i++ {
+				tracker.Record(tt.statusCode)
+			}
+
+			// With 3 of 3 being the code under test:
+			//   - failure code → 100% failure rate → unhealthy
+			//   - non-failure code → 0% failure rate → healthy
+			assert.Equal(t, !tt.wantFail, tracker.Healthy(testRateThreshold, testMinFailures),
+				"status code %d classification mismatch", tt.statusCode)
+		})
+	}
+}
+
+func TestErrorRateTracker_OldEventsAgeOut(t *testing.T) {
+	// Custom clock so we can advance time deterministically.
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	tracker := middleware.NewErrorRateTrackerWithClock(testWindow, clock)
+
+	// Record a burst of failures at t=0
+	for i := 0; i < 10; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+	assert.False(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"immediately after a burst of 5xx, tracker should be unhealthy")
+
+	// Advance past the window — all old events should age out.
+	now = now.Add(testWindow + time.Second)
+
+	assert.True(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"after the window elapses with no new events, tracker should be healthy again")
+}
+
+const testCooldown = 5 * time.Minute
+
+// TestErrorRateTracker_StickyLatch_StaysUnhealthyWithinCooldown verifies that
+// HealthyWithinCooldown keeps reporting unhealthy for `cooldown` after the
+// last evaluation that tripped the threshold, even after the sliding window's
+// own events have aged out. This is the liveness-probe view: once the pod has
+// been demonstrated to fail, don't let it look healthy again until the probe
+// has had time to restart it.
+func TestErrorRateTracker_StickyLatch_StaysUnhealthyWithinCooldown(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	tracker := middleware.NewErrorRateTrackerWithClock(testWindow, clock)
+
+	// Record 3 × 500 — tripping the threshold. Must actually call
+	// HealthyWithinCooldown (or Healthy) once so the latch gets set; the
+	// tracker doesn't speculate about unhealthy state until asked.
+	for i := 0; i < 3; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+	assert.False(t, tracker.HealthyWithinCooldown(testRateThreshold, testMinFailures, testCooldown),
+		"immediately after 3 × 500, HealthyWithinCooldown should be false")
+
+	// Advance past the sliding window. The raw events age out, so
+	// the instantaneous Healthy() view goes back to healthy.
+	now = now.Add(testWindow + time.Second)
+	assert.True(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"after window elapses, instantaneous Healthy() should be true (events aged out)")
+
+	// But the cooldown hasn't elapsed yet — HealthyWithinCooldown should
+	// still latch unhealthy.
+	assert.False(t, tracker.HealthyWithinCooldown(testRateThreshold, testMinFailures, testCooldown),
+		"within cooldown after last unhealthy evaluation, HealthyWithinCooldown must remain false")
+}
+
+// TestErrorRateTracker_StickyLatch_ClearsAfterCooldown verifies the latch
+// releases once the cooldown elapses with no further unhealthy evaluations.
+func TestErrorRateTracker_StickyLatch_ClearsAfterCooldown(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	tracker := middleware.NewErrorRateTrackerWithClock(testWindow, clock)
+
+	for i := 0; i < 3; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+	// Trip the latch.
+	assert.False(t, tracker.HealthyWithinCooldown(testRateThreshold, testMinFailures, testCooldown))
+
+	// Advance past both the window AND the cooldown. No new failures.
+	now = now.Add(testCooldown + time.Second)
+
+	assert.True(t, tracker.HealthyWithinCooldown(testRateThreshold, testMinFailures, testCooldown),
+		"after cooldown elapses with no new unhealthy evaluations, HealthyWithinCooldown should be true")
+}
+
+// TestErrorRateTracker_StickyLatch_RefreshesOnContinuedFailures verifies that
+// each new unhealthy evaluation pushes the latch forward, so a pod that keeps
+// failing never slides back to healthy via the cooldown expiring.
+func TestErrorRateTracker_StickyLatch_RefreshesOnContinuedFailures(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	tracker := middleware.NewErrorRateTrackerWithClock(testWindow, clock)
+
+	// Record failures and trip the latch.
+	for i := 0; i < 3; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+	assert.False(t, tracker.HealthyWithinCooldown(testRateThreshold, testMinFailures, testCooldown))
+
+	// Advance past window, then record fresh failures. The latch's
+	// lastUnhealthyAt should move to "now," so the cooldown is measured from
+	// this newer timestamp.
+	now = now.Add(testWindow + time.Second)
+	for i := 0; i < 3; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+	assert.False(t, tracker.HealthyWithinCooldown(testRateThreshold, testMinFailures, testCooldown),
+		"newly recorded failures refresh the latch")
+
+	// Advance a little less than the cooldown — still within latch.
+	now = now.Add(testCooldown - time.Second)
+	assert.False(t, tracker.HealthyWithinCooldown(testRateThreshold, testMinFailures, testCooldown),
+		"still within cooldown measured from the most recent unhealthy evaluation")
+
+	// Advance past cooldown — latch releases.
+	now = now.Add(2 * time.Second)
+	assert.True(t, tracker.HealthyWithinCooldown(testRateThreshold, testMinFailures, testCooldown))
+}
+
+func TestErrorRateTracker_ConcurrentAccess_DoesNotRace(t *testing.T) {
+	// Meaningful only under `go test -race`, but runs cleanly under normal test too.
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				tracker.Record(http.StatusNoContent)
+				_ = tracker.Healthy(testRateThreshold, testMinFailures)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestErrorRateMiddleware_RecordsStatusCodesIntoTracker(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	// Handler that always returns 500 so we can drive the tracker into an
+	// unhealthy state purely through the middleware.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	wrapped := middleware.ErrorRateMiddleware(tracker)(handler)
+
+	// One failure is below the minFailures floor — tracker should still be healthy.
+	for i := 0; i < 1; i++ {
+		rr := httptestRecorder()
+		req, _ := http.NewRequest("POST", "/", nil)
+		wrapped.ServeHTTP(rr, req)
+	}
+	assert.True(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"one failure recorded through the middleware should be below minFailures")
+
+	// Two more failures — now we have 3 of 3 all failing, clearly over the 20% threshold.
+	for i := 0; i < 2; i++ {
+		rr := httptestRecorder()
+		req, _ := http.NewRequest("POST", "/", nil)
+		wrapped.ServeHTTP(rr, req)
+	}
+	assert.False(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"after 3 failing requests via the middleware, the tracker should be unhealthy")
+}
+
+// TestErrorRateMiddleware_PanicRecordsFailure verifies that when the wrapped
+// handler panics, the panic is still recorded as a 500 in the tracker before
+// it propagates to the outer panic middleware. Otherwise a panicking endpoint
+// would never register as failing on the health check.
+func TestErrorRateMiddleware_PanicRecordsFailure(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("boom")
+	})
+	wrapped := middleware.ErrorRateMiddleware(tracker)(handler)
+
+	// Fire testMinFailures panicking requests. Each must propagate its panic
+	// out past the middleware (we catch it here in the test via recover()),
+	// but the tracker must have logged each as a failure before the panic
+	// escapes — otherwise we'd still see Healthy=true after all three.
+	for i := 0; i < testMinFailures; i++ {
+		func() {
+			defer func() { _ = recover() }()
+			rr := httptestRecorder()
+			req, _ := http.NewRequest("POST", "/", nil)
+			wrapped.ServeHTTP(rr, req)
+		}()
+	}
+
+	assert.False(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"panicking handlers must be recorded as failures so the health check can see them")
+}
+
+func TestErrorRateMiddleware_RecordsDefaultStatusWhenHandlerDoesNotCallWriteHeader(t *testing.T) {
+	// Go's http package treats a handler that writes a body without calling
+	// WriteHeader as an implicit 200. Make sure the tracker agrees — otherwise
+	// "silent" success responses would go uncounted.
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// No WriteHeader, no body; effectively an empty 200 OK response.
+		_ = w
+	})
+	wrapped := middleware.ErrorRateMiddleware(tracker)(handler)
+
+	for i := 0; i < 5; i++ {
+		rr := httptestRecorder()
+		req, _ := http.NewRequest("POST", "/", nil)
+		wrapped.ServeHTTP(rr, req)
+	}
+	assert.True(t, tracker.Healthy(testRateThreshold, testMinFailures),
+		"successful responses (no explicit WriteHeader) should be recorded as non-failures")
+}
+
+// httptestRecorder is a thin wrapper so tests don't need to import httptest
+// at every call site.
+func httptestRecorder() *httptestRR {
+	return &httptestRR{headers: http.Header{}}
+}
+
+type httptestRR struct {
+	status  int
+	headers http.Header
+}
+
+func (r *httptestRR) Header() http.Header         { return r.headers }
+func (r *httptestRR) Write(b []byte) (int, error) { return len(b), nil }
+func (r *httptestRR) WriteHeader(code int)        { r.status = code }
+
+// TestErrorRateTracker_HealthzIntegration verifies the pattern used in
+// collector/main.go: register a health-check function that reads the tracker,
+// and have go-obvious's healthz aggregator report failure when the tracker
+// reports unhealthy. This is the chain that actually makes /healthz return
+// 503 on the running collector.
+//
+// Note: go-obvious's healthz package is a process-wide singleton, so this
+// test uses a unique check name per run to avoid cross-contamination.
+func TestErrorRateTracker_HealthzIntegration(t *testing.T) {
+	tracker := middleware.NewErrorRateTracker(testWindow)
+
+	checkName := "test-errorrate-tracker-integration-" + t.Name()
+	healthz.Register(checkName, func() error {
+		if !tracker.Healthy(testRateThreshold, testMinFailures) {
+			return errors.New("collector 5xx rate exceeds threshold")
+		}
+		return nil
+	})
+
+	// With an empty tracker, the check passes.
+	assert.NoError(t, runNamedCheck(checkName),
+		"with no recorded failures, the registered health check should pass")
+
+	// 3 × 500 → tracker reports unhealthy → check returns error.
+	for i := 0; i < 3; i++ {
+		tracker.Record(http.StatusInternalServerError)
+	}
+	assert.Error(t, runNamedCheck(checkName),
+		"after 3 × 500, the registered health check should fail, which is what makes /healthz return 503")
+}
+
+// runNamedCheck invokes just one of the healthz singleton's registered checks
+// by name, so the integration test doesn't depend on whatever other tests in
+// the process may have registered.
+func runNamedCheck(name string) error {
+	c, ok := healthz.NewHealthz().(interface {
+		Checks() map[string]healthz.HealthCheck
+	})
+	if !ok {
+		return errors.New("healthz singleton did not expose Checks()")
+	}
+	fn, present := c.Checks()[name]
+	if !present {
+		return errors.New("check " + name + " not registered")
+	}
+	return fn()
+}

--- a/helm/templates/aggregator-deploy.yaml
+++ b/helm/templates/aggregator-deploy.yaml
@@ -90,20 +90,27 @@ spec:
               readOnly: true
             - name: aggregator-persistent-storage
               mountPath: {{ .Values.aggregator.mountRoot }}/data
+          {{- $collectorReadiness := mergeOverwrite (deepCopy .Values.aggregator.readinessProbe) (.Values.aggregator.collector.readinessProbe | default (dict)) -}}
+          {{- $collectorLiveness := mergeOverwrite (deepCopy .Values.aggregator.livenessProbe) (.Values.aggregator.collector.livenessProbe | default (dict)) }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.aggregator.collector.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 3
+            initialDelaySeconds: {{ $collectorReadiness.initialDelaySeconds }}
+            periodSeconds: {{ $collectorReadiness.periodSeconds }}
+            failureThreshold: {{ $collectorReadiness.failureThreshold }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              # /livez has sticky-latch semantics — once the collector's
+              # error-rate tracker has observed an unhealthy evaluation, it
+              # stays 503 through the cooldown so liveness actually fires a
+              # restart rather than oscillating Ready / NotReady with
+              # /healthz. Readiness stays on /healthz so recovery is fast.
+              path: /livez
               port: {{ .Values.aggregator.collector.port }}
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            failureThreshold: 3
+            initialDelaySeconds: {{ $collectorLiveness.initialDelaySeconds }}
+            periodSeconds: {{ $collectorLiveness.periodSeconds }}
+            failureThreshold: {{ $collectorLiveness.failureThreshold }}
           {{- include "cloudzero-agent.generateResources" (include "cloudzero-agent.mergeStringOverwrite" (list
               (.Values.components.aggregator.collector.resources | default (dict))
               (.Values.aggregator.collector.resources | default (dict))
@@ -129,20 +136,24 @@ spec:
               readOnly: true
             - name: aggregator-persistent-storage
               mountPath: {{ .Values.aggregator.mountRoot }}/data
+          {{- $shipperReadiness := mergeOverwrite (deepCopy .Values.aggregator.readinessProbe) (.Values.aggregator.shipper.readinessProbe | default (dict)) -}}
+          {{- $shipperLiveness := mergeOverwrite (deepCopy .Values.aggregator.livenessProbe) (.Values.aggregator.shipper.livenessProbe | default (dict)) }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: {{ .Values.aggregator.shipper.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 3
+            initialDelaySeconds: {{ $shipperReadiness.initialDelaySeconds }}
+            periodSeconds: {{ $shipperReadiness.periodSeconds }}
+            failureThreshold: {{ $shipperReadiness.failureThreshold }}
           livenessProbe:
             httpGet:
+              # The shipper has no in-process error-rate tracker, so /livez
+              # would not exist here — stay on /healthz.
               path: /healthz
               port: {{ .Values.aggregator.shipper.port }}
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            failureThreshold: 3
+            initialDelaySeconds: {{ $shipperLiveness.initialDelaySeconds }}
+            periodSeconds: {{ $shipperLiveness.periodSeconds }}
+            failureThreshold: {{ $shipperLiveness.failureThreshold }}
           {{- include "cloudzero-agent.generateResources" (include "cloudzero-agent.mergeStringOverwrite" (list
               (.Values.components.aggregator.shipper.resources | default (dict))
               (.Values.aggregator.shipper.resources | default (dict))

--- a/helm/tests/aggregator_probes_test.yaml
+++ b/helm/tests/aggregator_probes_test.yaml
@@ -1,0 +1,95 @@
+suite: test aggregator probe configuration
+templates:
+  - templates/aggregator-deploy.yaml
+tests:
+  # The collector liveness probe uses /livez (sticky-latch semantics). This
+  # gives a pod returning persistent 5xx time to self-heal via connection
+  # rotation; if it doesn't, /livez stays 503 and the probe restarts the pod.
+  # failureThreshold=10 at periodSeconds=30s = ~5 minutes tolerance.
+  - it: should default collector livenessProbe to /livez with failureThreshold=10
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /livez
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 10
+
+  # The shipper has no in-process error-rate tracker; its /healthz only
+  # reflects basic HTTP server liveness. The longer grace period that the
+  # collector uses doesn't apply — restart it promptly.
+  - it: should default shipper livenessProbe to /healthz with failureThreshold=3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.failureThreshold
+          value: 3
+
+  # Readiness stays aggressive for both containers — we want a broken pod out
+  # of the Service endpoint list quickly.
+  - it: should default collector readinessProbe to /healthz with failureThreshold=3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+
+  - it: should default shipper readinessProbe to /healthz with failureThreshold=3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.failureThreshold
+          value: 3
+
+  # Per-container overrides: collector-specific setting affects collector only.
+  - it: should honor aggregator.collector.livenessProbe.failureThreshold override
+    set:
+      aggregator.collector.livenessProbe.failureThreshold: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.failureThreshold
+          value: 3
+
+  - it: should honor aggregator.shipper.livenessProbe.failureThreshold override
+    set:
+      aggregator.shipper.livenessProbe.failureThreshold: 7
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.failureThreshold
+          value: 7
+
+  # Shared default override: both containers see it unless they individually
+  # override.
+  - it: should honor aggregator.livenessProbe.failureThreshold shared default override
+    set:
+      aggregator.livenessProbe.failureThreshold: 4
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 4
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.failureThreshold
+          value: 3
+
+  - it: should honor aggregator.readinessProbe.failureThreshold shared default override
+    set:
+      aggregator.readinessProbe.failureThreshold: 6
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 6
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.failureThreshold
+          value: 6

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -5593,8 +5593,44 @@
         "collector": {
           "additionalProperties": false,
           "properties": {
+            "livenessProbe": {
+              "additionalProperties": false,
+              "properties": {
+                "failureThreshold": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
             "port": {
               "type": "integer"
+            },
+            "readinessProbe": {
+              "additionalProperties": false,
+              "properties": {
+                "failureThreshold": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object"
             },
             "resources": {
               "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
@@ -5656,6 +5692,24 @@
           "$ref": "#/$defs/com.cloudzero.agent.image",
           "deprecated": true
         },
+        "livenessProbe": {
+          "additionalProperties": false,
+          "properties": {
+            "failureThreshold": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "initialDelaySeconds": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
         "logging": {
           "additionalProperties": false,
           "properties": {
@@ -5683,6 +5737,24 @@
         "profiling": {
           "type": "boolean"
         },
+        "readinessProbe": {
+          "additionalProperties": false,
+          "properties": {
+            "failureThreshold": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "initialDelaySeconds": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
         "reconnectFrequency": {
           "minimum": 0,
           "type": "integer"
@@ -5690,8 +5762,44 @@
         "shipper": {
           "additionalProperties": false,
           "properties": {
+            "livenessProbe": {
+              "additionalProperties": false,
+              "properties": {
+                "failureThreshold": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
             "port": {
               "type": "integer"
+            },
+            "readinessProbe": {
+              "additionalProperties": false,
+              "properties": {
+                "failureThreshold": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "initialDelaySeconds": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object"
             },
             "resources": {
               "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1439,6 +1439,40 @@ properties:
           How frequently to close HTTP connections from clients, to help
           distribute the load across the various collector replicas. 0=never,
           otherwise 1/N probability.
+      readinessProbe:
+        type: object
+        additionalProperties: false
+        description: |
+          Readiness probe configuration applied to both the collector and
+          shipper containers of the aggregator.
+        properties:
+          initialDelaySeconds:
+            type: integer
+            minimum: 0
+          periodSeconds:
+            type: integer
+            minimum: 1
+          failureThreshold:
+            type: integer
+            minimum: 1
+      livenessProbe:
+        type: object
+        additionalProperties: false
+        description: |
+          Liveness probe configuration applied to both the collector and
+          shipper containers of the aggregator. Liveness is deliberately more
+          tolerant than readiness so a pod has time to self-heal before being
+          restarted.
+        properties:
+          initialDelaySeconds:
+            type: integer
+            minimum: 0
+          periodSeconds:
+            type: integer
+            minimum: 1
+          failureThreshold:
+            type: integer
+            minimum: 1
       image:
         deprecated: true
         $ref: "#/$defs/com.cloudzero.agent.image"
@@ -1516,6 +1550,38 @@ properties:
           # Resource requirements for the collector
           resources:
             $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+          readinessProbe:
+            type: object
+            additionalProperties: false
+            description: |
+              Per-container overrides for the collector readiness probe,
+              merged on top of aggregator.readinessProbe.
+            properties:
+              initialDelaySeconds:
+                type: integer
+                minimum: 0
+              periodSeconds:
+                type: integer
+                minimum: 1
+              failureThreshold:
+                type: integer
+                minimum: 1
+          livenessProbe:
+            type: object
+            additionalProperties: false
+            description: |
+              Per-container overrides for the collector liveness probe,
+              merged on top of aggregator.livenessProbe.
+            properties:
+              initialDelaySeconds:
+                type: integer
+                minimum: 0
+              periodSeconds:
+                type: integer
+                minimum: 1
+              failureThreshold:
+                type: integer
+                minimum: 1
       shipper:
         type: object
         additionalProperties: false
@@ -1530,6 +1596,38 @@ properties:
           # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
           resources:
             $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
+          readinessProbe:
+            type: object
+            additionalProperties: false
+            description: |
+              Per-container overrides for the shipper readiness probe,
+              merged on top of aggregator.readinessProbe.
+            properties:
+              initialDelaySeconds:
+                type: integer
+                minimum: 0
+              periodSeconds:
+                type: integer
+                minimum: 1
+              failureThreshold:
+                type: integer
+                minimum: 1
+          livenessProbe:
+            type: object
+            additionalProperties: false
+            description: |
+              Per-container overrides for the shipper liveness probe,
+              merged on top of aggregator.livenessProbe.
+            properties:
+              initialDelaySeconds:
+                type: integer
+                minimum: 0
+              periodSeconds:
+                type: integer
+                minimum: 1
+              failureThreshold:
+                type: integer
+                minimum: 1
       # Node selector for the aggregator
       nodeSelector:
         $ref: "#/$defs/io.k8s.api.core.v1.PodSpec/properties/nodeSelector"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1578,6 +1578,24 @@ aggregator:
   # load across the various collector replicas. 0=never, otherwise 1/N
   # probability.
   reconnectFrequency: 16
+  # Kubernetes readiness probe configuration for both the collector and shipper
+  # containers. Readiness is kept aggressive so that a pod returning 5xx is
+  # removed from the Service endpoint list quickly (within ~30s at defaults).
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+  # Kubernetes liveness probe configuration for both the collector and shipper
+  # containers. Liveness is deliberately more tolerant than readiness: a pod
+  # that the health check reports as unhealthy gets removed from the Service
+  # quickly, but only restarted after sustained failure. This gives the pod a
+  # chance to self-heal (for example via connection rotation) before
+  # Kubernetes kills it. At periodSeconds=30, failureThreshold=10 yields ~5
+  # minutes of sustained unhealth before restart.
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    failureThreshold: 10
   # Container image configuration for the aggregator components.
   #
   # Deprecated. Please use components.aggregator.image instead.
@@ -1683,6 +1701,11 @@ aggregator:
       limits:
         memory: ""
         cpu: ""
+    # Per-container probe overrides merged on top of aggregator.readinessProbe
+    # and aggregator.livenessProbe. Empty by default — the collector uses the
+    # shared aggregator probe settings.
+    readinessProbe: {}
+    livenessProbe: {}
   # Configuration for the shipper component of the aggregator.
   shipper:
     # Port that the shipper listens on for internal communication.
@@ -1700,6 +1723,13 @@ aggregator:
       limits:
         memory: ""
         cpu: ""
+    # Per-container probe overrides merged on top of aggregator.readinessProbe
+    # and aggregator.livenessProbe. The shipper does not run the error-rate
+    # tracker that extends the collector's restart budget, so its liveness
+    # uses a tighter failureThreshold.
+    readinessProbe: {}
+    livenessProbe:
+      failureThreshold: 3
   # Node selector configuration for the aggregator pods.
   #
   # See the Kubernetes documentation for details:

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -915,7 +915,9 @@ data:
         sendInterval: 10m
         sendTimeout: 120s
       collector:
+        livenessProbe: {}
         port: 8080
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -940,6 +942,10 @@ data:
         pullPolicy: null
         repository: null
         tag: null
+      livenessProbe:
+        failureThreshold: 10
+        initialDelaySeconds: 30
+        periodSeconds: 30
       logging:
         capture: true
         level: info
@@ -947,9 +953,16 @@ data:
       name: null
       nodeSelector: {}
       profiling: false
+      readinessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 10
+        periodSeconds: 10
       reconnectFrequency: 16
       shipper:
+        livenessProbe:
+          failureThreshold: 3
         port: 8081
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -2847,11 +2860,16 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /healthz
+              # /livez has sticky-latch semantics — once the collector's
+              # error-rate tracker has observed an unhealthy evaluation, it
+              # stays 503 through the cooldown so liveness actually fires a
+              # restart rather than oscillating Ready / NotReady with
+              # /healthz. Readiness stays on /healthz so recovery is fast.
+              path: /livez
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
-            failureThreshold: 3
+            failureThreshold: 10
           resources:
             limits:
               cpu: 2000m
@@ -2893,6 +2911,8 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
+              # The shipper has no in-process error-rate tracker, so /livez
+              # would not exist here — stay on /healthz.
               path: /healthz
               port: 8081
             initialDelaySeconds: 30

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -831,7 +831,9 @@ data:
         sendInterval: 10m
         sendTimeout: 120s
       collector:
+        livenessProbe: {}
         port: 8080
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -856,6 +858,10 @@ data:
         pullPolicy: null
         repository: null
         tag: null
+      livenessProbe:
+        failureThreshold: 10
+        initialDelaySeconds: 30
+        periodSeconds: 30
       logging:
         capture: true
         level: info
@@ -863,9 +869,16 @@ data:
       name: null
       nodeSelector: {}
       profiling: false
+      readinessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 10
+        periodSeconds: 10
       reconnectFrequency: 16
       shipper:
+        livenessProbe:
+          failureThreshold: 3
         port: 8081
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -2741,11 +2754,16 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /healthz
+              # /livez has sticky-latch semantics — once the collector's
+              # error-rate tracker has observed an unhealthy evaluation, it
+              # stays 503 through the cooldown so liveness actually fires a
+              # restart rather than oscillating Ready / NotReady with
+              # /healthz. Readiness stays on /healthz so recovery is fast.
+              path: /livez
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
-            failureThreshold: 3
+            failureThreshold: 10
           resources:
             limits:
               cpu: 2000m
@@ -2787,6 +2805,8 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
+              # The shipper has no in-process error-rate tracker, so /livez
+              # would not exist here — stay on /healthz.
               path: /healthz
               port: 8081
             initialDelaySeconds: 30

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -919,7 +919,9 @@ data:
         sendInterval: 10m
         sendTimeout: 120s
       collector:
+        livenessProbe: {}
         port: 8080
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -944,6 +946,10 @@ data:
         pullPolicy: null
         repository: null
         tag: null
+      livenessProbe:
+        failureThreshold: 10
+        initialDelaySeconds: 30
+        periodSeconds: 30
       logging:
         capture: true
         level: info
@@ -951,9 +957,16 @@ data:
       name: null
       nodeSelector: {}
       profiling: false
+      readinessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 10
+        periodSeconds: 10
       reconnectFrequency: 16
       shipper:
+        livenessProbe:
+          failureThreshold: 3
         port: 8081
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -3024,11 +3037,16 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /healthz
+              # /livez has sticky-latch semantics — once the collector's
+              # error-rate tracker has observed an unhealthy evaluation, it
+              # stays 503 through the cooldown so liveness actually fires a
+              # restart rather than oscillating Ready / NotReady with
+              # /healthz. Readiness stays on /healthz so recovery is fast.
+              path: /livez
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
-            failureThreshold: 3
+            failureThreshold: 10
           resources:
             limits:
               cpu: 2000m
@@ -3070,6 +3088,8 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
+              # The shipper has no in-process error-rate tracker, so /livez
+              # would not exist here — stay on /healthz.
               path: /healthz
               port: 8081
             initialDelaySeconds: 30

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -846,7 +846,9 @@ data:
         sendInterval: 10m
         sendTimeout: 120s
       collector:
+        livenessProbe: {}
         port: 8080
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -871,6 +873,10 @@ data:
         pullPolicy: null
         repository: null
         tag: null
+      livenessProbe:
+        failureThreshold: 10
+        initialDelaySeconds: 30
+        periodSeconds: 30
       logging:
         capture: true
         level: info
@@ -878,9 +884,16 @@ data:
       name: null
       nodeSelector: {}
       profiling: false
+      readinessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 10
+        periodSeconds: 10
       reconnectFrequency: 16
       shipper:
+        livenessProbe:
+          failureThreshold: 3
         port: 8081
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -2756,11 +2769,16 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /healthz
+              # /livez has sticky-latch semantics — once the collector's
+              # error-rate tracker has observed an unhealthy evaluation, it
+              # stays 503 through the cooldown so liveness actually fires a
+              # restart rather than oscillating Ready / NotReady with
+              # /healthz. Readiness stays on /healthz so recovery is fast.
+              path: /livez
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
-            failureThreshold: 3
+            failureThreshold: 10
           resources:
             limits:
               cpu: 2000m
@@ -2802,6 +2820,8 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
+              # The shipper has no in-process error-rate tracker, so /livez
+              # would not exist here — stay on /healthz.
               path: /healthz
               port: 8081
             initialDelaySeconds: 30

--- a/tests/helm/template/kubestate.yaml
+++ b/tests/helm/template/kubestate.yaml
@@ -882,7 +882,9 @@ data:
         sendInterval: 10m
         sendTimeout: 120s
       collector:
+        livenessProbe: {}
         port: 8080
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -907,6 +909,10 @@ data:
         pullPolicy: null
         repository: null
         tag: null
+      livenessProbe:
+        failureThreshold: 10
+        initialDelaySeconds: 30
+        periodSeconds: 30
       logging:
         capture: true
         level: info
@@ -914,9 +920,16 @@ data:
       name: null
       nodeSelector: {}
       profiling: false
+      readinessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 10
+        periodSeconds: 10
       reconnectFrequency: 16
       shipper:
+        livenessProbe:
+          failureThreshold: 3
         port: 8081
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -2297,11 +2310,16 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /healthz
+              # /livez has sticky-latch semantics — once the collector's
+              # error-rate tracker has observed an unhealthy evaluation, it
+              # stays 503 through the cooldown so liveness actually fires a
+              # restart rather than oscillating Ready / NotReady with
+              # /healthz. Readiness stays on /healthz so recovery is fast.
+              path: /livez
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
-            failureThreshold: 3
+            failureThreshold: 10
           resources:
             limits:
               cpu: 2000m
@@ -2343,6 +2361,8 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
+              # The shipper has no in-process error-rate tracker, so /livez
+              # would not exist here — stay on /healthz.
               path: /healthz
               port: 8081
             initialDelaySeconds: 30

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -846,7 +846,9 @@ data:
         sendInterval: 10m
         sendTimeout: 120s
       collector:
+        livenessProbe: {}
         port: 8080
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -871,6 +873,10 @@ data:
         pullPolicy: null
         repository: null
         tag: null
+      livenessProbe:
+        failureThreshold: 10
+        initialDelaySeconds: 30
+        periodSeconds: 30
       logging:
         capture: true
         level: info
@@ -878,9 +884,16 @@ data:
       name: null
       nodeSelector: {}
       profiling: false
+      readinessProbe:
+        failureThreshold: 3
+        initialDelaySeconds: 10
+        periodSeconds: 10
       reconnectFrequency: 16
       shipper:
+        livenessProbe:
+          failureThreshold: 3
         port: 8081
+        readinessProbe: {}
         resources:
           limits:
             cpu: ""
@@ -2756,11 +2769,16 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /healthz
+              # /livez has sticky-latch semantics — once the collector's
+              # error-rate tracker has observed an unhealthy evaluation, it
+              # stays 503 through the cooldown so liveness actually fires a
+              # restart rather than oscillating Ready / NotReady with
+              # /healthz. Readiness stays on /healthz so recovery is fast.
+              path: /livez
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
-            failureThreshold: 3
+            failureThreshold: 10
           resources:
             limits:
               cpu: 2000m
@@ -2802,6 +2820,8 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
+              # The shipper has no in-process error-rate tracker, so /livez
+              # would not exist here — stay on /healthz.
               path: /healthz
               port: 8081
             initialDelaySeconds: 30


### PR DESCRIPTION
CP-40663 fixed a specific DiskStore bug but surfaced a broader gap: nothing in the aggregator detects or recovers from a pod stuck in a persistent 5xx state. /healthz registered zero checks and always returned 200, so readiness and liveness probes never fired. A broken pod stayed in the Service's endpoint list until a human intervened.

Functional Change:

Before: a pod returning 5xx stayed in rotation and client connections stayed pinned to it. Recovery depended on a probabilistic 1-in-16 Connection: close on success responses; on one customer's cluster this took about an hour.

After: /healthz returns 503 when the /collector 5xx rate exceeds 20% with at least 3 absolute failures in the last 60s. Readiness fails within ~30s, pulling the pod from the Service. A new /livez endpoint applies a 5-minute sticky latch on top of the same tracker, so liveness fires a pod restart if the broken state persists — even if readiness eviction silences new traffic and the instantaneous /healthz view would otherwise flap back to healthy. Every 5xx response sets Connection: close so clients reconnect and are re-balanced immediately.

Implementation:

1. ErrorRateTracker in app/http/middleware maintains a thread-safe, time-windowed view of HTTP response statuses. It exposes two views:

   - Healthy(rateThreshold, minFailures): instantaneous, suitable for readiness. Returns true as soon as failures age out of the window.
   - HealthyWithinCooldown(..., cooldown): sticky-latch view for liveness. Records the time of each unhealthy evaluation and stays false for cooldown after the most recent one, even if events have aged out.

2. ErrorRateMiddleware wraps the /collector handler and records each response status into the tracker. A deferred recover also records panics as 500s before re-raising so panicking handlers still register on the health check.

3. NewRemoteWriteAPI gains a WithErrorRateTracker option. The collector main.go owns the tracker, passes it to the API, registers a go-obvious/server healthz check that reads tracker.Healthy, and mounts a new LivezAPI at /livez that reads tracker.HealthyWithinCooldown with a 5-minute cooldown.

4. remote_write.go sets Connection: close on the 5xx path so a client's pinned TCP session is torn down immediately rather than waiting for the 1-in-16 success-path rotation.

5. The Helm chart adds aggregator.readinessProbe and aggregator.livenessProbe as shared defaults, plus per-container override slots under aggregator.collector and aggregator.shipper. Collector liveness targets /livez with failureThreshold=10; shipper liveness targets /healthz with failureThreshold=3, since the shipper has no in-process error-rate tracker and a longer restart grace would be unwarranted.

Validation:

- ErrorRateTracker unit tests cover instantaneous evaluation, sticky latch within cooldown, latch release after cooldown, latch refresh on continued failures, status code classification, aging out of old events, and concurrent access.
- ErrorRateMiddleware tests verify status recording, the default-200 case, and that panics still register as 500s in the tracker.
- LivezAPI tests verify 200 on empty tracker, 503 on instantaneous unhealth, continued 503 after events age out but within cooldown, and return to 200 after cooldown elapses.
- TestRemoteWrite_ConnectionCloseOn500 asserts resp.Close on 5xx.
- TestRemoteWrite_ErrorRateTrackerWiring verifies the tracker receives responses when attached via the new option.
- helm/tests/aggregator_probes_test.yaml covers collector/shipper default split (/livez vs /healthz, ft=10 vs ft=3), per-container overrides, and shared-default overrides.
- make lint passes; make test passes across all Go packages; make helm-test passes 554/554 across 67 suites.
