### PR TITLE
CP-42919: bump bundled Alloy to v1.16.2 (Go 1.26.4, clears stdlib CVEs)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=gomod-$TARGETPLATFORM \
 FROM gcr.io/distroless/static-debian12:debug@sha256:46fcf1fa44d251b0944ba4b98ef4bbd266e33034e46489dbf92f680ca4917451 AS certs
 
 # Stage 5: Extract Alloy binary from CloudZero Alloy image
-FROM ghcr.io/cloudzero/alloy:v1.16.1 AS alloy
+FROM ghcr.io/cloudzero/alloy:v1.16.2 AS alloy
 
 # Stage 6: Final runtime image
 # Note: For debugging, you can temporarily change the image used for building by


### PR DESCRIPTION
## Summary

Bumps the bundled Alloy image in `docker/Dockerfile` from `v1.16.1` to `v1.16.2`.

## Why

The agent image's Grype scan was failing on 2 High-severity findings, both
originating **only** from the bundled `/app/cloudzero-alloy` binary:

- `CVE-2026-42504` (stdlib)
- `GO-2026-5038` (stdlib)

These come from Alloy `v1.16.1` having been built with **go1.26.3**. The agent's
own binaries are already built with go1.26.4 and scan clean. Alloy `v1.16.2`
(cloudzero fork sync onto upstream v1.16.2) is built with **go1.26.4** and scans
completely clean.

## Verification

`ghcr.io/cloudzero/alloy:v1.16.2` (digest `sha256:e6895f4ad15e…`, multi-arch)
scanned **by digest**:

```
grype ghcr.io/cloudzero/alloy@sha256:e6895f4ad15e... → No vulnerabilities found
```

(Scanning by digest avoids grype's stale tag cache.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)