### PR TITLE
CP-43356: convert KUTTL command:+args: steps to valid top-level commands:

### DIFF
--- a/.github/workflows/test-matrix-k8s.yaml
+++ b/.github/workflows/test-matrix-k8s.yaml
@@ -122,6 +122,13 @@ jobs:
           command: |
             make install-tools V=1
 
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Complete Chart Tests
         env:
           CLOUDZERO_DEV_API_KEY: ${{ secrets.CLOUDZERO_DEV_API_KEY }}
@@ -134,8 +141,29 @@ jobs:
           # Create cluster configuration files for this test run
           cp clusters/kind.yaml "clusters/$CLUSTER_NAME.yaml"
           cp clusters/kind-overrides.yaml "clusters/$CLUSTER_NAME-overrides.yaml"
-          # Run the complete test workflow using Kind
-          make kind-test "CLUSTER_NAME=$CLUSTER_NAME" V=1
+
+          # The chart (and the alloy-clustered-test suite) install the agent image
+          # at <prod-repo>:dev-<sha>, which is NOT published for a PR. Pull the
+          # freshly-built (untested) image for this matrix arch, retag it as the
+          # tag the chart installs, and kind-load it into the node so pods can start
+          # (chart imagePullPolicy is IfNotPresent). Pull single-arch: kind cannot
+          # load a multi-arch manifest list.
+          SRC="${{ inputs.image-repo }}/${{ inputs.image-path }}:${{ inputs.image-tag }}"
+          DST="ghcr.io/cloudzero/cloudzero-agent:dev-$(git rev-parse HEAD)"
+          docker pull --platform "${{ matrix.kver.platform }}" "$SRC"
+          docker tag "$SRC" "$DST"
+
+          # Run the test workflow phases explicitly so the image is loaded between
+          # cluster creation and chart install (the monolithic `kind-test` target
+          # does not expose that seam).
+          test_status=0
+          make kind-up "CLUSTER_NAME=$CLUSTER_NAME" V=1
+          make kind-load "CLUSTER_NAME=$CLUSTER_NAME" LOAD_IMAGE="$DST" V=1
+          make helm-install-current helm-wait "CLUSTER_NAME=$CLUSTER_NAME" V=1
+          make helm-test-kuttl "CLUSTER_NAME=$CLUSTER_NAME" V=1 || test_status=$?
+          make helm-uninstall "CLUSTER_NAME=$CLUSTER_NAME" V=1 || true
+          make kind-down "CLUSTER_NAME=$CLUSTER_NAME" V=1 || true
+          exit $test_status
 
       - name: Set version output
         id: set-output
@@ -250,6 +278,13 @@ jobs:
           echo "Contents:"
           cat "$EXTRA_OVERRIDES_FILE"
 
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Chart Tests with Specialized Configuration
         env:
           CLOUDZERO_DEV_API_KEY: ${{ secrets.CLOUDZERO_DEV_API_KEY }}
@@ -263,8 +298,25 @@ jobs:
           # Create cluster configuration files for this test run
           cp clusters/kind.yaml "clusters/$CLUSTER_NAME.yaml"
           cp clusters/kind-overrides.yaml "clusters/$CLUSTER_NAME-overrides.yaml"
-          # Run the complete test workflow using Kind with extra overrides
-          make kind-test "CLUSTER_NAME=$CLUSTER_NAME" "HELM_EXTRA_OVERRIDES=$HELM_EXTRA_OVERRIDES" V=1
+
+          # Make the freshly-built (untested) agent image available to the kind
+          # node under the tag the chart installs (see the version-matrix job for
+          # the full rationale). Pull single-arch so kind can load it.
+          SRC="${{ inputs.image-repo }}/${{ inputs.image-path }}:${{ inputs.image-tag }}"
+          DST="ghcr.io/cloudzero/cloudzero-agent:dev-$(git rev-parse HEAD)"
+          docker pull --platform linux/amd64 "$SRC"
+          docker tag "$SRC" "$DST"
+
+          # Run the test workflow phases explicitly so the image is loaded between
+          # cluster creation and chart install.
+          test_status=0
+          make kind-up "CLUSTER_NAME=$CLUSTER_NAME" V=1
+          make kind-load "CLUSTER_NAME=$CLUSTER_NAME" LOAD_IMAGE="$DST" V=1
+          make helm-install-current helm-wait "CLUSTER_NAME=$CLUSTER_NAME" "HELM_EXTRA_OVERRIDES=$HELM_EXTRA_OVERRIDES" V=1
+          make helm-test-kuttl "CLUSTER_NAME=$CLUSTER_NAME" "HELM_EXTRA_OVERRIDES=$HELM_EXTRA_OVERRIDES" V=1 || test_status=$?
+          make helm-uninstall "CLUSTER_NAME=$CLUSTER_NAME" "HELM_EXTRA_OVERRIDES=$HELM_EXTRA_OVERRIDES" V=1 || true
+          make kind-down "CLUSTER_NAME=$CLUSTER_NAME" V=1 || true
+          exit $test_status
 
       - name: Set config output
         id: set-output

--- a/Makefile
+++ b/Makefile
@@ -430,6 +430,16 @@ CLUSTER_NAME              ?= kind
 kind-up: # Create kind cluster for testing
 kind-up: tests/kuttl/kubeconfig
 
+# kind-load - Load a locally-available docker image into the kind cluster's node
+# so pods can use it without pulling from a registry (chart imagePullPolicy is
+# IfNotPresent). Used by CI to make the freshly-built (untested) agent image
+# available under the tag the chart installs. Set LOAD_IMAGE to the image ref.
+.PHONY: kind-load
+kind-load: ## Load LOAD_IMAGE into the kind cluster (uses CLUSTER_NAME)
+	$(if $(LOAD_IMAGE),,$(error LOAD_IMAGE must be set, e.g. make kind-load LOAD_IMAGE=repo/image:tag))
+	$(call LOG,KIND,load $(LOAD_IMAGE) into $(CLUSTER_NAME))
+	$(Q)$(KIND) load docker-image "$(LOAD_IMAGE)" --name $(CLUSTER_NAME)
+
 .PHONY: kind-down
 kind-down: ## Delete kind cluster and cleanup
 	$(call LOG,KIND,delete cluster $(CLUSTER_NAME))

--- a/tests/kuttl/alloy-clustered-test/steps/01-install-clustered-chart.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/01-install-clustered-chart.yaml
@@ -2,21 +2,32 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: install-clustered-chart
-spec:
-  commands:
-    # Install the chart in clustered mode as a separate release so we do not
-    # disturb the default cz-agent release other KUTTL suites run against.
-    # The dev image tag mirrors the `make helm-install-current` target.
-    - command: sh
-      args:
-        - "-c"
-        - |
-          set -e
-          DEV_TAG="dev-$(git rev-parse HEAD)"
-          .tools/bin/helm upgrade --install cz-alloy-ct ./helm \
-            --namespace cz-alloy-clustered-test \
-            --create-namespace \
-            --values clusters/kind-overrides.yaml \
-            --set components.agent.mode=clustered \
-            --set components.agent.image.tag="$DEV_TAG" \
-            --wait --timeout=3m
+# kuttl command steps use top-level `commands:` with `script:` (a shell-script
+# string). kuttl's TestStep has no `spec` field and its Command has no `args`
+# field (`command` is a single string), so the previous `spec:`+`command:`+`args:`
+# shape silently no-opped. kuttl also runs scripts with CWD = this step directory,
+# so we walk up to the repo root before using repo-relative paths
+# (.tools/bin/helm, ./helm, clusters/).
+commands:
+  # Install the chart in clustered mode as a separate release so we do not
+  # disturb the default release other kuttl suites run against.
+  # The dev image tag mirrors the `make helm-install-current` target.
+  #
+  # `timeout:` must exceed `helm --wait --timeout=3m` (180s). kuttl applies a 30s
+  # per-command timeout here (this suite's kuttl-test.yaml sets `spec.timeout`, which
+  # kuttl ignores — the timeout field is top-level — so the 30s default applies), and
+  # that would kill the install mid-wait. The explicit per-command `timeout:` overrides it.
+  - timeout: 240
+    script: |
+      set -e
+      ROOT="$PWD"
+      while [ "$ROOT" != "/" ] && [ ! -f "$ROOT/helm/Chart.yaml" ]; do ROOT=$(dirname "$ROOT"); done
+      cd "$ROOT"
+      DEV_TAG="dev-$(git rev-parse HEAD)"
+      .tools/bin/helm upgrade --install cz-alloy-ct ./helm \
+        --namespace cz-alloy-clustered-test \
+        --create-namespace \
+        --values clusters/kind-overrides.yaml \
+        --set components.agent.mode=clustered \
+        --set components.agent.image.tag="$DEV_TAG" \
+        --wait --timeout=3m

--- a/tests/kuttl/alloy-clustered-test/steps/02-verify-alloy-ready.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/02-verify-alloy-ready.yaml
@@ -2,59 +2,74 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: verify-alloy-ready
-spec:
-  commands:
-    # Belt-and-suspenders: step 01's `helm --wait` already blocks on Ready,
-    # but re-assert explicitly here so the failure message points at readiness
-    # rather than at helm timing out.
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=Ready
-        - pod
-        - -l
-        - app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct
-        - -n
-        - cz-alloy-clustered-test
-        - --timeout=180s
-    # Fail if the Alloy container has restarted at all. The pre-fix failure
-    # is CrashLoopBackOff on first start, so any restart > 0 before Ready
-    # flags the regression even if a later retry somehow succeeded.
-    - command: sh
-      args:
-        - "-c"
-        - |
-          set -e
-          RESTARTS=$(kubectl get pod \
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped. These steps are kubectl-only
+# and read KUBECONFIG from the environment, so no repo-root cd is needed.
+commands:
+  # Belt-and-suspenders: step 01's `helm --wait` already blocks on Ready,
+  # but re-assert explicitly here so the failure message points at readiness
+  # rather than at helm timing out.
+  #
+  # Pre-check: `kubectl wait -l <selector>` exits 0 immediately on kubectl <1.27
+  # when no pod yet matches, which would vacuously pass. Poll until at least one
+  # matching pod exists before handing off to kubectl wait.
+  #
+  # `timeout:` must cover the up-to-~60s poll loop + `kubectl wait --timeout=180s`; kuttl's
+  # 30s per-command default (suite spec.timeout is ignored) would otherwise clamp it.
+  - timeout: 300
+    script: |
+      set -e
+      for i in $(seq 1 30); do
+        COUNT=$(kubectl get pod \
+          -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+          -n cz-alloy-clustered-test \
+          --no-headers 2>/dev/null | wc -l)
+        if [ "$COUNT" -gt 0 ]; then
+          echo "Alloy (server) pod appeared (attempt $i)"
+          break
+        fi
+        [ "$i" -eq 30 ] && { echo "FAIL: Alloy (server) pod never appeared" >&2; exit 1; }
+        sleep 2
+      done
+      kubectl wait --for=condition=Ready pod \
+        -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+        -n cz-alloy-clustered-test \
+        --timeout=180s
+
+  # Fail if the Alloy container has restarted at all. The pre-fix failure
+  # is CrashLoopBackOff on first start, so any restart > 0 before Ready
+  # flags the regression even if a later retry somehow succeeded.
+  - script: |
+      set -e
+      RESTARTS=$(kubectl get pod \
+        -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+        -n cz-alloy-clustered-test \
+        -o jsonpath='{.items[*].status.containerStatuses[?(@.name=="cloudzero-agent-alloy")].restartCount}')
+      echo "Alloy container restart count: $RESTARTS"
+      for r in $RESTARTS; do
+        if [ "$r" -ne 0 ]; then
+          echo "FAIL: Alloy container restarted $r times (expected 0)" >&2
+          kubectl describe pod \
             -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
-            -n cz-alloy-clustered-test \
-            -o jsonpath='{.items[*].status.containerStatuses[?(@.name=="cloudzero-agent-alloy")].restartCount}')
-          echo "Alloy container restart count: $RESTARTS"
-          for r in $RESTARTS; do
-            if [ "$r" -ne 0 ]; then
-              echo "FAIL: Alloy container restarted $r times (expected 0)" >&2
-              kubectl describe pod \
-                -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
-                -n cz-alloy-clustered-test >&2 || true
-              exit 1
-            fi
-          done
-    # Fail if the specific /tmp regression signature appears in Alloy logs.
-    # Pins this assertion to CP-40307 so unrelated clustered-mode failures
-    # can't silently green-bar.
-    - command: sh
-      args:
-        - "-c"
-        - |
-          set -e
-          LOGS=$(kubectl logs \
-            -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
-            -n cz-alloy-clustered-test \
-            -c cloudzero-agent-alloy \
-            --all-containers=false \
-            --tail=-1 2>&1 || true)
-          if echo "$LOGS" | grep -q 'mkdir /tmp: permission denied'; then
-            echo "FAIL: Alloy logs contain the CP-40307 regression signature" >&2
-            echo "$LOGS" >&2
-            exit 1
-          fi
+            -n cz-alloy-clustered-test >&2 || true
+          exit 1
+        fi
+      done
+
+  # Fail if the specific /tmp regression signature appears in Alloy logs.
+  # Pins this assertion to CP-40307 so unrelated clustered-mode failures
+  # can't silently green-bar.
+  - script: |
+      set -e
+      LOGS=$(kubectl logs \
+        -l app.kubernetes.io/name=server,app.kubernetes.io/instance=cz-alloy-ct \
+        -n cz-alloy-clustered-test \
+        -c cloudzero-agent-alloy \
+        --all-containers=false \
+        --tail=-1 2>&1 || true)
+      if echo "$LOGS" | grep -q 'mkdir /tmp: permission denied'; then
+        echo "FAIL: Alloy logs contain the CP-40307 regression signature" >&2
+        echo "$LOGS" >&2
+        exit 1
+      fi

--- a/tests/kuttl/alloy-clustered-test/steps/99-uninstall.yaml
+++ b/tests/kuttl/alloy-clustered-test/steps/99-uninstall.yaml
@@ -2,17 +2,23 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: uninstall-clustered-chart
-spec:
-  commands:
-    # Uninstall the dedicated release so subsequent kuttl suites and the
-    # `kind-test` teardown are unaffected. `--ignore-not-found` and `|| true`
-    # keep cleanup best-effort even if an earlier step failed.
-    - command: sh
-      args:
-        - "-c"
-        - |
-          .tools/bin/helm uninstall cz-alloy-ct \
-            --namespace cz-alloy-clustered-test \
-            --ignore-not-found || true
-          kubectl delete namespace cz-alloy-clustered-test \
-            --ignore-not-found --wait=false || true
+# Uses top-level `commands:` with `script:` (kuttl's TestStep has no `spec` field
+# and its Command has no `args` field). Walks up to the repo root before calling
+# .tools/bin/helm, since kuttl runs scripts with CWD = this step dir.
+commands:
+  # Uninstall the dedicated release so subsequent kuttl suites and the
+  # `kind-test` teardown are unaffected. `--ignore-not-found` and `|| true`
+  # keep cleanup best-effort even if an earlier step failed.
+  #
+  # Headroom over the 30s per-command timeout (this suite's kuttl-test.yaml sets
+  # `spec.timeout`, which kuttl ignores, so the 30s default applies) for helm uninstall.
+  - timeout: 120
+    script: |
+      ROOT="$PWD"
+      while [ "$ROOT" != "/" ] && [ ! -f "$ROOT/helm/Chart.yaml" ]; do ROOT=$(dirname "$ROOT"); done
+      cd "$ROOT"
+      .tools/bin/helm uninstall cz-alloy-ct \
+        --namespace cz-alloy-clustered-test \
+        --ignore-not-found || true
+      kubectl delete namespace cz-alloy-clustered-test \
+        --ignore-not-found --wait=false || true

--- a/tests/kuttl/collector-comprehensive-test/steps/02-validate-collector-logs.yaml
+++ b/tests/kuttl/collector-comprehensive-test/steps/02-validate-collector-logs.yaml
@@ -2,44 +2,42 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: validate-collector-logs
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=available
-        - deployment/collector-comprehensive-test-deployment
-        - -n
-        - collector-comprehensive-test-namespace
-        - --timeout=60s
-    - command: sleep
-      args:
-        - "60"
-    - command: sh
-      args:
-        - -c
-        - "echo '=== Validating Collector Logs ==='"
-    - command: sh
-      args:
-        - -c
-        - "kubectl logs deployment/cz-agent-aggregator -n cz-agent -c cz-agent-aggregator-collector --since=2m > /tmp/collector-logs.txt || echo 'Warning: Failed to get collector logs'"
-    - command: sh
-      args:
-        - -c
-        - "if grep -q 'remote_write.*metrics' /tmp/collector-logs.txt; then echo 'Remote write metrics found in logs'; else echo 'No remote_write metrics found'; fi"
-    - command: sh
-      args:
-        - -c
-        - "grep -q 'kube_pod_info' /tmp/collector-logs.txt && echo 'Found metric: kube_pod_info' || echo 'Missing metric: kube_pod_info'"
-    - command: sh
-      args:
-        - -c
-        - "grep -q 'kube_pod_labels' /tmp/collector-logs.txt && echo 'Found metric: kube_pod_labels' || echo 'Missing metric: kube_pod_labels'"
-    - command: sh
-      args:
-        - -c
-        - "grep -q 'czo_cost_metrics_shipping_progress' /tmp/collector-logs.txt && echo 'Found metric: czo_cost_metrics_shipping_progress' || echo 'Missing metric: czo_cost_metrics_shipping_progress'"
-    - command: sh
-      args:
-        - -c
-        - "if grep -q 'czo_webhook' /tmp/collector-logs.txt; then echo 'Webhook metrics being collected'; else echo 'No webhook metrics found in collector logs'; fi"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# The aggregator is referenced by LABEL (app.kubernetes.io/name=aggregator) in its
+# actual namespace, not the stale hardcoded `deployment/cz-agent-aggregator -n cz-agent`.
+# The alloy co-install (instance=cz-alloy-ct) is excluded. The log-content checks are
+# best-effort diagnostics (they print Found/Missing and never fail the step), matching
+# the original intent.
+commands:
+  # Hard assertion: the suite's own test deployment (created in step 01) must be available.
+  # `timeout:` covers the wait's --timeout=60s (kuttl's 30s default would otherwise clamp it).
+  - command: kubectl wait --for=condition=available deployment/collector-comprehensive-test-deployment -n collector-comprehensive-test-namespace --timeout=60s
+    timeout: 90
+  # kuttl applies a 30s per-command timeout here (the suite's kuttl-test.yaml sets
+  # `spec.timeout`, which kuttl ignores — the field is top-level — so the 30s default
+  # applies); this 60s settle sleep needs a larger explicit `timeout:`.
+  - command: sleep 60
+    timeout: 90
+  # Best-effort log-content diagnostics. Consolidated into one script so the log
+  # capture and the greps share a shell (the original chained via a /tmp file).
+  - script: |
+      echo '=== Validating Collector Logs ==='
+      NS=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null)
+      CONTAINER=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -o jsonpath='{.items[0].spec.template.spec.containers[?(@.name)].name}' 2>/dev/null \
+        | tr ' ' '\n' | grep -- '-aggregator-collector$' | head -1)
+      kubectl logs \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -c "$CONTAINER" --since=2m > /tmp/collector-logs.txt 2>/dev/null \
+        || echo 'Warning: Failed to get collector logs'
+      if grep -q 'remote_write.*metrics' /tmp/collector-logs.txt; then echo 'Remote write metrics found in logs'; else echo 'No remote_write metrics found'; fi
+      grep -q 'kube_pod_info' /tmp/collector-logs.txt && echo 'Found metric: kube_pod_info' || echo 'Missing metric: kube_pod_info'
+      grep -q 'kube_pod_labels' /tmp/collector-logs.txt && echo 'Found metric: kube_pod_labels' || echo 'Missing metric: kube_pod_labels'
+      grep -q 'czo_cost_metrics_shipping_progress' /tmp/collector-logs.txt && echo 'Found metric: czo_cost_metrics_shipping_progress' || echo 'Missing metric: czo_cost_metrics_shipping_progress'
+      if grep -q 'czo_webhook' /tmp/collector-logs.txt; then echo 'Webhook metrics being collected'; else echo 'No webhook metrics found in collector logs'; fi

--- a/tests/kuttl/collector-comprehensive-test/steps/03-test-collector-metrics.yaml
+++ b/tests/kuttl/collector-comprehensive-test/steps/03-test-collector-metrics.yaml
@@ -2,25 +2,19 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: test-collector-metrics
-spec:
-  commands:
-    - command: sh
-      args:
-        - -c
-        - "echo '=== Testing Collector Metrics Endpoints ==='"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_pod_info' && echo '✅ Pod metrics found' || echo '❌ No pod metrics found'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_deployment' && echo '✅ Deployment metrics found' || echo '❌ No deployment metrics found'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_service' && echo '✅ Service metrics found' || echo '❌ No service metrics found'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-aggregator.cz-agent.svc.cluster.local/metrics | head -20 || echo 'Warning: Collector metrics endpoint test failed'"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# These checks curl in-cluster service DNS (*.svc.cluster.local), which does NOT
+# resolve from the host where kuttl runs scripts, so they remain best-effort
+# diagnostics (every line exits 0 via `|| echo`), faithfully matching the original
+# intent. Hardening these into genuine assertions (port-forward / in-cluster exec)
+# is a deliberate follow-up, not this ticket.
+commands:
+  - script: |
+      echo '=== Testing Collector Metrics Endpoints ==='
+      curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_pod_info' && echo '✅ Pod metrics found' || echo '❌ No pod metrics found'
+      curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_deployment' && echo '✅ Deployment metrics found' || echo '❌ No deployment metrics found'
+      curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | grep -q 'kube_service' && echo '✅ Service metrics found' || echo '❌ No service metrics found'
+      curl -m 10 http://cz-agent-aggregator.cz-agent.svc.cluster.local/metrics | head -20 || echo 'Warning: Collector metrics endpoint test failed'

--- a/tests/kuttl/collector-test/steps/02-verify-collector-logs.yaml
+++ b/tests/kuttl/collector-test/steps/02-verify-collector-logs.yaml
@@ -2,26 +2,46 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: verify-collector-logs
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=available
-        - deployment/metric-test-deployment
-        - -n
-        - metric-test-namespace
-        - --timeout=60s
-    - command: sleep
-      args:
-        - "30"
-    - command: kubectl
-      args:
-        - logs
-        - deployment/cz-agent-aggregator
-        - -n
-        - cz-agent
-        - -c
-        - cz-agent-aggregator-collector
-        - --since=2m
-        - --tail=20
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field (`command` is a single
+# string), so the previous `spec:`+`command:`+`args:` shape silently no-opped.
+# kubectl reads KUBECONFIG from the environment, so no repo-root cd is needed.
+#
+# The shared agent install is referenced by LABEL (app.kubernetes.io/name=aggregator)
+# in the namespace it was actually installed into, NOT by the stale hardcoded name
+# `deployment/cz-agent-aggregator -n cz-agent` (the chart names it `<release>-cz-aggregator`
+# and the namespace/release are config-driven, e.g. im-a-namespace/im-a-release on kind).
+# The alloy-clustered-test release (instance=cz-alloy-ct) installs the same chart, so it
+# is excluded from discovery.
+commands:
+  # The suite's own test deployment (created in step 01) must be available.
+  # `timeout:` must cover the wait's own --timeout=60s; without it kuttl's 30s
+  # per-command default (suite spec.timeout is ignored) would clamp the wait to 30s.
+  - command: kubectl wait --for=condition=available deployment/metric-test-deployment -n metric-test-namespace --timeout=60s
+    timeout: 90
+  # Let the collector scrape a couple of cycles. kuttl applies a 30s per-command
+  # timeout here (the suite's kuttl-test.yaml sets `spec.timeout`, which kuttl ignores
+  # — the timeout field is top-level — so the 30s default applies), so this 30s sleep
+  # needs an explicit larger `timeout:` or it races the deadline.
+  - command: sleep 30
+    timeout: 60
+  # Fetch the aggregator's collector-container logs from the shared install,
+  # discovered by label (excluding the alloy co-install).
+  - script: |
+      set -e
+      NS=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}')
+      [ -n "$NS" ] || { echo "FAIL: shared aggregator deployment not found" >&2; exit 1; }
+      # The collector container is named "<release>-cz-aggregator-collector"; select it
+      # generically rather than hardcoding the release prefix.
+      CONTAINER=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -o jsonpath='{.items[0].spec.template.spec.containers[?(@.name)].name}' \
+        | tr ' ' '\n' | grep -- '-aggregator-collector$' | head -1)
+      echo "aggregator namespace=$NS collector container=$CONTAINER"
+      kubectl logs \
+        -l 'app.kubernetes.io/name=aggregator,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" \
+        -c "$CONTAINER" \
+        --since=2m --tail=20

--- a/tests/kuttl/collector-test/steps/03-test-collector-metrics.yaml
+++ b/tests/kuttl/collector-test/steps/03-test-collector-metrics.yaml
@@ -2,19 +2,34 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: test-collector-metrics
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - port-forward
-        - service/cz-agent-cloudzero-state-metrics
-        - 8080:8080
-        - -n
-        - cz-agent
-    - command: sleep
-      args:
-        - "5"
-    - command: sh
-      args:
-        - -c
-        - "curl http://localhost:8080/metrics | head -20"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# This consolidates port-forward + curl into ONE script because kuttl runs each
+# command entry in a separate shell — a foreground `kubectl port-forward` would
+# block the step forever, so it is backgrounded and torn down via `trap`. The
+# state-metrics service is selected by LABEL (app.kubernetes.io/name=ksm) in its
+# actual namespace, not the stale hardcoded `service/cz-agent-cloudzero-state-metrics
+# -n cz-agent`. The alloy co-install (instance=cz-alloy-ct) is excluded.
+commands:
+  - script: |
+      set -e
+      NS=$(kubectl get svc \
+        -l 'app.kubernetes.io/name=ksm,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}')
+      SVC=$(kubectl get svc \
+        -l 'app.kubernetes.io/name=ksm,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -o jsonpath='{.items[0].metadata.name}')
+      [ -n "$NS" ] && [ -n "$SVC" ] || { echo "FAIL: state-metrics (ksm) service not found" >&2; exit 1; }
+      echo "port-forwarding svc/$SVC -n $NS"
+      kubectl port-forward "service/$SVC" 8080:8080 -n "$NS" >/tmp/cz-ksm-pf.log 2>&1 &
+      PF=$!
+      trap 'kill $PF 2>/dev/null || true' EXIT
+      sleep 5
+      # Land the body first so a failed fetch fails the step: piping `curl | head`
+      # would mask curl's exit status (the pipeline returns head's, always 0), and
+      # `set -o pipefail` is unsafe here (head closing the pipe SIGPIPEs a successful
+      # curl). Fetch to a file under `set -e`, then head it.
+      curl -sf http://localhost:8080/metrics -o /tmp/cz-ksm-metrics.txt
+      head -20 /tmp/cz-ksm-metrics.txt

--- a/tests/kuttl/webhook-comprehensive-test/steps/02-verify-webhook-health.yaml
+++ b/tests/kuttl/webhook-comprehensive-test/steps/02-verify-webhook-health.yaml
@@ -2,32 +2,25 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: verify-webhook-health
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=available
-        - deployment/webhook-comprehensive-test-deployment
-        - -n
-        - webhook-comprehensive-test-namespace
-        - --timeout=60s
-    - command: sleep
-      args:
-        - "30"
-    - command: sh
-      args:
-        - -c
-        - "echo '=== Testing Webhook Health Endpoints ==='"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 -k https://cz-agent-cloudzero-agent-webhook-server-svc.cz-agent.svc.cluster.local:443/healthz || echo 'Warning: Webhook health endpoint test failed'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | head -10 || echo 'Warning: State metrics endpoint test failed'"
-    - command: sh
-      args:
-        - -c
-        - "curl -m 10 http://cz-agent-aggregator.cz-agent.svc.cluster.local/metrics | head -10 || echo 'Warning: Collector metrics endpoint test failed'"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# The endpoint checks curl in-cluster service DNS (*.svc.cluster.local), which does
+# NOT resolve from the host where kuttl runs scripts, so they remain best-effort
+# diagnostics (`|| echo Warning`), faithfully matching the original intent. Only the
+# test-namespace deployment wait (created by step 01) is a hard assertion.
+commands:
+  # Hard assertion: the suite's own test deployment (created in step 01) must be available.
+  # `timeout:` covers the wait's --timeout=60s (kuttl's 30s default would otherwise clamp it).
+  - command: kubectl wait --for=condition=available deployment/webhook-comprehensive-test-deployment -n webhook-comprehensive-test-namespace --timeout=60s
+    timeout: 90
+  # kuttl's default per-command timeout is 30s; this 30s settle sleep needs a larger one.
+  - command: sleep 30
+    timeout: 60
+  # Best-effort endpoint diagnostics (in-cluster DNS not reachable from host).
+  - script: |
+      echo '=== Testing Webhook Health Endpoints ==='
+      curl -m 10 -k https://cz-agent-cloudzero-agent-webhook-server-svc.cz-agent.svc.cluster.local:443/healthz || echo 'Warning: Webhook health endpoint test failed'
+      curl -m 10 http://cz-agent-cloudzero-state-metrics.cz-agent.svc.cluster.local:8080/metrics | head -10 || echo 'Warning: State metrics endpoint test failed'
+      curl -m 10 http://cz-agent-aggregator.cz-agent.svc.cluster.local/metrics | head -10 || echo 'Warning: Collector metrics endpoint test failed'

--- a/tests/kuttl/webhook-comprehensive-test/steps/03-validate-webhook-metrics.yaml
+++ b/tests/kuttl/webhook-comprehensive-test/steps/03-validate-webhook-metrics.yaml
@@ -2,24 +2,24 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: validate-webhook-metrics
-spec:
-  commands:
-    - command: sleep
-      args:
-        - "30"
-    - command: sh
-      args:
-        - -c
-        - "echo '=== Validating Webhook Metrics ==='"
-    - command: sh
-      args:
-        - -c
-        - "WEBHOOK_METRICS=$(curl -m 10 -k https://cz-agent-cloudzero-agent-webhook-server-svc.cz-agent.svc.cluster.local:443/metrics) || echo 'Warning: Failed to fetch webhook metrics'"
-    - command: sh
-      args:
-        - -c
-        - 'if echo "$WEBHOOK_METRICS" | grep -q ''czo_webhook_types_total''; then echo ''✅ Webhook metrics found''; echo "$WEBHOOK_METRICS" | grep ''czo_webhook_types_total''; else echo ''❌ No webhook metrics found''; fi'
-    - command: sh
-      args:
-        - -c
-        - 'WEBHOOK_COUNT=$(echo "$WEBHOOK_METRICS" | grep ''czo_webhook_types_total'' | wc -l); if [ "$WEBHOOK_COUNT" -gt 0 ]; then echo "✅ Webhook metrics found ($WEBHOOK_COUNT entries)"; else echo ''❌ No webhook metrics found''; fi'
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# These five original commands MUST live in one `script:` block: $WEBHOOK_METRICS is
+# set by the curl and read by the later grep/count steps, and kuttl runs each command
+# entry in a SEPARATE shell — split across entries the variable would be empty and the
+# checks would silently always report "no metrics". The curl hits in-cluster service DNS
+# (*.svc.cluster.local), which does not resolve from the host, so this stays a
+# best-effort diagnostic (every path exits 0), faithfully matching the original intent.
+commands:
+  # kuttl applies a 30s per-command timeout here (the suite's kuttl-test.yaml sets
+  # `spec.timeout`, which kuttl ignores — the field is top-level — so the 30s default
+  # applies); this block sleeps 30s then curls, so it needs a larger explicit `timeout:`.
+  - timeout: 90
+    script: |
+      sleep 30
+      echo '=== Validating Webhook Metrics ==='
+      WEBHOOK_METRICS=$(curl -m 10 -k https://cz-agent-cloudzero-agent-webhook-server-svc.cz-agent.svc.cluster.local:443/metrics) || echo 'Warning: Failed to fetch webhook metrics'
+      if echo "$WEBHOOK_METRICS" | grep -q 'czo_webhook_types_total'; then echo '✅ Webhook metrics found'; echo "$WEBHOOK_METRICS" | grep 'czo_webhook_types_total'; else echo '❌ No webhook metrics found'; fi
+      WEBHOOK_COUNT=$(echo "$WEBHOOK_METRICS" | grep 'czo_webhook_types_total' | wc -l); if [ "$WEBHOOK_COUNT" -gt 0 ]; then echo "✅ Webhook metrics found ($WEBHOOK_COUNT entries)"; else echo '❌ No webhook metrics found'; fi

--- a/tests/kuttl/webhook-test/steps/02-verify-webhook-events.yaml
+++ b/tests/kuttl/webhook-test/steps/02-verify-webhook-events.yaml
@@ -2,32 +2,33 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: verify-webhook-events
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - wait
-        - --for=condition=available
-        - deployment/webhook-test-deployment
-        - -n
-        - webhook-test-namespace
-        - --timeout=60s
-    - command: sleep
-      args:
-        - "10"
-    - command: kubectl
-      args:
-        - get
-        - pods
-        - -n
-        - webhook-test-namespace
-        - -o
-        - wide
-    - command: kubectl
-      args:
-        - logs
-        - deployment/cz-agent-cloudzero-agent-webhook-server
-        - -n
-        - cz-agent
-        - --since=2m
-        - --tail=10
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped. kubectl reads KUBECONFIG
+# from the environment, so no repo-root cd is needed.
+#
+# The shared webhook server is referenced by LABEL (app.kubernetes.io/name=webhook-server)
+# in its actual namespace, NOT by the stale hardcoded name
+# `deployment/cz-agent-cloudzero-agent-webhook-server -n cz-agent` (the chart names it
+# `<release>-cz-webhook`; the namespace/release are config-driven). The alloy co-install
+# (instance=cz-alloy-ct) is excluded.
+commands:
+  # The suite's own test deployment (created in step 01) must be available.
+  # `timeout:` covers the wait's --timeout=60s (kuttl's 30s default would otherwise clamp it).
+  - command: kubectl wait --for=condition=available deployment/webhook-test-deployment -n webhook-test-namespace --timeout=60s
+    timeout: 90
+  - command: sleep 10
+  # Diagnostic: list the suite's test pods.
+  - command: kubectl get pods -n webhook-test-namespace -o wide
+  # Fetch the shared webhook-server logs, discovered by label (excluding alloy).
+  - script: |
+      set -e
+      NS=$(kubectl get deploy \
+        -l 'app.kubernetes.io/name=webhook-server,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}')
+      [ -n "$NS" ] || { echo "FAIL: shared webhook-server deployment not found" >&2; exit 1; }
+      echo "webhook-server namespace=$NS"
+      kubectl logs \
+        -l 'app.kubernetes.io/name=webhook-server,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" \
+        --since=2m --tail=10

--- a/tests/kuttl/webhook-test/steps/03-test-metrics-endpoint.yaml
+++ b/tests/kuttl/webhook-test/steps/03-test-metrics-endpoint.yaml
@@ -2,19 +2,34 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 metadata:
   name: test-metrics-endpoint
-spec:
-  commands:
-    - command: kubectl
-      args:
-        - port-forward
-        - service/cz-agent-cloudzero-agent-webhook-server-svc
-        - 8443:443
-        - -n
-        - cz-agent
-    - command: sleep
-      args:
-        - "5"
-    - command: sh
-      args:
-        - -c
-        - "curl -k https://localhost:8443/metrics | head -20"
+# kuttl command steps use top-level `commands:` with `script:`. kuttl's TestStep
+# has no `spec` field and its Command has no `args` field, so the previous
+# `spec:`+`command:`+`args:` shape silently no-opped.
+#
+# Consolidated into ONE script because kuttl runs each command entry in a separate
+# shell — a foreground `kubectl port-forward` would block the step forever, so it is
+# backgrounded and torn down via `trap`. The webhook-server service is selected by
+# LABEL (app.kubernetes.io/name=webhook-server) in its actual namespace, not the stale
+# hardcoded `service/cz-agent-cloudzero-agent-webhook-server-svc -n cz-agent`.
+# The alloy co-install (instance=cz-alloy-ct) is excluded.
+commands:
+  - script: |
+      set -e
+      NS=$(kubectl get svc \
+        -l 'app.kubernetes.io/name=webhook-server,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -A -o jsonpath='{.items[0].metadata.namespace}')
+      SVC=$(kubectl get svc \
+        -l 'app.kubernetes.io/name=webhook-server,app.kubernetes.io/instance!=cz-alloy-ct' \
+        -n "$NS" -o jsonpath='{.items[0].metadata.name}')
+      [ -n "$NS" ] && [ -n "$SVC" ] || { echo "FAIL: webhook-server service not found" >&2; exit 1; }
+      echo "port-forwarding svc/$SVC -n $NS"
+      kubectl port-forward "service/$SVC" 8443:443 -n "$NS" >/tmp/cz-webhook-pf.log 2>&1 &
+      PF=$!
+      trap 'kill $PF 2>/dev/null || true' EXIT
+      sleep 5
+      # Land the body first so a failed fetch fails the step: piping `curl | head`
+      # would mask curl's exit status (the pipeline returns head's, always 0), and
+      # `set -o pipefail` is unsafe here (head closing the pipe SIGPIPEs a successful
+      # curl). Fetch to a file under `set -e`, then head it.
+      curl -skf https://localhost:8443/metrics -o /tmp/cz-webhook-metrics.txt
+      head -20 /tmp/cz-webhook-metrics.txt


### PR DESCRIPTION
## Problem

Command-based KUTTL steps across the pre-existing `tests/kuttl` suites have been silently no-op'ing, so their e2e assertions never actually ran — the suites reported **PASS** without executing any of their `kubectl`/`helm`/`curl` logic. Two independent bugs cause this:

1. **`command:` + `args:`** — kuttl's `Command` has no `args` field and `command` is a single string, so only the bare first word (`kubectl`, `sh`, `sleep`) ran.
2. **`spec:` wrapper** — kuttl's `TestStep` has a **top-level** `commands` field and **no `spec`**, so nesting `commands:` under `spec:` made the whole step a no-op. Confirmed empirically with a marker probe against the pinned kuttl v0.25.0.

So `make kind-test` / `helm-test-kuttl` has been false-green for anything relying on `commands`.

## Fix

Converts the **11** affected step files across `alloy-clustered-test`, `collector-test`, `collector-comprehensive-test`, `webhook-test`, and `webhook-comprehensive-test` to valid kuttl, preserving each step's original intent:

- Drop `spec:`; put `commands:` at the top level; use `script:` / single-string `command:` instead of `command:`+`args:`.
- Reference shared agent components by **label** (`app.kubernetes.io/name=aggregator|webhook-server|ksm`) and **discover the install namespace**, instead of the stale hardcoded `cz-agent-*` names that don't exist in the current chart (`<release>-cz-*`). Discovery excludes the alloy co-install (`instance!=cz-alloy-ct`).
- Background `kubectl port-forward` (a foreground one would hang the step) and land the curl body to a file before `head` so a failed fetch fails the step.
- Walk up to the repo root before the alloy `helm` calls (kuttl runs scripts with CWD = the step dir), with a loop-termination guard; pre-poll selector-based `kubectl wait`s.
- Set explicit per-command `timeout:` on long-running commands (sleeps, `helm --wait`, and every `kubectl wait`): these suites' `kuttl-test.yaml` put `timeout` under `spec:`, which kuttl ignores, so the **30s** per-command default otherwise applied and clamped them.
- Consolidate `webhook-comprehensive/03` into one `script:` so `$WEBHOOK_METRICS` survives across the curl→grep→count chain (kuttl runs each entry in its own shell).

## CI: make the built image usable by the matrix kind tests

Once the suites genuinely run they need a working agent image, which exposed a **pre-existing** gap: the `test-matrix-k8s` path installed an **unpullable** image (`kind-overrides.yaml` pins an `intentionally-invalid-tag` and the freshly-built untested image was never wired in), so agent pods never reached Ready — invisible while the suites were hollow. Fixed:

- New `kind-load` Makefile target.
- Both `test-matrix-k8s.yaml` jobs now log in to ghcr, pull the freshly-built untested image for the matrix arch, retag it as the tag the chart installs (`dev-<sha>`), `kind load` it into the node (chart `imagePullPolicy: IfNotPresent`), and run the kind phases explicitly (`up → load → install/wait → helm-test-kuttl → teardown`) so the image is present before install.

## Verification

All five suites verified to genuinely **execute and PASS** against a local kind cluster using the exact `up → kind-load → install/wait → helm-test-kuttl` sequence CI now uses (5 PASS / 0 FAIL). A **negative control** (breaking an assertion / the curl target) confirms the now-live checks go **red** on a real regression.

## Scope

- The CP-43292 `webhookserver-disabled-test` / `webhookserver-upgrade-test` suites share bug #2 and are handled on that branch.

Refs CP-43356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)