### PR TITLE
CP-43412: Clarify version input in Manual Prepare Release workflow

### DIFF
--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release."
+        description: 'Version to release (e.g., "1.2.3").'
         required: true
 
 jobs:


### PR DESCRIPTION
## Summary

Clarifies the `Version to release` input on the **Manual Prepare Release** workflow ([release-to-main.yml](.github/workflows/release-to-main.yml)) so it's obvious the version must be entered **without** a `v` prefix.

```diff
-        description: "Version to release."
+        description: 'Version to release (e.g., "1.2.3").'
```

## Why

The workflow prepends the `v` itself when tagging and cutting the GitHub release:

- `git tag -a "v${{ ... version }}"`
- `tag_name: v${{ ... version }}`

…and uses the bare version for the release-notes file lookup (`helm/docs/releases/<version>.md`). Entering `v1.2.3` would therefore produce a `vv1.2.3` tag and fail the release-notes check. `workflow_dispatch` inputs have no separate help/hint field, so the guidance lives in the `description` text.