### PR TITLE
CP-43380: Bump prometheus-config-reloader to v0.91.0

### DIFF
--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -706,7 +706,7 @@ components:
   prometheusReloader:
     image:
       repository: quay.io/prometheus-operator/prometheus-config-reloader
-      tag: "v0.87.0"
+      tag: "v0.91.0"
 
   # Settings for the aggregator component. This is the piece which accepts
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -706,7 +706,7 @@ components:
   prometheusReloader:
     image:
       repository: quay.io/prometheus-operator/prometheus-config-reloader
-      tag: "v0.87.0"
+      tag: "v0.91.0"
 
   # Settings for the aggregator component. This is the piece which accepts
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -1116,7 +1116,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.87.0
+          tag: v0.91.0
       validator:
         annotations: {}
         checks:
@@ -2618,7 +2618,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -1031,7 +1031,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.87.0
+          tag: v0.91.0
       validator:
         annotations: {}
         checks:
@@ -2533,7 +2533,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -1119,7 +1119,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.87.0
+          tag: v0.91.0
       validator:
         annotations: {}
         checks:
@@ -2444,7 +2444,7 @@ spec:
         # in the prometheus.yml.in file with the actual node name, then use that
         # processed file in the container.
         - name: config-subst
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/sh
@@ -2473,7 +2473,7 @@ spec:
               mountPath: /etc/config/prometheus/configmaps/processed/
       containers:
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config
@@ -2817,7 +2817,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -1046,7 +1046,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.87.0
+          tag: v0.91.0
       validator:
         annotations: {}
         checks:
@@ -2548,7 +2548,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config

--- a/tests/helm/template/kubestate.yaml
+++ b/tests/helm/template/kubestate.yaml
@@ -1083,7 +1083,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.87.0
+          tag: v0.91.0
       validator:
         annotations: {}
         checks:
@@ -2067,7 +2067,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1046,7 +1046,7 @@ data:
       prometheusReloader:
         image:
           repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.87.0
+          tag: v0.91.0
       validator:
         annotations: {}
         checks:
@@ -2548,7 +2548,7 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.87.0"
+          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --watched-dir=/etc/config


### PR DESCRIPTION
## Summary

Bumps the `prometheus-config-reloader` sidecar image in the cloudzero-agent Helm chart from `v0.87.0` to `v0.91.0` — the latest published upstream image. This is a one-line tag change in `helm/values.yaml`; the registry (`quay.io/prometheus-operator/prometheus-config-reloader`) is unchanged.

Jira: [CP-43380](https://cloudzero.atlassian.net/browse/CP-43380)

## Why

The pinned `v0.87.0` image carries a large number of known Critical/High CVEs, most already fixed upstream. A grype scan (grype 0.114.0) shows the upgrade roughly halves Critical+High exposure:

| Severity | v0.87.0 | v0.91.0 |
| --- | --- | --- |
| Critical | 12 | 8 |
| High | 35 | 15 |
| **Critical + High** | **47** | **23** |

> Note: `v0.91.0` is the newest tag actually published to the registry; the v0.92 source tag has not yet been released as an image. This bump is a quick interim mitigation and is independent of the longer-term effort to vendor the reloader from source.

## Validation

- `make helm-lint` passes (1 chart linted, 0 failed).
- Verified `quay.io` and `ghcr.io` publish identical digests for both tags, so the registry choice is content-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CP-43380]: https://cloudzero.atlassian.net/browse/CP-43380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ