### PR TITLE
CP-43313: Update embedded Alloy to v1.17.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=gomod-$TARGETPLATFORM \
 FROM gcr.io/distroless/static-debian12:debug@sha256:46fcf1fa44d251b0944ba4b98ef4bbd266e33034e46489dbf92f680ca4917451 AS certs
 
 # Stage 5: Extract Alloy binary from CloudZero Alloy image
-FROM ghcr.io/cloudzero/alloy:v1.16.2 AS alloy
+FROM ghcr.io/cloudzero/alloy:v1.17.0 AS alloy
 
 # Stage 6: Final runtime image
 # Note: For debugging, you can temporarily change the image used for building by


### PR DESCRIPTION
## Summary

Updates the embedded Grafana Alloy binary to **v1.17.0** by bumping the CloudZero Alloy image used in the Alloy extraction stage of `docker/Dockerfile` (`ghcr.io/cloudzero/alloy:v1.16.2` → `v1.17.0`).

## Details

- Stage 5 of `docker/Dockerfile` extracts the Alloy binary from `ghcr.io/cloudzero/alloy`; bumped the tag to `v1.17.0`.
- Confirmed `ghcr.io/cloudzero/alloy:v1.17.0` exists in the org container registry, so the build stage resolves.
- No other references to the embedded Alloy version exist in the chart or source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CP-43313]: https://cloudzero.atlassian.net/browse/CP-43313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ