### PR TITLE
CP-43513: Stamp record timestamps in the streaming store

### DIFF
--- a/app/functions/webhook/main.go
+++ b/app/functions/webhook/main.go
@@ -87,7 +87,7 @@ func main() {
 
 	if backfill {
 		log.Info().Msg("Starting backfill mode")
-		streamStore := streaming.New(settings)
+		streamStore := streaming.New(settings, clock)
 		wd, err2 := webhook.NewWebhookFactory(streamStore, settings, clock)
 		if err2 != nil {
 			log.Fatal().Err(err2).Msg("failed to create webhook domain controller")

--- a/app/storage/streaming/store.go
+++ b/app/storage/streaming/store.go
@@ -26,6 +26,7 @@ const defaultBatchRecords = 500
 
 type Store struct {
 	settings      *config.Settings
+	clock         types.TimeProvider
 	mu            sync.Mutex
 	batch         []*types.ResourceTags
 	maxBatchCount int
@@ -34,10 +35,12 @@ type Store struct {
 }
 
 // New creates a streaming store that sends records directly to the
-// collector endpoint configured in settings.RemoteWrite.
-func New(settings *config.Settings) *Store {
+// collector endpoint configured in settings.RemoteWrite. The clock stamps
+// record timestamps.
+func New(settings *config.Settings, clock types.TimeProvider) *Store {
 	return &Store{
 		settings:      settings,
+		clock:         clock,
 		batch:         make([]*types.ResourceTags, 0, defaultBatchRecords),
 		maxBatchCount: defaultBatchRecords,
 		maxRetries:    settings.RemoteWrite.MaxRetries,
@@ -48,6 +51,10 @@ func New(settings *config.Settings) *Store {
 func (s *Store) Create(_ context.Context, record *types.ResourceTags) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Stamp timestamps on create; Update delegates here.
+	now := s.clock.GetCurrentTime()
+	record.RecordCreated, record.RecordUpdated = now, now
 
 	s.batch = append(s.batch, record)
 

--- a/app/storage/streaming/store_test.go
+++ b/app/storage/streaming/store_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cloudzero/cloudzero-agent/app/storage/streaming"
 	"github.com/cloudzero/cloudzero-agent/app/types"
 	"github.com/cloudzero/cloudzero-agent/app/types/mocks"
-	"github.com/cloudzero/cloudzero-agent/app/utils"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +44,8 @@ func TestStreamingStoreEndToEnd(t *testing.T) {
 	defer sink.server.Close()
 
 	settings := makeSettings(t, sink.server.URL)
-	clock := &utils.Clock{}
+	clockTime := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	clock := mocks.NewMockClock(clockTime)
 
 	store := streaming.New(settings, clock)
 	wc, err := webhook.NewWebhookFactory(store, settings, clock)
@@ -94,13 +94,12 @@ func TestStreamingStoreEndToEnd(t *testing.T) {
 	received := sink.timeseries()
 	require.NotEmpty(t, received, "collector should have received timeseries")
 
-	// Samples must carry a recent timestamp, not the zero-time sentinel.
-	const sentinel = int64(-6795364578871)
-	before := clock.GetCurrentTime().Add(-time.Hour).UnixNano() / int64(time.Millisecond)
+	// Every sample must carry the injected clock's timestamp, not the
+	// zero-time sentinel that corrupted backfilled metadata.
+	expectedTimestamp := clockTime.UnixNano() / int64(time.Millisecond)
 	for _, series := range received {
 		for _, sample := range series.Samples {
-			assert.NotEqual(t, sentinel, sample.Timestamp, "sample must not carry the zero-time sentinel")
-			assert.Greater(t, sample.Timestamp, before, "sample timestamp should be recent")
+			assert.Equal(t, expectedTimestamp, sample.Timestamp, "sample must carry the clock's timestamp")
 		}
 	}
 

--- a/app/storage/streaming/store_test.go
+++ b/app/storage/streaming/store_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/cloudzero/cloudzero-agent/app/domain/webhook"
 	"github.com/cloudzero/cloudzero-agent/app/domain/webhook/backfiller"
 	"github.com/cloudzero/cloudzero-agent/app/storage/streaming"
+	"github.com/cloudzero/cloudzero-agent/app/types"
+	"github.com/cloudzero/cloudzero-agent/app/types/mocks"
 	"github.com/cloudzero/cloudzero-agent/app/utils"
 
 	corev1 "k8s.io/api/core/v1"
@@ -45,7 +47,7 @@ func TestStreamingStoreEndToEnd(t *testing.T) {
 	settings := makeSettings(t, sink.server.URL)
 	clock := &utils.Clock{}
 
-	store := streaming.New(settings)
+	store := streaming.New(settings, clock)
 	wc, err := webhook.NewWebhookFactory(store, settings, clock)
 	require.NoError(t, err)
 
@@ -91,6 +93,16 @@ func TestStreamingStoreEndToEnd(t *testing.T) {
 
 	received := sink.timeseries()
 	require.NotEmpty(t, received, "collector should have received timeseries")
+
+	// Samples must carry a recent timestamp, not the zero-time sentinel.
+	const sentinel = int64(-6795364578871)
+	before := clock.GetCurrentTime().Add(-time.Hour).UnixNano() / int64(time.Millisecond)
+	for _, series := range received {
+		for _, sample := range series.Samples {
+			assert.NotEqual(t, sentinel, sample.Timestamp, "sample must not carry the zero-time sentinel")
+			assert.Greater(t, sample.Timestamp, before, "sample timestamp should be recent")
+		}
+	}
 
 	// Index received timeseries by __name__ for easier lookup.
 	type ts struct {
@@ -151,6 +163,31 @@ func TestStreamingStoreEndToEnd(t *testing.T) {
 	require.NotNil(t, podEntry, "should have pod labels for 'web-1'")
 	assert.Equal(t, "web", podEntry.labels["label_app"])
 	assert.Equal(t, "platform", podEntry.labels["label_team"])
+}
+
+// TestStoreCreateStampsTimestamps verifies Create stamps
+// RecordCreated/RecordUpdated from the injected clock.
+func TestStoreCreateStampsTimestamps(t *testing.T) {
+	clockTime := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	clock := mocks.NewMockClock(clockTime)
+
+	settings := makeSettings(t, "http://example.invalid")
+	store := streaming.New(settings, clock)
+
+	record := &types.ResourceTags{Type: config.Pod, Name: "web-1"}
+	require.True(t, record.RecordCreated.IsZero(), "precondition: RecordCreated must be zero")
+	require.True(t, record.RecordUpdated.IsZero(), "precondition: RecordUpdated must be zero")
+
+	require.NoError(t, store.Create(context.Background(), record))
+
+	assert.Equal(t, clockTime, record.RecordCreated, "Create must stamp RecordCreated from the clock")
+	assert.Equal(t, clockTime, record.RecordUpdated, "Create must stamp RecordUpdated from the clock")
+
+	// Update delegates to Create.
+	updateTime := clockTime.Add(time.Hour)
+	clock.SetCurrentTime(updateTime)
+	require.NoError(t, store.Update(context.Background(), record))
+	assert.Equal(t, updateTime, record.RecordUpdated, "Update must restamp from the clock")
 }
 
 // collectorSink is an httptest server that captures Prometheus WriteRequests.


### PR DESCRIPTION
The backfill job emitted resource metadata metrics (cloudzero_*_labels and cloudzero_*_annotations) with a sample timestamp far in the past instead of the discovery time, corrupting the time attribution of backfilled metadata.

Root Cause:

The backfill path uses the streaming store, whose Create/Update never set RecordCreated/RecordUpdated (unlike the SQLite repo used by the webhook server). The pusher derives each sample's timestamp from maxTime(RecordUpdated, RecordCreated); with both left at the zero value, time.Time{}.UnixNano()/int64(time.Millisecond) serializes as a large negative sentinel that renders as the year 1754. The webhook-server path was unaffected.

Functional Requirements:

1. Backfilled records must carry a real timestamp, matching the webhook path.

   streaming.Store now holds an injected types.TimeProvider and stamps RecordCreated/RecordUpdated on Create (Update delegates to Create), mirroring the SQLite repo. The backfill wiring in functions/webhook/main.go passes the clock already in scope into streaming.New.

Validation:

- Added TestStoreCreateStampsTimestamps: Create and Update stamp from an injected clock.
- Extended the end-to-end streaming test to assert every emitted sample carries a recent timestamp, not the sentinel.
- go test on the streaming package passes; format, lint, and build are clean.