### PR TITLE
CP-43292: make the webhook server optional

### DIFF
--- a/.github/workflows/test-matrix-k8s.yaml
+++ b/.github/workflows/test-matrix-k8s.yaml
@@ -122,6 +122,13 @@ jobs:
           command: |
             make install-tools V=1
 
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Complete Chart Tests
         env:
           CLOUDZERO_DEV_API_KEY: ${{ secrets.CLOUDZERO_DEV_API_KEY }}
@@ -134,8 +141,29 @@ jobs:
           # Create cluster configuration files for this test run
           cp clusters/kind.yaml "clusters/$CLUSTER_NAME.yaml"
           cp clusters/kind-overrides.yaml "clusters/$CLUSTER_NAME-overrides.yaml"
-          # Run the complete test workflow using Kind
-          make kind-test "CLUSTER_NAME=$CLUSTER_NAME" V=1
+
+          # The chart (and the alloy-clustered-test suite) install the agent image
+          # at <prod-repo>:dev-<sha>, which is NOT published for a PR. Pull the
+          # freshly-built (untested) image for this matrix arch, retag it as the
+          # tag the chart installs, and kind-load it into the node so pods can start
+          # (chart imagePullPolicy is IfNotPresent). Pull single-arch: kind cannot
+          # load a multi-arch manifest list.
+          SRC="${{ inputs.image-repo }}/${{ inputs.image-path }}:${{ inputs.image-tag }}"
+          DST="ghcr.io/cloudzero/cloudzero-agent:dev-$(git rev-parse HEAD)"
+          docker pull --platform "${{ matrix.kver.platform }}" "$SRC"
+          docker tag "$SRC" "$DST"
+
+          # Run the test workflow phases explicitly so the image is loaded between
+          # cluster creation and chart install (the monolithic `kind-test` target
+          # does not expose that seam).
+          test_status=0
+          make kind-up "CLUSTER_NAME=$CLUSTER_NAME" V=1
+          make kind-load "CLUSTER_NAME=$CLUSTER_NAME" LOAD_IMAGE="$DST" V=1
+          make helm-install-current helm-wait "CLUSTER_NAME=$CLUSTER_NAME" V=1
+          make helm-test-kuttl "CLUSTER_NAME=$CLUSTER_NAME" V=1 || test_status=$?
+          make helm-uninstall "CLUSTER_NAME=$CLUSTER_NAME" V=1 || true
+          make kind-down "CLUSTER_NAME=$CLUSTER_NAME" V=1 || true
+          exit $test_status
 
       - name: Set version output
         id: set-output
@@ -250,6 +278,13 @@ jobs:
           echo "Contents:"
           cat "$EXTRA_OVERRIDES_FILE"
 
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Chart Tests with Specialized Configuration
         env:
           CLOUDZERO_DEV_API_KEY: ${{ secrets.CLOUDZERO_DEV_API_KEY }}
@@ -263,8 +298,25 @@ jobs:
           # Create cluster configuration files for this test run
           cp clusters/kind.yaml "clusters/$CLUSTER_NAME.yaml"
           cp clusters/kind-overrides.yaml "clusters/$CLUSTER_NAME-overrides.yaml"
-          # Run the complete test workflow using Kind with extra overrides
-          make kind-test "CLUSTER_NAME=$CLUSTER_NAME" "HELM_EXTRA_OVERRIDES=$HELM_EXTRA_OVERRIDES" V=1
+
+          # Make the freshly-built (untested) agent image available to the kind
+          # node under the tag the chart installs (see the version-matrix job for
+          # the full rationale). Pull single-arch so kind can load it.
+          SRC="${{ inputs.image-repo }}/${{ inputs.image-path }}:${{ inputs.image-tag }}"
+          DST="ghcr.io/cloudzero/cloudzero-agent:dev-$(git rev-parse HEAD)"
+          docker pull --platform linux/amd64 "$SRC"
+          docker tag "$SRC" "$DST"
+
+          # Run the test workflow phases explicitly so the image is loaded between
+          # cluster creation and chart install.
+          test_status=0
+          make kind-up "CLUSTER_NAME=$CLUSTER_NAME" V=1
+          make kind-load "CLUSTER_NAME=$CLUSTER_NAME" LOAD_IMAGE="$DST" V=1
+          make helm-install-current helm-wait "CLUSTER_NAME=$CLUSTER_NAME" "HELM_EXTRA_OVERRIDES=$HELM_EXTRA_OVERRIDES" V=1
+          make helm-test-kuttl "CLUSTER_NAME=$CLUSTER_NAME" "HELM_EXTRA_OVERRIDES=$HELM_EXTRA_OVERRIDES" V=1 || test_status=$?
+          make helm-uninstall "CLUSTER_NAME=$CLUSTER_NAME" "HELM_EXTRA_OVERRIDES=$HELM_EXTRA_OVERRIDES" V=1 || true
+          make kind-down "CLUSTER_NAME=$CLUSTER_NAME" V=1 || true
+          exit $test_status
 
       - name: Set config output
         id: set-output

--- a/Makefile
+++ b/Makefile
@@ -430,6 +430,16 @@ CLUSTER_NAME              ?= kind
 kind-up: # Create kind cluster for testing
 kind-up: tests/kuttl/kubeconfig
 
+# kind-load - Load a locally-available docker image into the kind cluster's node
+# so pods can use it without pulling from a registry (chart imagePullPolicy is
+# IfNotPresent). Used by CI to make the freshly-built (untested) agent image
+# available under the tag the chart installs. Set LOAD_IMAGE to the image ref.
+.PHONY: kind-load
+kind-load: ## Load LOAD_IMAGE into the kind cluster (uses CLUSTER_NAME)
+	$(if $(LOAD_IMAGE),,$(error LOAD_IMAGE must be set, e.g. make kind-load LOAD_IMAGE=repo/image:tag))
+	$(call LOG,KIND,load $(LOAD_IMAGE) into $(CLUSTER_NAME))
+	$(Q)$(KIND) load docker-image "$(LOAD_IMAGE)" --name $(CLUSTER_NAME)
+
 .PHONY: kind-down
 kind-down: ## Delete kind cluster and cleanup
 	$(call LOG,KIND,delete cluster $(CLUSTER_NAME))

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -776,6 +776,16 @@ components:
           cpu: "2000m"
   # Settings for the webhook server.
   webhookServer:
+    # Whether to run the webhook server (admission controller for resource
+    # metadata). Ternary:
+    #   true  - always run the webhook server
+    #   false - never run it (e.g. when the in-agent KubeState plugin supplies
+    #           metrics and you cannot deploy an admission webhook)
+    #   auto  - let the chart decide. Currently equivalent to `true`; a future
+    #           release will make `auto` follow the KubeState configuration.
+    # Note: if insightsController.enabled is explicitly set (true/false), it takes
+    # precedence over this field for backward compatibility.
+    enabled: auto
     replicas: null
     # Horizontal Pod Autoscaler configuration for the webhook server.
     #
@@ -1293,11 +1303,11 @@ server:
 # Configuration for the webhook server (née Insights Controller), which collects
 # and processes Kubernetes resource metadata for cost attribution and analysis.
 insightsController:
-  # Whether to enable the insights controller.
-  #
-  # It is strongly recommended that this feature be enabled as it provides
-  # important functionality.
-  enabled: true
+  # **DEPRECATED**: use `components.webhookServer.enabled` instead. Retained for
+  # backward compatibility: when explicitly set (true/false) this value takes
+  # precedence over components.webhookServer.enabled. Leave unset (null) to use
+  # the new field.
+  enabled: null
   # Configuration for collecting labels from Kubernetes resources.
   labels:
     # Whether to enable collection of specific labels for cost attribution

--- a/helm/templates/_alloy_helpers.tpl
+++ b/helm/templates/_alloy_helpers.tpl
@@ -159,7 +159,7 @@ Usage: {{ include "cloudzero-agent.alloy.riverConfig" . }}
 {{- include "cloudzero-agent.alloy.scrapeCAdvisor" . }}
 {{- end }}
 
-{{- if .Values.insightsController.enabled }}
+{{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
 {{ include "cloudzero-agent.alloy.scrapeWebhook" . }}
 {{- end }}
 

--- a/helm/templates/_webhook_helpers.tpl
+++ b/helm/templates/_webhook_helpers.tpl
@@ -1,0 +1,38 @@
+{{/*
+Webhook server enablement resolver.
+
+Single source of truth for whether the admission webhook server (née Insights
+Controller) and its supporting resources should be rendered.
+
+Precedence:
+  1. Legacy insightsController.enabled, when explicitly set (a bool), wins.
+     (Its default is null, so an explicit true/false is distinguishable.)
+  2. Otherwise components.webhookServer.enabled (true | false | "auto").
+     "auto" and unset both currently resolve to enabled (true). A future
+     release will make "auto" follow the KubeState configuration; that is the
+     only line to change here when promoting that behavior.
+
+Returns "true" (truthy) when enabled, or "" (empty/falsy) when disabled —
+the standard truthy-string / empty-string idiom used by the chart's other
+boolean-resolving helpers.
+
+Usage: {{ if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}...{{ end }}
+*/}}
+{{- define "cloudzero-agent.webhookServer.enabled" -}}
+{{- $ic := .Values.insightsController.enabled -}}
+{{- if not (kindIs "invalid" $ic) -}}
+  {{- /* Legacy precedence: explicitly set insightsController.enabled wins. */ -}}
+  {{- if $ic -}}{{- true -}}{{- end -}}
+{{- else -}}
+  {{- $w := .Values.components.webhookServer.enabled -}}
+  {{- if kindIs "invalid" $w -}}
+    {{- /* unset = auto */ -}}
+    {{- true -}}
+  {{- else if eq (toString $w) "auto" -}}
+    {{- /* auto = true for now; future: follow KubeState */ -}}
+    {{- true -}}
+  {{- else if eq (toString $w) "true" -}}
+    {{- true -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/agent-cm.yaml
+++ b/helm/templates/agent-cm.yaml
@@ -51,9 +51,9 @@ data:
       {{- include "cloudzero-agent.prometheus.scrapeCAdvisor" (dict "root" . "scrapeLocalNodeOnly" false) | nindent 6 }}
       {{- end }}{{/* End cadvisor scrape job */}}
 
-      {{- if .Values.insightsController.enabled }}
+      {{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
       {{- include "cloudzero-agent.prometheus.scrapeWebhookJob" . | nindent 6 }}
-      {{- end }}{{/* End webhook (insightsController) scrape job */}}
+      {{- end }}{{/* End webhook (webhookServer) scrape job */}}
 
       {{- if .Values.prometheusConfig.scrapeJobs.aggregator.enabled }}
       {{- include "cloudzero-agent.prometheus.scrapeAggregator" . | nindent 6 }}

--- a/helm/templates/agent-issuer.yaml
+++ b/helm/templates/agent-issuer.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.insightsController.tls.useCertManager }}
+{{- if and (eq (include "cloudzero-agent.webhookServer.enabled" .) "true") .Values.insightsController.tls.useCertManager }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/helm/templates/backfill-job.yaml
+++ b/helm/templates/backfill-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.insightsController.enabled }}
+{{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
 {{ $backFillValues := (include "cloudzero-agent.backFill" . | fromYaml) }}
 {{- if $backFillValues.enabled }}
 {{- /*

--- a/helm/templates/config-loader-job.yaml
+++ b/helm/templates/config-loader-job.yaml
@@ -82,7 +82,13 @@ spec:
             - --config-validator
             - /cloudzero/config/validator/validator.yml
             - --config-webhook
+            {{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
             - {{ include "cloudzero-agent.insightsController.configurationMountPath" . }}/server-config.yaml
+            {{- else }}
+            {{- /* Keep the flag with an empty value (do NOT omit it): the loader's
+                   NewSettings errors on a nil/missing arg, but tolerates "". See CP-43292. */}}
+            - ""
+            {{- end }}
             - --config-aggregator
             - {{ .Values.aggregator.mountRoot }}/config/config.yml
           {{- include "cloudzero-agent.generateResources" (include "cloudzero-agent.mergeStringOverwrite" (list
@@ -101,8 +107,10 @@ spec:
               mountPath: /etc/config/prometheus/configmaps/
             - name: config-validator
               mountPath: /cloudzero/config/validator # validator.yml
+            {{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
             - name: config-webhook
               mountPath: {{ include "cloudzero-agent.insightsController.configurationMountPath" . }} # server-config.yaml
+            {{- end }}
             - name: config-aggregator
               mountPath: {{ .Values.aggregator.mountRoot }}/config # config.yaml
             - name: aggregator-persistent-storage
@@ -120,9 +128,11 @@ spec:
         - name: config-validator
           configMap:
             name: {{ include "cloudzero-agent.validatorConfigMapName" . }}
+        {{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
         - name: config-webhook
           configMap:
             name: {{ include "cloudzero-agent.webhookConfigMapName" . }}
+        {{- end }}
         - name: config-aggregator
           configMap:
             name: {{ include "cloudzero-agent.aggregator.name" . }}

--- a/helm/templates/init-cert-clusterrole.yaml
+++ b/helm/templates/init-cert-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initCertJob.rbac.create }}
+{{- if and (eq (include "cloudzero-agent.webhookServer.enabled" .) "true") .Values.initCertJob.rbac.create }}
 # ClusterRole for the init-cert Job
 #
 # This ClusterRole grants the init-cert job (which runs during

--- a/helm/templates/init-cert-clusterrolebinding.yaml
+++ b/helm/templates/init-cert-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initCertJob.rbac.create }}
+{{- if and (eq (include "cloudzero-agent.webhookServer.enabled" .) "true") .Values.initCertJob.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/templates/init-cert-job.yaml
+++ b/helm/templates/init-cert-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.insightsController.enabled }}
+{{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
 {{- if and .Values.insightsController.tls.secret.create (not .Values.insightsController.tls.useCertManager) .Values.initCertJob.enabled (not .Values.insightsController.tls.crt) (not .Values.insightsController.tls.key) }}
 apiVersion: batch/v1
 kind: Job

--- a/helm/templates/prometheusrule.yaml
+++ b/helm/templates/prometheusrule.yaml
@@ -83,6 +83,7 @@ spec:
 
         See: Monitoring the CloudZero Agent > Monitoring Webhook Event Processing
         */}}
+        {{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
         - alert: CloudZeroWebhookDown
           expr: |
             up{job="{{ include "cloudzero-agent.serviceName" . }}"} == 0
@@ -95,6 +96,7 @@ spec:
           annotations:
             summary: "CloudZero Webhook server is down"
             description: "The webhook server has been down for 5 minutes. Kubernetes resource metadata is not being captured for cost attribution."
+        {{- end }}
 
         {{/*
         CloudZeroAggregatorDown: The aggregator pod (containing the collector
@@ -151,6 +153,7 @@ spec:
         Uses czo_webhook_types_total from app/domain/webhook/webhook.go.
         See: Monitoring the CloudZero Agent > Monitoring Webhook TLS Certificate Health
         */}}
+        {{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
         - alert: CloudZeroWebhookNoEvents
           expr: rate(czo_webhook_types_total{job="{{ include "cloudzero-agent.serviceName" . }}"}[30m]) == 0
           for: 30m
@@ -160,6 +163,7 @@ spec:
           annotations:
             summary: "CloudZero Webhook receiving zero admission events"
             description: "The webhook has not received any Kubernetes admission requests for 30 minutes despite being running. The most common cause is a TLS certificate mismatch. Compare the caBundle in the ValidatingWebhookConfiguration with the ca.crt in the webhook TLS secret."
+        {{- end }}
 
         {{/*
         ===== Warning Alerts =====
@@ -199,6 +203,7 @@ spec:
 
         See: Monitoring the CloudZero Agent > Monitoring Webhook Event Processing
         */}}
+        {{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
         - alert: CloudZeroWebhookServerHighLatency
           expr: |
             histogram_quantile(0.99,
@@ -215,6 +220,7 @@ spec:
           annotations:
             summary: "High server-side processing latency on CloudZero Webhook"
             description: "The webhook server-side processing p99 exceeds 500ms. This measures internal processing time only; actual API server impact includes additional network and TLS overhead. Cross-reference with apiserver_admission_webhook_admission_duration_seconds."
+        {{- end }}
 
         {{/*
         CloudZeroWebhookRemoteWriteFailures: The webhook cannot deliver
@@ -223,6 +229,7 @@ spec:
         Uses remote_write_failures_total from the webhook metrics.
         See: Monitoring the CloudZero Agent > Monitoring Webhook Metadata Delivery
         */}}
+        {{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
         - alert: CloudZeroWebhookRemoteWriteFailures
           expr: rate(remote_write_failures_total{job="{{ include "cloudzero-agent.serviceName" . }}"}[30m]) > 0
           for: 15m
@@ -232,6 +239,7 @@ spec:
           annotations:
             summary: "CloudZero Webhook failing to push metadata"
             description: "The webhook cannot push resource metadata to the CloudZero API. Cost attribution metadata is not being delivered. Check network connectivity and API key validity."
+        {{- end }}
 
         {{/*
         CloudZeroRemoteWriteLag: The internal Prometheus agent's remote-write

--- a/helm/templates/servicemonitor-webhook.yaml
+++ b/helm/templates/servicemonitor-webhook.yaml
@@ -18,7 +18,7 @@ which means Prometheus connects directly to the webhook (bypassing the sidecar).
 See: Monitoring the CloudZero Agent > Monitoring Webhook Event Processing
      Monitoring the CloudZero Agent > Monitoring Webhook Metadata Delivery
 */}}
-{{- if include "cloudzero-agent.monitoring.serviceMonitorsActive" . }}
+{{- if and (eq (include "cloudzero-agent.webhookServer.enabled" .) "true") (include "cloudzero-agent.monitoring.serviceMonitorsActive" .) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/helm/templates/validator-cm.yaml
+++ b/helm/templates/validator-cm.yaml
@@ -66,21 +66,34 @@ data:
         - /etc/prometheus/prometheus.yml
         - /etc/config/prometheus/configmaps/prometheus.yml
 
+    {{- /* When the webhook server is disabled, force the post-start
+           webhook_server_reachable check to "disabled" so the validator does not
+           probe a non-existent service. "disabled" is the stageCheck sentinel that
+           omits a check (see cloudzero-agent.validator.stageCheck in _helpers.tpl).
+           deepCopy the checks map first: .Values is shared across the render and
+           must not be mutated in place. */ -}}
+    {{- $checks := deepCopy .Values.components.validator.checks -}}
+    {{- if ne (include "cloudzero-agent.webhookServer.enabled" .) "true" -}}
+      {{- $ps := dict -}}
+      {{- if hasKey $checks "post-start" -}}{{- $ps = index $checks "post-start" -}}{{- end -}}
+      {{- $_ := set $ps "webhook_server_reachable" "disabled" -}}
+      {{- $_ := set $checks "post-start" $ps -}}
+    {{- end }}
     diagnostics:
       stages:
         - {{- include "cloudzero-agent.validator.stageCheck" (dict
                 "stage"        "pre-start"
-                "checksConfig" .Values.components.validator.checks
+                "checksConfig" $checks
               ) | nindent 10 }}
         - {{- include "cloudzero-agent.validator.stageCheck" (dict
                 "stage"        "post-start"
-                "checksConfig" .Values.components.validator.checks
+                "checksConfig" $checks
               ) | nindent 10 }}
         - {{- include "cloudzero-agent.validator.stageCheck" (dict
                 "stage"        "pre-stop"
-                "checksConfig" .Values.components.validator.checks
+                "checksConfig" $checks
               ) | nindent 10 }}
         - {{- include "cloudzero-agent.validator.stageCheck" (dict
                 "stage"        "config-load"
-                "checksConfig" .Values.components.validator.checks
+                "checksConfig" $checks
               ) | nindent 10 }}

--- a/helm/templates/webhook-certificate.yaml
+++ b/helm/templates/webhook-certificate.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.insightsController.tls.useCertManager }}
+{{- if and (eq (include "cloudzero-agent.webhookServer.enabled" .) "true") .Values.insightsController.tls.useCertManager }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -46,4 +46,4 @@ spec:
   issuerRef:
     name: {{ include "cloudzero-agent.issuerName" . }}
     kind: Issuer
-{{ end }}
+{{- end }}

--- a/helm/templates/webhook-cm.yaml
+++ b/helm/templates/webhook-cm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.insightsController.enabled }}
+{{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
 {{- with .Values.insightsController }}
 {{- if and .labels.enabled (not .labels.patterns) }}
 {{- $msg := "\n\nThe required field(s) 'insightsController.labels.enabled' and/or 'insightsController.labels.patterns' is not set! See the README.md for more information." }}

--- a/helm/templates/webhook-deploy.yaml
+++ b/helm/templates/webhook-deploy.yaml
@@ -23,7 +23,7 @@ Operational characteristics:
 The webhook server is essential for CloudZero cost allocation accuracy,
 ensuring complete resource metadata collection across all Kubernetes workloads.
 */}}
-{{- if .Values.insightsController.enabled }}
+{{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/templates/webhook-hpa.yaml
+++ b/helm/templates/webhook-hpa.yaml
@@ -1,10 +1,10 @@
 {{- $autoscaling := include "cloudzero-agent.getAutoscaling" (dict "component" .Values.components.webhookServer.autoscaling "defaults" .Values.defaults.autoscaling) | fromYaml -}}
-{{- if and .Values.insightsController.enabled $autoscaling.enabled }}
+{{- if and (eq (include "cloudzero-agent.webhookServer.enabled" .) "true") $autoscaling.enabled }}
 {{- /*
 Horizontal Pod Autoscaler for CloudZero Webhook Server
 
-This HPA applies when the webhook server (insights controller) is enabled
-(insightsController.enabled=true) and autoscaling is enabled.
+This HPA applies when the webhook server is enabled (per components.webhookServer.enabled,
+honoring the deprecated insightsController.enabled) and autoscaling is enabled.
 Autoscaling configuration falls back to defaults.autoscaling when
 components.webhookServer.autoscaling is null or when individual properties are not set.
 

--- a/helm/templates/webhook-pdb.yaml
+++ b/helm/templates/webhook-pdb.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
 {{ include "cloudzero-agent.generatePodDisruptionBudget" (dict
     "component" .Values.components.webhookServer
     "componentName" "webhook-server"
@@ -6,3 +7,4 @@
     "replicas" (.Values.insightsController.server.replicaCount | default .Values.components.webhookServer.replicas | default .Values.defaults.replicas)
     "root" .
   ) }}
+{{- end }}

--- a/helm/templates/webhook-service.yaml
+++ b/helm/templates/webhook-service.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -34,3 +35,4 @@ spec:
       appProtocol: https
   selector:
     {{- include "cloudzero-agent.insightsController.server.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/templates/webhook-serviceaccount.yaml
+++ b/helm/templates/webhook-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initCertJob.rbac.create }}
+{{- if and (eq (include "cloudzero-agent.webhookServer.enabled" .) "true") .Values.initCertJob.rbac.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/templates/webhook-tls-secret.yaml
+++ b/helm/templates/webhook-tls-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.insightsController.tls.secret.create .Values.insightsController.tls.enabled (not .Values.insightsController.tls.useCertManager) }}
+{{- if and (eq (include "cloudzero-agent.webhookServer.enabled" .) "true") .Values.insightsController.tls.secret.create .Values.insightsController.tls.enabled (not .Values.insightsController.tls.useCertManager) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/templates/webhook-validating-config.yaml
+++ b/helm/templates/webhook-validating-config.yaml
@@ -23,7 +23,7 @@ Supported Resources (see app/types/k8s_object.go):
 This configuration is essential for CloudZero cost allocation completeness,
 ensuring no Kubernetes resources are missed in cost attribution analysis.
 */}}
-{{- if .Values.insightsController.enabled }}
+{{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
 {{ $labelsEnabled := $.Values.insightsController.labels.enabled }}
 {{ $annotationEnabled := $.Values.insightsController.annotations.enabled }}
 {{- if or $labelsEnabled $annotationEnabled }}

--- a/helm/tests/webhookserver_enabled_test.yaml
+++ b/helm/tests/webhookserver_enabled_test.yaml
@@ -1,0 +1,48 @@
+# Resolver truth table + webhook-server gating.
+# Asserts components.webhookServer.enabled (× legacy insightsController.enabled)
+# correctly drives presence/absence of the webhook Deployment.
+suite: webhook server enable/disable resolver
+templates:
+  - webhook-deploy.yaml
+tests:
+  - it: default (both unset) renders the webhook Deployment
+    set:
+      insightsController.labels.patterns: ["app.kubernetes.io/.*"]
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: webhookServer.enabled=auto renders the Deployment
+    set:
+      components.webhookServer.enabled: auto
+      insightsController.labels.patterns: ["app.kubernetes.io/.*"]
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: webhookServer.enabled=true renders the Deployment
+    set:
+      components.webhookServer.enabled: true
+      insightsController.labels.patterns: ["app.kubernetes.io/.*"]
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: webhookServer.enabled=false removes the Deployment
+    set:
+      components.webhookServer.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: legacy insightsController.enabled=false wins over webhookServer.enabled=true
+    set:
+      components.webhookServer.enabled: true
+      insightsController.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: legacy insightsController.enabled=true wins over webhookServer.enabled=false
+    set:
+      components.webhookServer.enabled: false
+      insightsController.enabled: true
+      insightsController.labels.patterns: ["app.kubernetes.io/.*"]
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/helm/tests/webhookserver_gating_test.yaml
+++ b/helm/tests/webhookserver_gating_test.yaml
@@ -1,0 +1,350 @@
+suite: webhook server gating across resources
+tests:
+  - it: webhook ConfigMap absent when disabled
+    templates: [templates/webhook-cm.yaml]
+    set: { components.webhookServer.enabled: false }
+    asserts: [{ hasDocuments: { count: 0 } }]
+  - it: webhook ConfigMap present by default
+    templates: [templates/webhook-cm.yaml]
+    set: { insightsController.labels.patterns: ["app.kubernetes.io/.*"] }
+    asserts: [{ hasDocuments: { count: 1 } }]
+  - it: ValidatingWebhookConfiguration absent when disabled
+    templates: [templates/webhook-validating-config.yaml]
+    set: { components.webhookServer.enabled: false }
+    asserts: [{ hasDocuments: { count: 0 } }]
+  - it: init-cert Job absent when disabled
+    templates: [templates/init-cert-job.yaml]
+    set: { components.webhookServer.enabled: false }
+    asserts: [{ hasDocuments: { count: 0 } }]
+  - it: backfill resources absent when disabled
+    templates: [templates/backfill-job.yaml]
+    set: { components.webhookServer.enabled: false }
+    asserts: [{ hasDocuments: { count: 0 } }]
+  - it: webhook HPA absent when disabled even if autoscaling on
+    templates: [templates/webhook-hpa.yaml]
+    set:
+      components.webhookServer.enabled: false
+      components.webhookServer.autoscaling.enabled: true
+    asserts: [{ hasDocuments: { count: 0 } }]
+  - it: agent ConfigMap omits the webhook scrape job when disabled
+    templates: [templates/agent-cm.yaml]
+    set: { components.webhookServer.enabled: false }
+    asserts:
+      - notMatchRegex:
+          path: data["prometheus.yml"]
+          pattern: "cloudzero-webhook-job"
+  - it: agent ConfigMap includes the webhook scrape job by default
+    templates: [templates/agent-cm.yaml]
+    set: { insightsController.labels.patterns: ["app.kubernetes.io/.*"] }
+    asserts:
+      - matchRegex:
+          path: data["prometheus.yml"]
+          pattern: "cloudzero-webhook-job"
+
+  # --- webhook-service.yaml ---
+  - it: webhook Service absent when disabled
+    templates: [templates/webhook-service.yaml]
+    set:
+      components.webhookServer.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: webhook Service present when enabled
+    templates: [templates/webhook-service.yaml]
+    # labels.patterns is required render-time input (webhook label collection); set so the resource renders.
+    set:
+      insightsController.labels.patterns: ["app.kubernetes.io/.*"]
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- webhook-pdb.yaml ---
+  - it: webhook PDB absent when disabled
+    templates: [templates/webhook-pdb.yaml]
+    set:
+      components.webhookServer.enabled: false
+      components.webhookServer.podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: webhook PDB present when enabled
+    templates: [templates/webhook-pdb.yaml]
+    set:
+      components.webhookServer.podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- webhook-serviceaccount.yaml ---
+  - it: init-cert ServiceAccount absent when disabled
+    templates: [templates/webhook-serviceaccount.yaml]
+    set:
+      components.webhookServer.enabled: false
+      initCertJob.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: init-cert ServiceAccount present when enabled
+    templates: [templates/webhook-serviceaccount.yaml]
+    set:
+      initCertJob.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- init-cert-clusterrole.yaml ---
+  - it: init-cert ClusterRole absent when disabled
+    templates: [templates/init-cert-clusterrole.yaml]
+    set:
+      components.webhookServer.enabled: false
+      initCertJob.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: init-cert ClusterRole present when enabled
+    templates: [templates/init-cert-clusterrole.yaml]
+    set:
+      initCertJob.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- init-cert-clusterrolebinding.yaml ---
+  - it: init-cert ClusterRoleBinding absent when disabled
+    templates: [templates/init-cert-clusterrolebinding.yaml]
+    set:
+      components.webhookServer.enabled: false
+      initCertJob.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: init-cert ClusterRoleBinding present when enabled
+    templates: [templates/init-cert-clusterrolebinding.yaml]
+    set:
+      initCertJob.rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- servicemonitor-webhook.yaml ---
+  - it: webhook ServiceMonitor absent when disabled even if monitoring on
+    templates: [templates/servicemonitor-webhook.yaml]
+    set:
+      components.webhookServer.enabled: false
+      components.monitoring.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: webhook ServiceMonitor present when enabled and monitoring on
+    templates: [templates/servicemonitor-webhook.yaml]
+    set:
+      components.monitoring.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- agent-issuer.yaml ---
+  - it: webhook Issuer absent when disabled
+    templates: [templates/agent-issuer.yaml]
+    set:
+      components.webhookServer.enabled: false
+      insightsController.tls.useCertManager: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: webhook Issuer present when enabled
+    templates: [templates/agent-issuer.yaml]
+    set:
+      insightsController.tls.useCertManager: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- webhook-certificate.yaml ---
+  - it: webhook Certificate absent when disabled
+    templates: [templates/webhook-certificate.yaml]
+    set:
+      components.webhookServer.enabled: false
+      insightsController.tls.useCertManager: true
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: webhook Certificate present when enabled
+    templates: [templates/webhook-certificate.yaml]
+    set:
+      insightsController.tls.useCertManager: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- webhook-tls-secret.yaml ---
+  - it: webhook TLS secret absent when disabled
+    templates: [templates/webhook-tls-secret.yaml]
+    set:
+      components.webhookServer.enabled: false
+      insightsController.tls.enabled: true
+      insightsController.tls.secret.create: true
+      insightsController.tls.useCertManager: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: webhook TLS secret present when enabled
+    templates: [templates/webhook-tls-secret.yaml]
+    set:
+      insightsController.tls.enabled: true
+      insightsController.tls.secret.create: true
+      insightsController.tls.useCertManager: false
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  # --- config-loader-job.yaml ---
+  - it: config-loader keeps the --config-webhook flag but empties its value when disabled
+    templates: [templates/config-loader-job.yaml]
+    set:
+      components.webhookServer.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: "--config-webhook"
+      # Assert by index: --config-webhook lands at index 18, its value at 19.
+      # This is non-vacuous: it fails if the value were a mount path (enabled render).
+      - equal:
+          path: spec.template.spec.containers[0].command[18]
+          value: "--config-webhook"
+      - equal:
+          path: spec.template.spec.containers[0].command[19]
+          value: ""
+  - it: config-loader passes the mount path as --config-webhook value when enabled
+    templates: [templates/config-loader-job.yaml]
+    set:
+      insightsController.labels.patterns: ["app.kubernetes.io/.*"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command[18]
+          value: "--config-webhook"
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: "/etc/cloudzero-agent-insights/server-config.yaml"
+  - it: config-loader drops the webhook volume when disabled
+    templates: [templates/config-loader-job.yaml]
+    set:
+      components.webhookServer.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: config-webhook
+          any: true
+  - it: config-loader drops the webhook volumeMount when disabled
+    templates: [templates/config-loader-job.yaml]
+    set:
+      components.webhookServer.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config-webhook
+          any: true
+  - it: config-loader mounts the webhook config by default (enabled)
+    templates: [templates/config-loader-job.yaml]
+    set:
+      insightsController.labels.patterns: ["app.kubernetes.io/.*"]
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config-webhook
+          any: true
+
+  # --- validator-cm.yaml ---
+  - it: validator config drops webhook_server_reachable when disabled
+    templates: [templates/validator-cm.yaml]
+    set:
+      components.webhookServer.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["validator.yml"]
+          pattern: "webhook_server_reachable"
+  - it: validator config keeps webhook_server_reachable when enabled
+    templates: [templates/validator-cm.yaml]
+    set:
+      insightsController.labels.patterns: ["app.kubernetes.io/.*"]
+    asserts:
+      - matchRegex:
+          path: data["validator.yml"]
+          pattern: "post-start[\\s\\S]*webhook_server_reachable"
+
+  # --- prometheusrule.yaml ---
+  # The four webhook alerts (CloudZeroWebhookDown / NoEvents / ServerHighLatency /
+  # RemoteWriteFailures) must not be emitted when the webhook server is disabled,
+  # even though the PrometheusRule itself still renders (monitoring on). We assert
+  # against spec.groups[0].rules with content: {alert: <name>}, any: true because
+  # helm-unittest cannot regex-match the `spec` map directly (it is not a string).
+  # CloudZeroWebhookDown is the critical one: its expr uses absent(up{...}), which
+  # would page forever for a deliberately-disabled component.
+  # NOTE: prometheusrule.yaml renders a single rule group, so spec.groups[0] is stable. Revisit if a second group is added.
+  - it: PrometheusRule has no webhook alerts when disabled (monitoring on)
+    templates: [templates/prometheusrule.yaml]
+    set:
+      components.webhookServer.enabled: false
+      components.monitoring.enabled: true
+    asserts:
+      - notContains:
+          path: spec.groups[0].rules
+          content:
+            alert: CloudZeroWebhookDown
+          any: true
+      - notContains:
+          path: spec.groups[0].rules
+          content:
+            alert: CloudZeroWebhookNoEvents
+          any: true
+      - notContains:
+          path: spec.groups[0].rules
+          content:
+            alert: CloudZeroWebhookServerHighLatency
+          any: true
+      - notContains:
+          path: spec.groups[0].rules
+          content:
+            alert: CloudZeroWebhookRemoteWriteFailures
+          any: true
+  - it: PrometheusRule keeps non-webhook alerts when webhook disabled
+    templates: [templates/prometheusrule.yaml]
+    set:
+      components.webhookServer.enabled: false
+      components.monitoring.enabled: true
+    asserts:
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: CloudZeroAgentDown
+          any: true
+  # labels.patterns is set so the webhook resolver path renders cleanly (labels-without-patterns fails the chart).
+  - it: PrometheusRule has webhook alerts when enabled (monitoring on)
+    templates: [templates/prometheusrule.yaml]
+    set:
+      insightsController.labels.patterns: ["app.kubernetes.io/.*"]
+      components.monitoring.enabled: true
+    asserts:
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: CloudZeroWebhookDown
+          any: true
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: CloudZeroWebhookNoEvents
+          any: true
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: CloudZeroWebhookServerHighLatency
+          any: true
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: CloudZeroWebhookRemoteWriteFailures
+          any: true

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -6443,6 +6443,21 @@
               },
               "type": "object"
             },
+            "enabled": {
+              "default": "auto",
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "enum": ["auto"],
+                  "type": "string"
+                }
+              ]
+            },
             "labels": {
               "$ref": "#/$defs/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta/properties/labels"
             },
@@ -6806,8 +6821,16 @@
           "type": ["string", "null"]
         },
         "enabled": {
-          "default": true,
-          "type": "boolean"
+          "default": null,
+          "deprecated": true,
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
         },
         "labels": {
           "additionalProperties": false,

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1217,6 +1217,28 @@ properties:
         additionalProperties: false
         type: object
         properties:
+          enabled:
+            description: |
+              Whether to run the webhook server (admission controller for
+              resource metadata).
+
+              - "auto" (default): Let the chart decide. Currently equivalent to
+                true; a future release will make "auto" follow the KubeState
+                configuration.
+              - true: Always run the webhook server.
+              - false: Never run it (e.g. when the in-agent KubeState plugin
+                supplies metadata, or cluster policy disallows admission webhooks).
+
+              Takes effect only when the deprecated insightsController.enabled is
+              unset (null). When insightsController.enabled is explicitly set, it
+              takes precedence over this field.
+            default: auto
+            oneOf:
+              - type: "null"
+              - type: boolean
+              - type: string
+                enum:
+                  - auto
           autoscaling:
             description: |
               Horizontal Pod Autoscaler configuration for the webhook server.
@@ -1988,10 +2010,15 @@ properties:
     properties:
       enabled:
         description: |
-          Whether to enable the insights controller. It is strongly recommended
-          that this feature be enabled as it provides important functionality.
-        type: boolean
-        default: true
+          DEPRECATED: use components.webhookServer.enabled instead. Retained for
+          backward compatibility: when explicitly set (true/false) this value
+          takes precedence over components.webhookServer.enabled. Leave unset
+          (null) to use the new field.
+        deprecated: true
+        default: null
+        oneOf:
+          - type: "null"
+          - type: boolean
       labels:
         description: |
           Configuration for collecting labels from Kubernetes resources.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -776,6 +776,16 @@ components:
           cpu: "2000m"
   # Settings for the webhook server.
   webhookServer:
+    # Whether to run the webhook server (admission controller for resource
+    # metadata). Ternary:
+    #   true  - always run the webhook server
+    #   false - never run it (e.g. when the in-agent KubeState plugin supplies
+    #           metrics and you cannot deploy an admission webhook)
+    #   auto  - let the chart decide. Currently equivalent to `true`; a future
+    #           release will make `auto` follow the KubeState configuration.
+    # Note: if insightsController.enabled is explicitly set (true/false), it takes
+    # precedence over this field for backward compatibility.
+    enabled: auto
     replicas: null
     # Horizontal Pod Autoscaler configuration for the webhook server.
     #
@@ -1293,11 +1303,11 @@ server:
 # Configuration for the webhook server (née Insights Controller), which collects
 # and processes Kubernetes resource metadata for cost attribution and analysis.
 insightsController:
-  # Whether to enable the insights controller.
-  #
-  # It is strongly recommended that this feature be enabled as it provides
-  # important functionality.
-  enabled: true
+  # **DEPRECATED**: use `components.webhookServer.enabled` instead. Retained for
+  # backward compatibility: when explicitly set (true/false) this value takes
+  # precedence over components.webhookServer.enabled. Leave unset (null) to use
+  # the new field.
+  enabled: null
   # Configuration for collecting labels from Kubernetes resources.
   labels:
     # Whether to enable collection of specific labels for cost attribution

--- a/tests/helm/schema/components.webhookServer.enabled.auto.pass.yaml
+++ b/tests/helm/schema/components.webhookServer.enabled.auto.pass.yaml
@@ -1,0 +1,5 @@
+# Valid: the string "auto" (current default).
+clusterName: "test-cluster"
+components:
+  webhookServer:
+    enabled: auto

--- a/tests/helm/schema/components.webhookServer.enabled.false.pass.yaml
+++ b/tests/helm/schema/components.webhookServer.enabled.false.pass.yaml
@@ -1,0 +1,5 @@
+# Valid: explicit boolean false (the disable case).
+clusterName: "test-cluster"
+components:
+  webhookServer:
+    enabled: false

--- a/tests/helm/schema/components.webhookServer.enabled.invalid-type.fail.yaml
+++ b/tests/helm/schema/components.webhookServer.enabled.invalid-type.fail.yaml
@@ -1,0 +1,5 @@
+# Invalid: components.webhookServer.enabled must be null, a boolean, or the string "auto".
+clusterName: "test-cluster"
+components:
+  webhookServer:
+    enabled: 123

--- a/tests/helm/schema/components.webhookServer.enabled.null.pass.yaml
+++ b/tests/helm/schema/components.webhookServer.enabled.null.pass.yaml
@@ -1,0 +1,7 @@
+# Valid: null (unset) — the new field defers to its default.
+clusterName: "test-cluster"
+cloudAccountId: "123456789012"
+region: us-east-1
+components:
+  webhookServer:
+    enabled: null

--- a/tests/helm/schema/components.webhookServer.enabled.true.pass.yaml
+++ b/tests/helm/schema/components.webhookServer.enabled.true.pass.yaml
@@ -1,0 +1,5 @@
+# Valid: explicit boolean true.
+clusterName: "test-cluster"
+components:
+  webhookServer:
+    enabled: true

--- a/tests/helm/schema/insightsController.enabled.null.pass.yaml
+++ b/tests/helm/schema/insightsController.enabled.null.pass.yaml
@@ -1,0 +1,6 @@
+# Valid: insightsController.enabled may now be null (unset) — defers to components.webhookServer.enabled.
+clusterName: "test-cluster"
+cloudAccountId: "123456789012"
+region: us-east-1
+insightsController:
+  enabled: null

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -1163,6 +1163,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        enabled: auto
         labels: {}
         podAnnotations: {}
         podDisruptionBudget: null
@@ -1290,7 +1291,7 @@ data:
           pods: true
           statefulsets: false
       configurationMountPath: null
-      enabled: true
+      enabled: null
       labels:
         enabled: true
         patterns:
@@ -1817,7 +1818,6 @@ data:
       configurations:
         - /etc/prometheus/prometheus.yml
         - /etc/config/prometheus/configmaps/prometheus.yml
-
     diagnostics:
       stages:
         -

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -1078,6 +1078,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        enabled: auto
         labels: {}
         podAnnotations: {}
         podDisruptionBudget: null
@@ -1205,7 +1206,7 @@ data:
           pods: true
           statefulsets: false
       configurationMountPath: null
-      enabled: true
+      enabled: null
       labels:
         enabled: true
         patterns:
@@ -1732,7 +1733,6 @@ data:
       configurations:
         - /etc/prometheus/prometheus.yml
         - /etc/config/prometheus/configmaps/prometheus.yml
-
     diagnostics:
       stages:
         -

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -1166,6 +1166,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        enabled: auto
         labels: {}
         podAnnotations: {}
         podDisruptionBudget: null
@@ -1293,7 +1294,7 @@ data:
           pods: true
           statefulsets: false
       configurationMountPath: null
-      enabled: true
+      enabled: null
       labels:
         enabled: true
         patterns:
@@ -1820,7 +1821,6 @@ data:
       configurations:
         - /etc/prometheus/prometheus.yml
         - /etc/config/prometheus/configmaps/prometheus.yml
-
     diagnostics:
       stages:
         -

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -1093,6 +1093,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        enabled: auto
         labels: {}
         podAnnotations: {}
         podDisruptionBudget: null
@@ -1220,7 +1221,7 @@ data:
           pods: true
           statefulsets: false
       configurationMountPath: null
-      enabled: true
+      enabled: null
       labels:
         enabled: true
         patterns:
@@ -1747,7 +1748,6 @@ data:
       configurations:
         - /etc/prometheus/prometheus.yml
         - /etc/config/prometheus/configmaps/prometheus.yml
-
     diagnostics:
       stages:
         -

--- a/tests/helm/template/kubestate.yaml
+++ b/tests/helm/template/kubestate.yaml
@@ -1130,6 +1130,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        enabled: auto
         labels: {}
         podAnnotations: {}
         podDisruptionBudget: null
@@ -1257,7 +1258,7 @@ data:
           pods: true
           statefulsets: false
       configurationMountPath: null
-      enabled: true
+      enabled: null
       labels:
         enabled: true
         patterns:
@@ -1561,7 +1562,6 @@ data:
       configurations:
         - /etc/prometheus/prometheus.yml
         - /etc/config/prometheus/configmaps/prometheus.yml
-
     diagnostics:
       stages:
         -

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1093,6 +1093,7 @@ data:
               memory: 128Mi
           schedule: 0 */12 * * *
           securityContext: {}
+        enabled: auto
         labels: {}
         podAnnotations: {}
         podDisruptionBudget: null
@@ -1220,7 +1221,7 @@ data:
           pods: true
           statefulsets: false
       configurationMountPath: null
-      enabled: true
+      enabled: null
       labels:
         enabled: true
         patterns:
@@ -1747,7 +1748,6 @@ data:
       configurations:
         - /etc/prometheus/prometheus.yml
         - /etc/config/prometheus/configmaps/prometheus.yml
-
     diagnostics:
       stages:
         -

--- a/tests/kuttl/alloy-clustered-test/steps/01-install-clustered-chart.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/01-install-clustered-chart.yaml
@@ -2,21 +2,32 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: install-clustered-chart
-spec:
-  commands:
-    # Install the chart in clustered mode as a separate release so we do not
-    # disturb the default cz-agent release other KUTTL suites run against.
-    # The dev image tag mirrors the `make helm-install-current` target.
-    - command: sh
-      args:
-        - "-c"
-        - |
-          set -e
-          DEV_TAG="dev-$(git rev-parse HEAD)"
-          .tools/bin/helm upgrade --install cz-alloy-ct ./helm \
-            --namespace cz-alloy-clustered-test \
-            --create-namespace \
-            --values clusters/kind-overrides.yaml \
-            --set components.agent.mode=clustered \
-            --set components.agent.image.tag="$DEV_TAG" \
-            --wait --timeout=3m
+# kuttl command steps use top-level `commands:` with `script:` (a shell-script
+# string). kuttl's TestStep has no `spec` field and its Command has no `args`
+# field (`command` is a single string), so the previous `spec:`+`command:`+`args:`
+# shape silently no-opped. kuttl also runs scripts with CWD = this step directory,
+# so we walk up to the repo root before using repo-relative paths
+# (.tools/bin/helm, ./helm, clusters/).
+commands:
+  # Install the chart in clustered mode as a separate release so we do not
+  # disturb the default release other kuttl suites run against.
+  # The dev image tag mirrors the `make helm-install-current` target.
+  #
+  # `timeout:` must exceed `helm --wait --timeout=3m` (180s). kuttl applies a 30s
+  # per-command timeout here (this suite's kuttl-test.yaml sets `spec.timeout`, which
+  # kuttl ignores — the timeout field is top-level — so the 30s default applies), and
+  # that would kill the install mid-wait. The explicit per-command `timeout:` overrides it.
+  - timeout: 240
+    script: |
+      set -e
+      ROOT="$PWD"
+      while [ "$ROOT" != "/" ] && [ ! -f "$ROOT/helm/Chart.yaml" ]; do ROOT=$(dirname "$ROOT"); done
+      cd "$ROOT"
+      DEV_TAG="dev-$(git rev-parse HEAD)"
+      .tools/bin/helm upgrade --install cz-alloy-ct ./helm \
+        --namespace cz-alloy-clustered-test \
+        --create-namespace \
+        --values clusters/kind-overrides.yaml \
+        --set components.agent.mode=clustered \
+        --set components.agent.image.tag="$DEV_TAG" \
+        --wait --timeout=3m

--- a/tests/kuttl/alloy-clustered-test/steps/02-verify-alloy-ready.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/02-verify-alloy-ready.yaml
@@ -2,59 +2,74 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: verify-alloy-ready
-spec:
-  commands:
-    # Belt-and-suspenders: step 01's `helm --wait` already blocks on Ready,
-    # but re-assert explicitly here so the failure message points at readiness
-    # rather than at helm timing out.
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=Ready
-        - pod
-        - -l
-        - app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct
-        - -n
-        - cz-alloy-clustered-test
-        - --timeout=180s
-    # Fail if the Alloy container has restarted at all. The pre-fix failure
-    # is CrashLoopBackOff on first start, so any restart > 0 before Ready
-    # flags the regression even if a later retry somehow succeeded.
-    - command: sh
-      args:
-        - "-c"
-        - |
-          set -e
-          RESTARTS=$(kubectl get pod \
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped. These steps are kubectl-only
+# and read KUBECONFIG from the environment, so no repo-root cd is needed.
+commands:
+  # Belt-and-suspenders: step 01's `helm --wait` already blocks on Ready,
+  # but re-assert explicitly here so the failure message points at readiness
+  # rather than at helm timing out.
+  #
+  # Pre-check: `kubectl wait -l <selector>` exits 0 immediately on kubectl <1.27
+  # when no pod yet matches, which would vacuously pass. Poll until at least one
+  # matching pod exists before handing off to kubectl wait.
+  #
+  # `timeout:` must cover the up-to-~60s poll loop + `kubectl wait --timeout=180s`; kuttl's
+  # 30s per-command default (suite spec.timeout is ignored) would otherwise clamp it.
+  - timeout: 300
+    script: |
+      set -e
+      for i in $(seq 1 30); do
+        COUNT=$(kubectl get pod \
+          -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+          -n cz-alloy-clustered-test \
+          --no-headers 2>/dev/null | wc -l)
+        if [ "$COUNT" -gt 0 ]; then
+          echo "Alloy (server) pod appeared (attempt $i)"
+          break
+        fi
+        [ "$i" -eq 30 ] && { echo "FAIL: Alloy (server) pod never appeared" >&2; exit 1; }
+        sleep 2
+      done
+      kubectl wait --for=condition=Ready pod \
+        -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+        -n cz-alloy-clustered-test \
+        --timeout=180s
+
+  # Fail if the Alloy container has restarted at all. The pre-fix failure
+  # is CrashLoopBackOff on first start, so any restart > 0 before Ready
+  # flags the regression even if a later retry somehow succeeded.
+  - script: |
+      set -e
+      RESTARTS=$(kubectl get pod \
+        -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+        -n cz-alloy-clustered-test \
+        -o jsonpath='{.items[*].status.containerStatuses[?(@.name=="cloudzero-agent-alloy")].restartCount}')
+      echo "Alloy container restart count: $RESTARTS"
+      for r in $RESTARTS; do
+        if [ "$r" -ne 0 ]; then
+          echo "FAIL: Alloy container restarted $r times (expected 0)" >&2
+          kubectl describe pod \
             -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
-            -n cz-alloy-clustered-test \
-            -o jsonpath='{.items[*].status.containerStatuses[?(@.name=="cloudzero-agent-alloy")].restartCount}')
-          echo "Alloy container restart count: $RESTARTS"
-          for r in $RESTARTS; do
-            if [ "$r" -ne 0 ]; then
-              echo "FAIL: Alloy container restarted $r times (expected 0)" >&2
-              kubectl describe pod \
-                -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
-                -n cz-alloy-clustered-test >&2 || true
-              exit 1
-            fi
-          done
-    # Fail if the specific /tmp regression signature appears in Alloy logs.
-    # Pins this assertion to CP-40307 so unrelated clustered-mode failures
-    # can't silently green-bar.
-    - command: sh
-      args:
-        - "-c"
-        - |
-          set -e
-          LOGS=$(kubectl logs \
-            -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
-            -n cz-alloy-clustered-test \
-            -c cloudzero-agent-alloy \
-            --all-containers=false \
-            --tail=-1 2>&1 || true)
-          if echo "$LOGS" | grep -q 'mkdir /tmp: permission denied'; then
-            echo "FAIL: Alloy logs contain the CP-40307 regression signature" >&2
-            echo "$LOGS" >&2
-            exit 1
-          fi
+            -n cz-alloy-clustered-test >&2 || true
+          exit 1
+        fi
+      done
+
+  # Fail if the specific /tmp regression signature appears in Alloy logs.
+  # Pins this assertion to CP-40307 so unrelated clustered-mode failures
+  # can't silently green-bar.
+  - script: |
+      set -e
+      LOGS=$(kubectl logs \
+        -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+        -n cz-alloy-clustered-test \
+        -c cloudzero-agent-alloy \
+        --all-containers=false \
+        --tail=-1 2>&1 || true)
+      if echo "$LOGS" | grep -q 'mkdir /tmp: permission denied'; then
+        echo "FAIL: Alloy logs contain the CP-40307 regression signature" >&2
+        echo "$LOGS" >&2
+        exit 1
+      fi

--- a/tests/kuttl/alloy-clustered-test/steps/99-uninstall.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/99-uninstall.yaml
@@ -2,17 +2,23 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: uninstall-clustered-chart
-spec:
-  commands:
-    # Uninstall the dedicated release so subsequent kuttl suites and the
-    # `kind-test` teardown are unaffected. `--ignore-not-found` and `|| true`
-    # keep cleanup best-effort even if an earlier step failed.
-    - command: sh
-      args:
-        - "-c"
-        - |
-          .tools/bin/helm uninstall cz-alloy-ct \
-            --namespace cz-alloy-clustered-test \
-            --ignore-not-found || true
-          kubectl delete namespace cz-alloy-clustered-test \
-            --ignore-not-found --wait=false || true
+# Uses top-level `commands:` with `script:` (kuttl's TestStep has no `spec` field
+# and its Command has no `args` field). Walks up to the repo root before calling
+# .tools/bin/helm, since kuttl runs scripts with CWD = this step dir.
+commands:
+  # Uninstall the dedicated release so subsequent kuttl suites and the
+  # `kind-test` teardown are unaffected. `--ignore-not-found` and `|| true`
+  # keep cleanup best-effort even if an earlier step failed.
+  #
+  # Headroom over the 30s per-command timeout (this suite's kuttl-test.yaml sets
+  # `spec.timeout`, which kuttl ignores, so the 30s default applies) for helm uninstall.
+  - timeout: 120
+    script: |
+      ROOT="$PWD"
+      while [ "$ROOT" != "/" ] && [ ! -f "$ROOT/helm/Chart.yaml" ]; do ROOT=$(dirname "$ROOT"); done
+      cd "$ROOT"
+      .tools/bin/helm uninstall cz-alloy-ct \
+        --namespace cz-alloy-clustered-test \
+        --ignore-not-found || true
+      kubectl delete namespace cz-alloy-clustered-test \
+        --ignore-not-found --wait=false || true

--- a/tests/kuttl/collector-comprehensive-test/steps/02-validate-collector-logs.yaml
+++ b/tests/kuttl/collector-comprehensive-test/steps/02-validate-collector-logs.yaml
@@ -2,44 +2,42 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: validate-collector-logs
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=available
-        - deployment/collector-comprehensive-test-deployment
-        - -n
-        - collector-comprehensive-test-namespace
-        - --timeout=60s
-    - command: sleep
-      args:
-        - "60"
-    - command: sh
-      args:
-        - -c
-        - "echo '=== Validating Collector Logs ==='"
-    - command: sh
-      args:
-        - -c
-        - "kubectl logs deployment/cz-agent-aggregator -n cz-agent -c cz-agent-aggregator-collector --since=2m > /tmp/collector-logs.txt || echo 'Warning: Failed to get collector logs'"
-    - command: sh
-      args:
-        - -c
-        - "if grep -q 'remote_write.*metrics' /tmp/collector-logs.txt; then echo 'Remote write metrics found in logs'; else echo 'No remote_write metrics found'; fi"
-    - command: sh
-      args:
-        - -c
-        - "grep -q 'kube_pod_info' /tmp/collector-logs.txt && echo 'Found metric: kube_pod_info' || echo 'Missing metric: kube_pod_info'"
-    - command: sh
-      args:
-        - -c
-        - "grep -q 'kube_pod_labels' /tmp/collector-logs.txt && echo 'Found metric: kube_pod_labels' || echo 'Missing metric: kube_pod_labels'"
-    - command: sh
-      args:
-        - -c
-        - "grep -q 'czo_cost_metrics_shipping_progress' /tmp/collector-logs.txt && echo 'Found metric: czo_cost_metrics_shipping_progress' || echo 'Missing metric: czo_cost_metrics_shipping_progress'"
-    - command: sh
-      args:
-        - -c
-        - "if grep -q 'czo_webhook' /tmp/collector-logs.txt; then echo 'Webhook metrics being collected'; else echo 'No webhook metrics found in collector logs'; fi"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# The aggregator is referenced by LABEL (app.kubernetes.io/name=aggregator) in its
+# actual namespace, not the stale hardcoded `deployment/cz-agent-aggregator -n cz-agent`.
+# The alloy co-install (instance=cz-alloy-ct) is excluded. The log-content checks are
+# best-effort diagnostics (they print Found/Missing and never fail the step), matching
+# the original intent.
+commands:
+  # Hard assertion: the suite's own test deployment (created in step 01) must be available.
+  # `timeout:` covers the wait's --timeout=60s (kuttl's 30s default would otherwise clamp it).
+  - command: kubectl wait --for=condition=available deployment/collector-comprehensive-test-deployment -n collector-comprehensive-test-namespace --timeout=60s
+    timeout: 90
+  # kuttl applies a 30s per-command timeout here (the suite's kuttl-test.yaml sets
+  # `spec.timeout`, which kuttl ignores — the field is top-level — so the 30s default
+  # applies); this 60s settle sleep needs a larger explicit `timeout:`.
+  - command: sleep 60
+    timeout: 90
+  # Best-effort log-content diagnostics. Consolidated into one script so the log
+  # capture and the greps share a shell (the original chained via a /tmp file).
+  - script: |
+      echo '=== Validating Collector Logs ==='
+      NS=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null)
+      CONTAINER=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -o jsonpath='{.items[0].spec.template.spec.containers[?(@.name)].name}' 2>/dev/null \
+        | tr ' ' '\n' | grep -- '-aggregator-collector$' | head -1)
+      kubectl logs \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -c "$CONTAINER" --since=2m > /tmp/collector-logs.txt 2>/dev/null \
+        || echo 'Warning: Failed to get collector logs'
+      if grep -q 'remote_write.*metrics' /tmp/collector-logs.txt; then echo 'Remote write metrics found in logs'; else echo 'No remote_write metrics found'; fi
+      grep -q 'kube_pod_info' /tmp/collector-logs.txt && echo 'Found metric: kube_pod_info' || echo 'Missing metric: kube_pod_info'
+      grep -q 'kube_pod_labels' /tmp/collector-logs.txt && echo 'Found metric: kube_pod_labels' || echo 'Missing metric: kube_pod_labels'
+      grep -q 'czo_cost_metrics_shipping_progress' /tmp/collector-logs.txt && echo 'Found metric: czo_cost_metrics_shipping_progress' || echo 'Missing metric: czo_cost_metrics_shipping_progress'
+      if grep -q 'czo_webhook' /tmp/collector-logs.txt; then echo 'Webhook metrics being collected'; else echo 'No webhook metrics found in collector logs'; fi

--- a/tests/kuttl/collector-comprehensive-test/steps/03-test-collector-metrics.yaml
+++ b/tests/kuttl/collector-comprehensive-test/steps/03-test-collector-metrics.yaml
@@ -2,25 +2,19 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: test-collector-metrics
-spec:
-  commands:
-    - command: sh
-      args:
-        - -c
-        - "echo '=== Testing Collector Metrics Endpoints ==='"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_pod_info' && echo '✅ Pod metrics found' || echo '❌ No pod metrics found'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_deployment' && echo '✅ Deployment metrics found' || echo '❌ No deployment metrics found'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_service' && echo '✅ Service metrics found' || echo '❌ No service metrics found'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-aggregator.cz-agent.svc.cluster.local/metrics | head -20 || echo 'Warning: Collector metrics endpoint test failed'"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# These checks curl in-cluster service DNS (*.svc.cluster.local), which does NOT
+# resolve from the host where kuttl runs scripts, so they remain best-effort
+# diagnostics (every line exits 0 via `|| echo`), faithfully matching the original
+# intent. Hardening these into genuine assertions (port-forward / in-cluster exec)
+# is a deliberate follow-up, not this ticket.
+commands:
+  - script: |
+      echo '=== Testing Collector Metrics Endpoints ==='
+      curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_pod_info' && echo '✅ Pod metrics found' || echo '❌ No pod metrics found'
+      curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_deployment' && echo '✅ Deployment metrics found' || echo '❌ No deployment metrics found'
+      curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_service' && echo '✅ Service metrics found' || echo '❌ No service metrics found'
+      curl -m 10 http://cz-agent-aggregator.cz-agent.svc.cluster.local/metrics | head -20 || echo 'Warning: Collector metrics endpoint test failed'

--- a/tests/kuttl/collector-test/steps/02-verify-collector-logs.yaml
+++ b/tests/kuttl/collector-test/steps/02-verify-collector-logs.yaml
@@ -2,26 +2,46 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: verify-collector-logs
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=available
-        - deployment/metric-test-deployment
-        - -n
-        - metric-test-namespace
-        - --timeout=60s
-    - command: sleep
-      args:
-        - "30"
-    - command: kubectl
-      args:
-        - logs
-        - deployment/cz-agent-aggregator
-        - -n
-        - cz-agent
-        - -c
-        - cz-agent-aggregator-collector
-        - --since=2m
-        - --tail=20
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field (`command` is a single
+# string), so the previous `spec:`+`command:`+`args:` shape silently no-opped.
+# kubectl reads KUBECONFIG from the environment, so no repo-root cd is needed.
+#
+# The shared agent install is referenced by LABEL (app.kubernetes.io/name=aggregator)
+# in the namespace it was actually installed into, NOT by the stale hardcoded name
+# `deployment/cz-agent-aggregator -n cz-agent` (the chart names it `<release>-cz-aggregator`
+# and the namespace/release are config-driven, e.g. im-a-namespace/im-a-release on kind).
+# The alloy-clustered-test release (instance=cz-alloy-ct) installs the same chart, so it
+# is excluded from discovery.
+commands:
+  # The suite's own test deployment (created in step 01) must be available.
+  # `timeout:` must cover the wait's own --timeout=60s; without it kuttl's 30s
+  # per-command default (suite spec.timeout is ignored) would clamp the wait to 30s.
+  - command: kubectl wait --for=condition=available deployment/metric-test-deployment -n metric-test-namespace --timeout=60s
+    timeout: 90
+  # Let the collector scrape a couple of cycles. kuttl applies a 30s per-command
+  # timeout here (the suite's kuttl-test.yaml sets `spec.timeout`, which kuttl ignores
+  # — the timeout field is top-level — so the 30s default applies), so this 30s sleep
+  # needs an explicit larger `timeout:` or it races the deadline.
+  - command: sleep 30
+    timeout: 60
+  # Fetch the aggregator's collector-container logs from the shared install,
+  # discovered by label (excluding the alloy co-install).
+  - script: |
+      set -e
+      NS=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}')
+      [ -n "$NS" ] || { echo "FAIL: shared aggregator deployment not found" >&2; exit 1; }
+      # The collector container is named "<release>-cz-aggregator-collector"; select it
+      # generically rather than hardcoding the release prefix.
+      CONTAINER=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -o jsonpath='{.items[0].spec.template.spec.containers[?(@.name)].name}' \
+        | tr ' ' '\n' | grep -- '-aggregator-collector$' | head -1)
+      echo "aggregator namespace=$NS collector container=$CONTAINER"
+      kubectl logs \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" \
+        -c "$CONTAINER" \
+        --since=2m --tail=20

--- a/tests/kuttl/collector-test/steps/03-test-collector-metrics.yaml
+++ b/tests/kuttl/collector-test/steps/03-test-collector-metrics.yaml
@@ -2,19 +2,34 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: test-collector-metrics
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - port-forward
-        - service/cz-agent-cloudzero-state-metrics
-        - 8080:8080
-        - -n
-        - cz-agent
-    - command: sleep
-      args:
-        - "5"
-    - command: sh
-      args:
-        - -c
-        - "curl http://localhost:8080/metrics | head -20"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# This consolidates port-forward + curl into ONE script because kuttl runs each
+# command entry in a separate shell — a foreground `kubectl port-forward` would
+# block the step forever, so it is backgrounded and torn down via `trap`. The
+# state-metrics service is selected by LABEL (app.kubernetes.io/name=ksm) in its
+# actual namespace, not the stale hardcoded `service/cz-agent-cloudzero-state-metrics
+# -n cz-agent`. The alloy co-install (instance=cz-alloy-ct) is excluded.
+commands:
+  - script: |
+      set -e
+      NS=$(kubectl get svc \
+        -l 'app.kubernetes.io/name=ksm,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}')
+      SVC=$(kubectl get svc \
+        -l 'app.kubernetes.io/name=ksm,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -o jsonpath='{.items[0].metadata.name}')
+      [ -n "$NS" ] && [ -n "$SVC" ] || { echo "FAIL: state-metrics (ksm) service not found" >&2; exit 1; }
+      echo "port-forwarding svc/$SVC -n $NS"
+      kubectl port-forward "service/$SVC" 8080:8080 -n "$NS" >/tmp/cz-ksm-pf.log 2>&1 &
+      PF=$!
+      trap 'kill $PF 2>/dev/null || true' EXIT
+      sleep 5
+      # Land the body first so a failed fetch fails the step: piping `curl | head`
+      # would mask curl's exit status (the pipeline returns head's, always 0), and
+      # `set -o pipefail` is unsafe here (head closing the pipe SIGPIPEs a successful
+      # curl). Fetch to a file under `set -e`, then head it.
+      curl -sf http://localhost:8080/metrics -o /tmp/cz-ksm-metrics.txt
+      head -20 /tmp/cz-ksm-metrics.txt

--- a/tests/kuttl/webhook-comprehensive-test/steps/02-verify-webhook-health.yaml
+++ b/tests/kuttl/webhook-comprehensive-test/steps/02-verify-webhook-health.yaml
@@ -2,32 +2,25 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: verify-webhook-health
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=available
-        - deployment/webhook-comprehensive-test-deployment
-        - -n
-        - webhook-comprehensive-test-namespace
-        - --timeout=60s
-    - command: sleep
-      args:
-        - "30"
-    - command: sh
-      args:
-        - -c
-        - "echo '=== Testing Webhook Health Endpoints ==='"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 -k https://cz-agent-cloudzero-agent-webhook-server-svc.cz-agent.svc.cluster.local:443/healthz || echo 'Warning: Webhook health endpoint test failed'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | head -10 || echo 'Warning: State metrics endpoint test failed'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-aggregator.cz-agent.svc.cluster.local/metrics | head -10 || echo 'Warning: Collector metrics endpoint test failed'"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# The endpoint checks curl in-cluster service DNS (*.svc.cluster.local), which does
+# NOT resolve from the host where kuttl runs scripts, so they remain best-effort
+# diagnostics (`|| echo Warning`), faithfully matching the original intent. Only the
+# test-namespace deployment wait (created by step 01) is a hard assertion.
+commands:
+  # Hard assertion: the suite's own test deployment (created in step 01) must be available.
+  # `timeout:` covers the wait's --timeout=60s (kuttl's 30s default would otherwise clamp it).
+  - command: kubectl wait --for=condition=available deployment/webhook-comprehensive-test-deployment -n webhook-comprehensive-test-namespace --timeout=60s
+    timeout: 90
+  # kuttl's default per-command timeout is 30s; this 30s settle sleep needs a larger one.
+  - command: sleep 30
+    timeout: 60
+  # Best-effort endpoint diagnostics (in-cluster DNS not reachable from host).
+  - script: |
+      echo '=== Testing Webhook Health Endpoints ==='
+      curl -m 10 -k https://cz-agent-cloudzero-agent-webhook-server-svc.cz-agent.svc.cluster.local:443/healthz || echo 'Warning: Webhook health endpoint test failed'
+      curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | head -10 || echo 'Warning: State metrics endpoint test failed'
+      curl -m 10 http://cz-agent-aggregator.cz-agent.svc.cluster.local/metrics | head -10 || echo 'Warning: Collector metrics endpoint test failed'

--- a/tests/kuttl/webhook-comprehensive-test/steps/03-validate-webhook-metrics.yaml
+++ b/tests/kuttl/webhook-comprehensive-test/steps/03-validate-webhook-metrics.yaml
@@ -2,24 +2,24 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: validate-webhook-metrics
-spec:
-  commands:
-    - command: sleep
-      args:
-        - "30"
-    - command: sh
-      args:
-        - -c
-        - "echo '=== Validating Webhook Metrics ==='"
-    - command: sh
-      args:
-        - -c
-        - "WEBHOOK_METRICS=$(curl -m 10 -k https://cz-agent-cloudzero-agent-webhook-server-svc.cz-agent.svc.cluster.local:443/metrics) || echo 'Warning: Failed to fetch webhook metrics'"
-    - command: sh
-      args:
-        - -c
-        - 'if echo "$WEBHOOK_METRICS" | grep -q ''czo_webhook_types_total''; then echo ''✅ Webhook metrics found''; echo "$WEBHOOK_METRICS" | grep ''czo_webhook_types_total''; else echo ''❌ No webhook metrics found''; fi'
-    - command: sh
-      args:
-        - -c
-        - 'WEBHOOK_COUNT=$(echo "$WEBHOOK_METRICS" | grep ''czo_webhook_types_total'' | wc -l); if [ "$WEBHOOK_COUNT" -gt 0 ]; then echo "✅ Webhook metrics found ($WEBHOOK_COUNT entries)"; else echo ''❌ No webhook metrics found''; fi'
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# These five original commands MUST live in one `script:` block: $WEBHOOK_METRICS is
+# set by the curl and read by the later grep/count steps, and kuttl runs each command
+# entry in a SEPARATE shell — split across entries the variable would be empty and the
+# checks would silently always report "no metrics". The curl hits in-cluster service DNS
+# (*.svc.cluster.local), which does not resolve from the host, so this stays a
+# best-effort diagnostic (every path exits 0), faithfully matching the original intent.
+commands:
+  # kuttl applies a 30s per-command timeout here (the suite's kuttl-test.yaml sets
+  # `spec.timeout`, which kuttl ignores — the field is top-level — so the 30s default
+  # applies); this block sleeps 30s then curls, so it needs a larger explicit `timeout:`.
+  - timeout: 90
+    script: |
+      sleep 30
+      echo '=== Validating Webhook Metrics ==='
+      WEBHOOK_METRICS=$(curl -m 10 -k https://cz-agent-cloudzero-agent-webhook-server-svc.cz-agent.svc.cluster.local:443/metrics) || echo 'Warning: Failed to fetch webhook metrics'
+      if echo "$WEBHOOK_METRICS" | grep -q 'czo_webhook_types_total'; then echo '✅ Webhook metrics found'; echo "$WEBHOOK_METRICS" | grep 'czo_webhook_types_total'; else echo '❌ No webhook metrics found'; fi
+      WEBHOOK_COUNT=$(echo "$WEBHOOK_METRICS" | grep 'czo_webhook_types_total' | wc -l); if [ "$WEBHOOK_COUNT" -gt 0 ]; then echo "✅ Webhook metrics found ($WEBHOOK_COUNT entries)"; else echo '❌ No webhook metrics found'; fi

--- a/tests/kuttl/webhook-test/steps/02-verify-webhook-events.yaml
+++ b/tests/kuttl/webhook-test/steps/02-verify-webhook-events.yaml
@@ -2,32 +2,33 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: verify-webhook-events
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=available
-        - deployment/webhook-test-deployment
-        - -n
-        - webhook-test-namespace
-        - --timeout=60s
-    - command: sleep
-      args:
-        - "10"
-    - command: kubectl
-      args:
-        - get
-        - pods
-        - -n
-        - webhook-test-namespace
-        - -o
-        - wide
-    - command: kubectl
-      args:
-        - logs
-        - deployment/cz-agent-cloudzero-agent-webhook-server
-        - -n
-        - cz-agent
-        - --since=2m
-        - --tail=10
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped. kubectl reads KUBECONFIG
+# from the environment, so no repo-root cd is needed.
+#
+# The shared webhook server is referenced by LABEL (app.kubernetes.io/name=webhook-server)
+# in its actual namespace, NOT by the stale hardcoded name
+# `deployment/cz-agent-cloudzero-agent-webhook-server -n cz-agent` (the chart names it
+# `<release>-cz-webhook`; the namespace/release are config-driven). The alloy co-install
+# (instance=cz-alloy-ct) is excluded.
+commands:
+  # The suite's own test deployment (created in step 01) must be available.
+  # `timeout:` covers the wait's --timeout=60s (kuttl's 30s default would otherwise clamp it).
+  - command: kubectl wait --for=condition=available deployment/webhook-test-deployment -n webhook-test-namespace --timeout=60s
+    timeout: 90
+  - command: sleep 10
+  # Diagnostic: list the suite's test pods.
+  - command: kubectl get pods -n webhook-test-namespace -o wide
+  # Fetch the shared webhook-server logs, discovered by label (excluding alloy).
+  - script: |
+      set -e
+      NS=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=webhook-server,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}')
+      [ -n "$NS" ] || { echo "FAIL: shared webhook-server deployment not found" >&2; exit 1; }
+      echo "webhook-server namespace=$NS"
+      kubectl logs \
+        -l 'app.kubernetes.io/name=webhook-server,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" \
+        --since=2m --tail=10

--- a/tests/kuttl/webhook-test/steps/03-test-metrics-endpoint.yaml
+++ b/tests/kuttl/webhook-test/steps/03-test-metrics-endpoint.yaml
@@ -2,19 +2,34 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: test-metrics-endpoint
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - port-forward
-        - service/cz-agent-cloudzero-agent-webhook-server-svc
-        - 8443:443
-        - -n
-        - cz-agent
-    - command: sleep
-      args:
-        - "5"
-    - command: sh
-      args:
-        - -c
-        - "curl -k https://localhost:8443/metrics | head -20"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# Consolidated into ONE script because kuttl runs each command entry in a separate
+# shell — a foreground `kubectl port-forward` would block the step forever, so it is
+# backgrounded and torn down via `trap`. The webhook-server service is selected by
+# LABEL (app.kubernetes.io/name=webhook-server) in its actual namespace, not the stale
+# hardcoded `service/cz-agent-cloudzero-agent-webhook-server-svc -n cz-agent`.
+# The alloy co-install (instance=cz-alloy-ct) is excluded.
+commands:
+  - script: |
+      set -e
+      NS=$(kubectl get svc \
+        -l 'app.kubernetes.io/name=webhook-server,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}')
+      SVC=$(kubectl get svc \
+        -l 'app.kubernetes.io/name=webhook-server,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -o jsonpath='{.items[0].metadata.name}')
+      [ -n "$NS" ] && [ -n "$SVC" ] || { echo "FAIL: webhook-server service not found" >&2; exit 1; }
+      echo "port-forwarding svc/$SVC -n $NS"
+      kubectl port-forward "service/$SVC" 8443:443 -n "$NS" >/tmp/cz-webhook-pf.log 2>&1 &
+      PF=$!
+      trap 'kill $PF 2>/dev/null || true' EXIT
+      sleep 5
+      # Land the body first so a failed fetch fails the step: piping `curl | head`
+      # would mask curl's exit status (the pipeline returns head's, always 0), and
+      # `set -o pipefail` is unsafe here (head closing the pipe SIGPIPEs a successful
+      # curl). Fetch to a file under `set -e`, then head it.
+      curl -skf https://localhost:8443/metrics -o /tmp/cz-webhook-metrics.txt
+      head -20 /tmp/cz-webhook-metrics.txt

--- a/tests/kuttl/webhookserver-disabled-test/kuttl-test.yaml
+++ b/tests/kuttl/webhookserver-disabled-test/kuttl-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+metadata:
+  name: webhookserver-disabled-test
+  annotations:
+    kuttl.dev/type: "test"
+testDirs:
+  - ./steps
+timeout: 600 # full agent install + readiness on a busy CI Kind node; see steps/00
+parallel: 1
+reportFormat: JSON
+reportName: webhookserver-disabled-test-report
+# The suite installs its own helm release in a dedicated namespace and
+# uninstalls it in step 99, so we do not let kuttl delete the namespace
+# (that would leave helm release state orphaned).
+deleteNamespace: false
+namespaceLabels:
+  test: webhookserver-disabled

--- a/tests/kuttl/webhookserver-disabled-test/steps/00-install-webhook-disabled.yaml
+++ b/tests/kuttl/webhookserver-disabled-test/steps/00-install-webhook-disabled.yaml
@@ -1,0 +1,64 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-webhook-disabled
+# kuttl command steps use `script:` (a shell-script string), NOT `command:`+`args:`.
+# kuttl's Commands schema has no `args` field and `command` is a single string, so
+# the `command:`+`args:` shape silently no-ops. kuttl also runs scripts with CWD set
+# to this step directory, so we walk up to the repo root before using repo-relative
+# paths (.tools/bin/helm, ./helm, clusters/). See docs/superpowers/kuttl-commands-noop-issue.md.
+commands:
+  # Install the chart with the admission webhook server DISABLED, as a
+  # separate release in a dedicated namespace so we do not disturb the
+  # default cz-agent release other kuttl suites run against.
+  #
+  # components.webhookServer.enabled=false   -> no webhook surface (CP-43292)
+  # components.agent.kubeState.enabled=true  -> in-agent KubeState plugin on
+  # kubeStateMetrics.enabled=false           -> required: the KubeState plugin
+  #                                             replaces kube-state-metrics, and
+  #                                             the chart rejects both being true.
+  #
+  # webhookserver-min-footprint.yaml shrinks this release (1 replica, tiny CPU
+  # requests) so it schedules alongside the default cz-agent release that
+  # `make kind-test` installs first. Without it, two full-size stacks exceed a
+  # CI Kind node's allocatable CPU, the new pods stay Pending, and helm --wait
+  # times out. See that file's header for the full rationale (CP-43292).
+  #
+  # The dev image tag mirrors the `make helm-install-current` target.
+  - script: |
+      set -e
+      ROOT="$PWD"
+      while [ "$ROOT" != "/" ] && [ ! -f "$ROOT/helm/Chart.yaml" ]; do ROOT=$(dirname "$ROOT"); done
+      cd "$ROOT"
+      DEV_TAG="dev-$(git rev-parse HEAD)"
+      NS=cz-webhookserver-disabled-test
+      if ! .tools/bin/helm upgrade --install cz-whdis ./helm \
+        --namespace "$NS" \
+        --create-namespace \
+        --values clusters/kind-overrides.yaml \
+        --values tests/kuttl/webhookserver-min-footprint.yaml \
+        --set components.agent.mode=clustered \
+        --set components.agent.image.tag="$DEV_TAG" \
+        --set components.webhookServer.enabled=false \
+        --set components.agent.kubeState.enabled=true \
+        --set kubeStateMetrics.enabled=false \
+        --wait --timeout=8m; then
+        # The install did not reach Ready. CI tears the cluster down on failure,
+        # so capture why HERE (node capacity, pod states, scheduling/crash
+        # reasons) before this step returns. See CP-43292.
+        echo "===== INSTALL FAILED - cluster diagnostics ($NS) ====="
+        echo "--- nodes ---"; kubectl get nodes -o wide || true
+        echo "--- node allocatable + allocated requests ---"
+        kubectl describe nodes | grep -A15 'Allocated resources' || true
+        echo "--- pods (test ns + default release + kube-system) ---"
+        kubectl get pods -A -o wide | grep -E 'NAMESPACE|cz-webhookserver|im-a-namespace|cz-agent|Pending|Init|CrashLoop|Error|ContainerCreating' || true
+        echo "--- not-ready pods in $NS: describe (scheduling/crash reason) ---"
+        for p in $(kubectl get pods -n "$NS" -o name 2>/dev/null); do
+          echo "··· $p ···"
+          kubectl describe "$p" -n "$NS" 2>/dev/null \
+            | grep -E 'Status:|Reason:|Message:|FailedScheduling|Insufficient|Unschedulable|Warning|Back-off|Liveness|Readiness|State:|Last State:|Exit Code:|Ready:' \
+            | head -25 || true
+        done
+        echo "===== end diagnostics ====="
+        exit 1
+      fi

--- a/tests/kuttl/webhookserver-disabled-test/steps/01-check-no-webhook-surface.yaml
+++ b/tests/kuttl/webhookserver-disabled-test/steps/01-check-no-webhook-surface.yaml
@@ -1,0 +1,41 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: assert-no-webhook-surface
+commands:
+  # Negative assertions: with components.webhookServer.enabled=false the
+  # webhook surface must be entirely absent. Each `kubectl get` is expected
+  # to FAIL with NotFound; we invert that with `! ... ` so the step succeeds
+  # only when the resource does NOT exist. Names verified by rendering the
+  # chart (release "cz-whdis"):
+  #   Service / Deployment            -> cz-whdis-cz-webhook
+  #   ValidatingWebhookConfiguration  -> cz-whdis-cz-webhook (cluster-scoped)
+
+  # Namespaced webhook Deployment must not exist.
+  - script: |
+      set -e
+        if kubectl get deployment cz-whdis-cz-webhook \
+            -n cz-webhookserver-disabled-test >/dev/null 2>&1; then
+          echo "FAIL: webhook Deployment cz-whdis-cz-webhook exists but should be absent" >&2
+          exit 1
+        fi
+        echo "OK: webhook Deployment absent"
+
+  # Namespaced webhook Service must not exist.
+  - script: |
+      set -e
+        if kubectl get service cz-whdis-cz-webhook \
+            -n cz-webhookserver-disabled-test >/dev/null 2>&1; then
+          echo "FAIL: webhook Service cz-whdis-cz-webhook exists but should be absent" >&2
+          exit 1
+        fi
+        echo "OK: webhook Service absent"
+
+  # Cluster-scoped ValidatingWebhookConfiguration must not exist.
+  - script: |
+      set -e
+        if kubectl get validatingwebhookconfiguration cz-whdis-cz-webhook >/dev/null 2>&1; then
+          echo "FAIL: ValidatingWebhookConfiguration cz-whdis-cz-webhook exists but should be absent" >&2
+          exit 1
+        fi
+        echo "OK: ValidatingWebhookConfiguration absent"

--- a/tests/kuttl/webhookserver-disabled-test/steps/02-check-healthy.yaml
+++ b/tests/kuttl/webhookserver-disabled-test/steps/02-check-healthy.yaml
@@ -1,0 +1,84 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: assert-healthy
+# Uses `script:` (kuttl has no `args` field; `command:`+`args:` silently no-ops).
+# kubectl reads KUBECONFIG from the environment, so these need no repo-root cd.
+commands:
+  # Regression guard for the original CP-43292 bug: with the webhook server
+  # disabled, the config-loader Job must still reach Complete. The Job name
+  # is checksum-suffixed (cz-whdis-confload-<hash>), so select it by label
+  # rather than by name. Label verified by rendering the chart:
+  #   app.kubernetes.io/name=validator, app.kubernetes.io/part-of=cloudzero-agent
+  #
+  # Pre-check: `kubectl wait --for=condition=Complete job -l <selector>` exits 0
+  # immediately on kubectl <1.27 when no matching Job exists yet, which would
+  # vacuously pass without the Job ever appearing. Poll until at least one
+  # matching Job exists before handing off to kubectl wait.
+  - script: |
+      set -e
+      for i in $(seq 1 30); do
+        COUNT=$(kubectl get job \
+          -l app.kubernetes.io/name=validator,app.kubernetes.io/part-of=cloudzero-agent \
+          -n cz-webhookserver-disabled-test \
+          --no-headers 2>/dev/null | wc -l)
+        if [ "$COUNT" -gt 0 ]; then
+          echo "config-loader Job appeared (attempt $i)"
+          break
+        fi
+        [ "$i" -eq 30 ] && { echo "FAIL: config-loader Job never appeared" >&2; exit 1; }
+        sleep 2
+      done
+      kubectl wait --for=condition=Complete job \
+        -l app.kubernetes.io/name=validator,app.kubernetes.io/part-of=cloudzero-agent \
+        -n cz-webhookserver-disabled-test \
+        --timeout=180s
+
+  # Belt-and-suspenders: step 00's `helm --wait` already blocks on Ready, but
+  # re-assert explicitly so a failure message points at the agent (server)
+  # pod readiness rather than at helm timing out. Selector verified by render:
+  #   app.kubernetes.io/name=server, app.kubernetes.io/instance=cz-whdis
+  #
+  # Pre-check: same kubectl wait empty-selector footgun applies to pods.
+  # Poll until at least one matching pod exists before handing off to kubectl wait.
+  - script: |
+      set -e
+      for i in $(seq 1 30); do
+        COUNT=$(kubectl get pod \
+          -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-whdis \
+          -n cz-webhookserver-disabled-test \
+          --no-headers 2>/dev/null | wc -l)
+        if [ "$COUNT" -gt 0 ]; then
+          echo "Agent (server) pod appeared (attempt $i)"
+          break
+        fi
+        [ "$i" -eq 30 ] && { echo "FAIL: agent (server) pod never appeared" >&2; exit 1; }
+        sleep 2
+      done
+      kubectl wait --for=condition=Ready pod \
+        -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-whdis \
+        -n cz-webhookserver-disabled-test \
+        --timeout=180s
+
+  # Fail if the cloudzero-agent-alloy container has restarted. A disabled-webhook
+  # misconfiguration manifests as CrashLoopBackOff, so any restart > 0 before
+  # Ready flags the regression even if a later retry somehow succeeded.
+  # Scoped to the cloudzero-agent-alloy container by name (matching the
+  # alloy-clustered-test idiom) to avoid counting init-container or sidecar
+  # restarts. Container name verified by rendering with webhookServer.enabled=false.
+  - script: |
+      set -e
+      RESTARTS=$(kubectl get pod \
+        -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-whdis \
+        -n cz-webhookserver-disabled-test \
+        -o jsonpath='{.items[*].status.containerStatuses[?(@.name=="cloudzero-agent-alloy")].restartCount}')
+      echo "cloudzero-agent-alloy container restart count: $RESTARTS"
+      for r in $RESTARTS; do
+        if [ "$r" -ne 0 ]; then
+          echo "FAIL: cloudzero-agent-alloy container restarted $r times (expected 0)" >&2
+          kubectl describe pod \
+            -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-whdis \
+            -n cz-webhookserver-disabled-test >&2 || true
+          exit 1
+        fi
+      done

--- a/tests/kuttl/webhookserver-disabled-test/steps/99-uninstall.yaml
+++ b/tests/kuttl/webhookserver-disabled-test/steps/99-uninstall.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: uninstall-webhook-disabled
+# Uses `script:` (kuttl has no `args` field). Walks up to the repo root before
+# calling .tools/bin/helm, since kuttl runs scripts with CWD = this step dir.
+commands:
+  # Uninstall the dedicated release so subsequent kuttl suites and the
+  # `kind-test` teardown are unaffected. `--ignore-not-found` and `|| true`
+  # keep cleanup best-effort even if an earlier step failed.
+  - script: |
+      ROOT="$PWD"
+      while [ "$ROOT" != "/" ] && [ ! -f "$ROOT/helm/Chart.yaml" ]; do ROOT=$(dirname "$ROOT"); done
+      cd "$ROOT"
+      .tools/bin/helm uninstall cz-whdis \
+        --namespace cz-webhookserver-disabled-test \
+        --ignore-not-found || true
+      kubectl delete namespace cz-webhookserver-disabled-test \
+        --ignore-not-found --wait=false || true

--- a/tests/kuttl/webhookserver-min-footprint.yaml
+++ b/tests/kuttl/webhookserver-min-footprint.yaml
@@ -1,0 +1,70 @@
+# Minimal-footprint, fast-start overlay for the webhookServer KUTTL e2e suites.
+#
+# WHY THIS EXISTS (CP-43292):
+# `make kind-test` installs the full default `cz-agent` release first, then runs
+# every KUTTL suite against that single Kind node. Our webhookServer suites need
+# a DIFFERENTLY configured release (webhook disabled / toggled), so they install
+# their own release alongside `cz-agent` and `helm --wait` for it inside a kuttl
+# step. Two problems made that step time out in CI; this overlay addresses both
+# without changing the behavior under test:
+#
+# 1. Resource pressure. The default release already requests ~1.7 CPU; a second
+#    full-size stack pushed the Kind node past its allocatable CPU, so the new
+#    pods stayed Pending. We shrink the test release to a single replica with
+#    tiny CPU/memory requests so it bin-packs into the remaining headroom:
+#      - defaults.replicas: 1  -> one replica per component (clustered mode would
+#                                 otherwise fan the server out to 3).
+#      - tiny CPU/memory requests on every component the release runs.
+#
+# 2. Slow startup. The validator's `api_key_valid` pre-start check makes HTTP
+#    calls to the CloudZero API and retries with backoff before the server's
+#    init container exits. The test cluster uses a deliberately-invalid API key,
+#    so that check can never pass and only adds minutes of retry latency (it
+#    runs even when "optional"). We set it to "disabled" so the validator init
+#    completes promptly; api-key validation is orthogonal to the webhook gating
+#    this suite verifies. The values docs suggest exactly this for tests.
+#
+# These values affect ONLY the test release; they are never part of the shipped
+# chart defaults. Functional behavior (webhook gating, config-loader, KubeState
+# plugin) is unchanged - only resource requests, replica counts, and the
+# (always-failing, network-bound) api-key check are adjusted.
+defaults:
+  replicas: 1
+
+components:
+  validator:
+    checks:
+      pre-start:
+        api_key_valid: disabled
+      config-load:
+        api_key_valid: disabled
+
+  agent:
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "64Mi"
+
+  aggregator:
+    collector:
+      resources:
+        requests:
+          cpu: "10m"
+          memory: "64Mi"
+    shipper:
+      resources:
+        requests:
+          cpu: "10m"
+          memory: "64Mi"
+
+  miscellaneous:
+    configLoader:
+      resources:
+        requests:
+          cpu: "10m"
+          memory: "64Mi"
+    helmless:
+      resources:
+        requests:
+          cpu: "10m"
+          memory: "64Mi"

--- a/tests/kuttl/webhookserver-upgrade-test/kuttl-test.yaml
+++ b/tests/kuttl/webhookserver-upgrade-test/kuttl-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+metadata:
+  name: webhookserver-upgrade-test
+  annotations:
+    kuttl.dev/type: "test"
+testDirs:
+  - ./steps
+timeout: 600 # two helm operations up to ~4 min each + assertion headroom
+parallel: 1
+reportFormat: JSON
+reportName: webhookserver-upgrade-test-report
+# The suite installs its own helm release in a dedicated namespace and
+# uninstalls it in step 99, so we do not let kuttl delete the namespace
+# (that would leave helm release state orphaned).
+deleteNamespace: false
+namespaceLabels:
+  test: webhookserver-upgrade

--- a/tests/kuttl/webhookserver-upgrade-test/steps/00-install-webhook-enabled.yaml
+++ b/tests/kuttl/webhookserver-upgrade-test/steps/00-install-webhook-enabled.yaml
@@ -1,0 +1,53 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-webhook-enabled
+# kuttl command steps use `script:` (no `args` field exists; `command:`+`args:`
+# silently no-ops). kuttl runs scripts with CWD = this step dir, so walk up to the
+# repo root before repo-relative paths. See docs/superpowers/kuttl-commands-noop-issue.md.
+commands:
+  # Install the chart with the admission webhook server ENABLED, as a
+  # separate release in a dedicated namespace so we do not disturb the
+  # default cz-agent release other kuttl suites run against. This is the
+  # starting state for the enabled->disabled upgrade removal test (CP-43292).
+  #
+  # The in-agent KubeState plugin is on (with kube-state-metrics off, which
+  # the chart requires) to match the disabled-fresh-install suite's config.
+  #
+  # webhookserver-min-footprint.yaml shrinks this release (1 replica, tiny CPU
+  # requests) so it schedules alongside the default cz-agent release that
+  # `make kind-test` installs first; otherwise two full-size stacks exhaust a
+  # CI Kind node's CPU and helm --wait times out. See that file's header
+  # (CP-43292).
+  #
+  # The dev image tag mirrors the `make helm-install-current` target.
+  - script: |
+      set -e
+      ROOT="$PWD"
+      while [ "$ROOT" != "/" ] && [ ! -f "$ROOT/helm/Chart.yaml" ]; do ROOT=$(dirname "$ROOT"); done
+      cd "$ROOT"
+      DEV_TAG="dev-$(git rev-parse HEAD)"
+      .tools/bin/helm upgrade --install cz-whup ./helm \
+        --namespace cz-webhookserver-upgrade-test \
+        --create-namespace \
+        --values clusters/kind-overrides.yaml \
+        --values tests/kuttl/webhookserver-min-footprint.yaml \
+        --set components.agent.mode=clustered \
+        --set components.agent.image.tag="$DEV_TAG" \
+        --set components.webhookServer.enabled=true \
+        --set components.agent.kubeState.enabled=true \
+        --set kubeStateMetrics.enabled=false \
+        --wait --timeout=8m
+
+      # Positively assert the cluster-scoped webhook resources exist after
+      # the enabled install, so step 02's "must be gone" assertions prove
+      # actual removal rather than removal-of-nothing. Names verified by
+      # rendering the chart with webhookServer.enabled=true, release cz-whup:
+      #   ValidatingWebhookConfiguration -> cz-whup-cz-webhook
+      #   ClusterRole                    -> cz-whup-cz-webhook-init-cert
+      #   ClusterRoleBinding             -> cz-whup-cz-webhook-init-cert
+      # With set -e, a missing resource causes kubectl get to return non-zero
+      # and fail this step immediately.
+      kubectl get validatingwebhookconfiguration cz-whup-cz-webhook
+      kubectl get clusterrole cz-whup-cz-webhook-init-cert
+      kubectl get clusterrolebinding cz-whup-cz-webhook-init-cert

--- a/tests/kuttl/webhookserver-upgrade-test/steps/01-upgrade-webhook-disabled.yaml
+++ b/tests/kuttl/webhookserver-upgrade-test/steps/01-upgrade-webhook-disabled.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: upgrade-webhook-disabled
+# Uses `script:` and walks up to the repo root (kuttl CWD = this step dir).
+commands:
+  # Upgrade the SAME release (cz-whup) from webhook-enabled to
+  # webhook-disabled. Helm should prune the cluster-scoped webhook resources
+  # (ValidatingWebhookConfiguration + init-cert ClusterRole/ClusterRoleBinding)
+  # that no longer render. All other flags match the install step so the only
+  # change is components.webhookServer.enabled true -> false (CP-43292).
+  - script: |
+      set -e
+      ROOT="$PWD"
+      while [ "$ROOT" != "/" ] && [ ! -f "$ROOT/helm/Chart.yaml" ]; do ROOT=$(dirname "$ROOT"); done
+      cd "$ROOT"
+      DEV_TAG="dev-$(git rev-parse HEAD)"
+      .tools/bin/helm upgrade --install cz-whup ./helm \
+        --namespace cz-webhookserver-upgrade-test \
+        --values clusters/kind-overrides.yaml \
+        --values tests/kuttl/webhookserver-min-footprint.yaml \
+        --set components.agent.mode=clustered \
+        --set components.agent.image.tag="$DEV_TAG" \
+        --set components.webhookServer.enabled=false \
+        --set components.agent.kubeState.enabled=true \
+        --set kubeStateMetrics.enabled=false \
+        --wait --timeout=8m

--- a/tests/kuttl/webhookserver-upgrade-test/steps/02-check-cluster-resources-removed.yaml
+++ b/tests/kuttl/webhookserver-upgrade-test/steps/02-check-cluster-resources-removed.yaml
@@ -1,0 +1,58 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: assert-cluster-resources-removed
+# Uses `script:` (kuttl has no `args` field). kubectl reads KUBECONFIG from the
+# environment, so these need no repo-root cd.
+commands:
+  # After the enabled->disabled upgrade, the cluster-scoped webhook resources
+  # must be pruned by helm. Each `kubectl get` is expected to FAIL with
+  # NotFound; we treat existence as a failure so the step succeeds only when
+  # the resource is GONE. Names verified by rendering the chart with the
+  # webhook ENABLED (release "cz-whup"):
+  #   ValidatingWebhookConfiguration -> cz-whup-cz-webhook
+  #   ClusterRole                    -> cz-whup-cz-webhook-init-cert
+  #   ClusterRoleBinding             -> cz-whup-cz-webhook-init-cert
+
+  # Cluster-scoped ValidatingWebhookConfiguration must be gone.
+  - script: |
+      set -e
+      if kubectl get validatingwebhookconfiguration cz-whup-cz-webhook >/dev/null 2>&1; then
+        echo "FAIL: ValidatingWebhookConfiguration cz-whup-cz-webhook still exists after upgrade" >&2
+        exit 1
+      fi
+      echo "OK: ValidatingWebhookConfiguration removed"
+
+  # init-cert ClusterRole must be gone.
+  - script: |
+      set -e
+      if kubectl get clusterrole cz-whup-cz-webhook-init-cert >/dev/null 2>&1; then
+        echo "FAIL: ClusterRole cz-whup-cz-webhook-init-cert still exists after upgrade" >&2
+        exit 1
+      fi
+      echo "OK: init-cert ClusterRole removed"
+
+  # init-cert ClusterRoleBinding must be gone.
+  - script: |
+      set -e
+      if kubectl get clusterrolebinding cz-whup-cz-webhook-init-cert >/dev/null 2>&1; then
+        echo "FAIL: ClusterRoleBinding cz-whup-cz-webhook-init-cert still exists after upgrade" >&2
+        exit 1
+      fi
+      echo "OK: init-cert ClusterRoleBinding removed"
+
+  # Sanity: the namespaced webhook Deployment/Service should also be gone, so
+  # the upgrade is a genuine teardown rather than a partial prune.
+  - script: |
+      set -e
+      if kubectl get deployment cz-whup-cz-webhook \
+          -n cz-webhookserver-upgrade-test >/dev/null 2>&1; then
+        echo "FAIL: webhook Deployment cz-whup-cz-webhook still exists after upgrade" >&2
+        exit 1
+      fi
+      if kubectl get service cz-whup-cz-webhook \
+          -n cz-webhookserver-upgrade-test >/dev/null 2>&1; then
+        echo "FAIL: webhook Service cz-whup-cz-webhook still exists after upgrade" >&2
+        exit 1
+      fi
+      echo "OK: namespaced webhook Deployment and Service removed"

--- a/tests/kuttl/webhookserver-upgrade-test/steps/99-uninstall.yaml
+++ b/tests/kuttl/webhookserver-upgrade-test/steps/99-uninstall.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: uninstall-webhook-upgrade
+# Uses `script:` and walks up to the repo root (kuttl CWD = this step dir).
+commands:
+  # Uninstall the dedicated release so subsequent kuttl suites and the
+  # `kind-test` teardown are unaffected. `--ignore-not-found` and `|| true`
+  # keep cleanup best-effort even if an earlier step failed.
+  - script: |
+      ROOT="$PWD"
+      while [ "$ROOT" != "/" ] && [ ! -f "$ROOT/helm/Chart.yaml" ]; do ROOT=$(dirname "$ROOT"); done
+      cd "$ROOT"
+      .tools/bin/helm uninstall cz-whup \
+        --namespace cz-webhookserver-upgrade-test \
+        --ignore-not-found || true
+      kubectl delete namespace cz-webhookserver-upgrade-test \
+        --ignore-not-found --wait=false || true


### PR DESCRIPTION
A customer cannot run the CloudZero Agent in production with the admission webhook server enabled, and needs the informer/KubeState-based path without it. The only existing toggle, insightsController.enabled, did not cleanly disable the webhook server: the config-loader Job stuck in ContainerCreating because it mounted a webhook ConfigMap that was never created when disabled, and many webhook resources rendered even when disabled, leaving dangling objects and a perpetually-firing critical "webhook down" alert.

Implementation Approach:

Introduce a single ternary toggle, components.webhookServer.enabled (true | false | "auto", default "auto" which currently maps to true), resolved by one helper, cloudzero-agent.webhookServer.enabled. Every webhook resource, the config-loader, and the validator consult that helper, so enablement is decided in exactly one place and disabling removes the entire webhook surface with no dangling objects. The legacy insightsController.enabled (default changed from true to null) takes precedence when explicitly set, preserving backward compatibility, and is marked deprecated in the schema. "auto" maps to enabled today behind a commented seam to later follow the KubeState configuration. Default behavior is unchanged.

Functional Requirements:

1. Operators must be able to disable the webhook server with a single value, with the entire webhook surface removed.

   Added the resolver helper in helm/templates/_webhook_helpers.tpl and gated every webhook-component resource on it: the webhook Deployment, Service, ConfigMap, HPA, and PDB; the ValidatingWebhookConfiguration; the init-cert Job, ClusterRole, ClusterRoleBinding, and ServiceAccount; the TLS certificate, issuer, and secret; the backfill job; and the agent and alloy webhook scrape-config blocks (agent-cm.yaml, _alloy_helpers.tpl).

2. Disabling must not break the agent (the original ContainerCreating/CrashLoop bug).

   In config-loader-job.yaml the webhook config volume and volumeMount are gated on the resolver, and the --config-webhook argument is passed as an empty string when disabled (NewSettings("") is benign), so the loader no longer mounts an absent ConfigMap. No Go change is required.

3. The validator must not probe a webhook that is not running.

   validator-cm.yaml forces the post-start webhook_server_reachable check to "disabled" when the resolver is off, using a deepCopy of the checks map so .Values is never mutated in place.

4. A disabled but monitored install must not page operators about the absent webhook.

   The four webhook alerts in prometheusrule.yaml (CloudZeroWebhookDown, NoEvents, ServerHighLatency, RemoteWriteFailures) are individually gated on the resolver, leaving the non-webhook alerts in the shared rule group intact.

5. The new field must be schema-valid and the legacy field marked deprecated.

   Added components.webhookServer.enabled (null | boolean | "auto") and changed insightsController.enabled to (null | boolean) with deprecated: true in the source helm/values.schema.yaml, then regenerated helm/values.schema.json. Regenerated the helmless embedded defaults (app/functions/helmless/default-values.yaml) and the helm template snapshots.

Validation:

- helm-unittest: a resolver truth-table (components.webhookServer.enabled crossed with the legacy insightsController.enabled) plus per-resource presence/absence assertions across the full webhook surface; the full suite passes (72 suites, 626 tests).
- Schema: added pass/fail fixtures for components.webhookServer.enabled (true/false/auto/null pass, invalid-type fail); make helm-test-schema passes.
- KUTTL e2e (new suites, run against a local kind cluster with a freshly built dev image): the disabled fresh-install suite passes — webhook Deployment, Service, and ValidatingWebhookConfiguration absent, config-loader Job reaches Complete, and the agent pod is Ready with zero container restarts. The enabled-to-disabled upgrade suite passes — the cluster-scoped ValidatingWebhookConfiguration and init-cert ClusterRole/ClusterRoleBinding are confirmed present after the enabled install and pruned after the upgrade.
- Lint, format, and generate checks pass in CI; default-on behavior verified unchanged via a render diff.
