### PR TITLE
CP-40907: Add Oracle Cloud (OCI) support to the agent

### DIFF
--- a/app/config/validator/deployment.go
+++ b/app/config/validator/deployment.go
@@ -16,9 +16,9 @@ import (
 )
 
 type Deployment struct {
-	AccountID   string      `yaml:"account_id" env:"ACCOUNT_ID" required:"true" env-description:"AWS Account ID"`
+	AccountID   string      `yaml:"account_id" env:"ACCOUNT_ID" required:"true" env-description:"CSP account ID"`
 	ClusterName string      `yaml:"cluster_name" env:"CLUSTER_NAME" required:"true" env-description:"Cluster Name"`
-	Region      string      `yaml:"region" env:"REGION" required:"true" env-description:"AWS Region"`
+	Region      string      `yaml:"region" env:"REGION" required:"true" env-description:"CSP region"`
 	scout       types.Scout `yaml:"-" env:"-" env-description:"Scout"`
 }
 

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -8,10 +8,14 @@ host: api.cloudzero.com
 # value will be used instead of the detected value. If you wish to use the
 # detected value, leave this property set to null.
 #
-# Note also that this must be a string value, even where the account ID may be
-# numeric (e.g., an AWS account ID). i.e., `"123456789012"` not `123456789012`.
-# If you are passing this as a parameter to the Helm CLI, you should generally
-# use --set-string (e.g., "cloudAccountId=123456789012").
+# On Oracle Cloud (OKE) the account ID cannot be auto-detected: the instance
+# metadata service exposes the tenancy OCID, not the numeric account ID that
+# CloudZero uses, so on OCI this property must be specified explicitly.
+#
+# Note also that this must be a string value, even where the account ID is
+# numeric (e.g., an AWS or Oracle Cloud account ID). i.e., `"123456789012"` not
+# `123456789012`. If you are passing this as a parameter to the Helm CLI, you
+# should generally use --set-string (e.g., "cloudAccountId=123456789012").
 cloudAccountId: ""
 
 # Name of the Kubernetes cluster.
@@ -30,9 +34,10 @@ clusterName: ""
 # Region the cluster is running in.
 #
 # This value can be automatically detected by the CloudZero Agent on AWS (EKS),
-# Google Cloud (GKE), and Azure (AKS), but if specified explicitly the specified
-# value will be used instead of the detected value. If you wish to use the
-# detected value, leave this property set to null.
+# Google Cloud (GKE), Azure (AKS), and Oracle Cloud (OKE). When a value is
+# auto-detected it takes precedence over an explicitly-provided one (a warning is
+# logged if they differ), so set this explicitly only when auto-detection is
+# unavailable. Leave it null to use the detected value.
 region: null
 
 # -- CloudZero API key. Required if existingSecretName is null.

--- a/app/utils/scout/README.md
+++ b/app/utils/scout/README.md
@@ -1,14 +1,17 @@
 # CloudZero Scout Package
 
-The CloudZero Scout package provides automatic cloud environment detection for AWS deployments. It identifies the current cloud provider and retrieves essential information like account ID and region.
+The CloudZero Scout package provides automatic cloud environment detection across the major cloud providers. It identifies the current cloud provider and retrieves essential information like account ID and region.
 
 ## Purpose
 
-Scout is designed to reduce the need for manual cloud environment configuration in CloudZero Agent deployments. It automatically detects whether the application is running on AWS and retrieves the necessary metadata for cost allocation and monitoring.
+Scout is designed to reduce the need for manual cloud environment configuration in CloudZero Agent deployments. It automatically detects which cloud provider the application is running on and retrieves the necessary metadata for cost allocation and monitoring.
 
 ## Supported Cloud Providers
 
-- **Amazon Web Services (AWS)** - Retrieves Account ID and Region via Instance Metadata Service (IMDS)
+- **Amazon Web Services (AWS)** - Retrieves Account ID and Region via the Instance Metadata Service (IMDS)
+- **Microsoft Azure** - Retrieves Subscription ID, Region, and (best-effort) cluster name via the Azure Instance Metadata Service
+- **Google Cloud (GCP)** - Retrieves project number and Region via the GCE metadata server
+- **Oracle Cloud Infrastructure (OCI)** - Retrieves Region via the OCI Instance Metadata Service v2. The account ID is **not** auto-detected: OCI exposes only the tenancy OCID, not the numeric account ID CloudZero uses, so `cloudAccountId` must be set manually on OKE.
 
 ## Key Features
 

--- a/app/utils/scout/oracle/oracle.go
+++ b/app/utils/scout/oracle/oracle.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package oracle provides Oracle Cloud Infrastructure (OCI) environment
+// detection and metadata retrieval using the OCI Instance Metadata Service
+// (IMDS) v2.
+package oracle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
+)
+
+const (
+	// ociMetadataURL is the OCI Instance Metadata Service v2 endpoint.
+	// https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm
+	ociMetadataURL = "http://169.254.169.254/opc/v2/instance/"
+
+	// authorizationHeader and authorizationHeaderValue are required by OCI
+	// IMDSv2; requests without them are rejected. The value is a fixed, public
+	// scheme constant, not a credential.
+	authorizationHeader      = "Authorization"
+	authorizationHeaderValue = "Bearer Oracle" // #nosec G101 - not a credential, a fixed IMDSv2 scheme value
+
+	requestTimeout = 5 * time.Second
+)
+
+// Scout detects and describes an OCI environment.
+type Scout struct {
+	client *http.Client
+}
+
+// instanceMetadata is the subset of the OCI IMDS response we consume.
+type instanceMetadata struct {
+	// CanonicalRegionName is the full region identifier (e.g. "us-ashburn-1"),
+	// matching the region naming CloudZero uses elsewhere.
+	CanonicalRegionName string `json:"canonicalRegionName"`
+	// Region is the short region key (e.g. "iad"); retained as an additional
+	// detection signal.
+	Region string `json:"region"`
+	// TenantID is the tenancy OCID. It is deliberately NOT used as the account
+	// ID (see EnvironmentInfo); it serves only as a positive OCI detection
+	// signal.
+	TenantID string `json:"tenantId"`
+}
+
+// NewScout creates a new OCI metadata scout.
+func NewScout() *Scout {
+	return &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+		},
+	}
+}
+
+// fetchMetadata retrieves and parses the OCI IMDSv2 instance document.
+func (s *Scout) fetchMetadata(ctx context.Context) (*instanceMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ociMetadataURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(authorizationHeader, authorizationHeaderValue)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OCI metadata: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get OCI metadata, status: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read OCI metadata response: %w", err)
+	}
+
+	var md instanceMetadata
+	if err := json.Unmarshal(body, &md); err != nil {
+		return nil, fmt.Errorf("failed to parse OCI metadata JSON: %w", err)
+	}
+
+	return &md, nil
+}
+
+// Detect determines whether the current environment is running on OCI by
+// querying the Instance Metadata Service. Network failures, non-200 responses,
+// and unparseable bodies are treated as "not OCI" rather than errors.
+func (s *Scout) Detect(ctx context.Context) (types.CloudProvider, error) {
+	md, err := s.fetchMetadata(ctx)
+	if err != nil {
+		return types.CloudProviderUnknown, nil //nolint:nilerr // inability to reach/parse IMDS means "not OCI", not a hard error
+	}
+
+	// A populated OCI-specific field confirms we're on OCI. This is intentionally
+	// more lenient than EnvironmentInfo, which additionally requires
+	// canonicalRegionName; detection should succeed on any positive OCI signal.
+	if md.TenantID != "" || md.CanonicalRegionName != "" || md.Region != "" {
+		return types.CloudProviderOCI, nil
+	}
+
+	return types.CloudProviderUnknown, nil
+}
+
+// EnvironmentInfo retrieves OCI environment information from the Instance
+// Metadata Service.
+func (s *Scout) EnvironmentInfo(ctx context.Context) (*types.EnvironmentInfo, error) {
+	md, err := s.fetchMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	region := strings.TrimSpace(md.CanonicalRegionName)
+	if region == "" {
+		return nil, errors.New("canonicalRegionName not found in OCI metadata")
+	}
+
+	return &types.EnvironmentInfo{
+		CloudProvider: types.CloudProviderOCI,
+		Region:        region,
+		// AccountID is intentionally left empty. OCI's Instance Metadata Service
+		// exposes the tenancy OCID (tenantId), not the numeric account ID that
+		// CloudZero expects, so it cannot be auto-detected and must be configured
+		// manually (cloudAccountId in the Helm chart). Returning a value here
+		// would also clobber any customer-provided value, since the
+		// scout-detection path treats detected values as authoritative over
+		// configured ones.
+		//
+		// ClusterName is likewise not exposed by the metadata service and is left
+		// empty, consistent with the AWS scout.
+	}, nil
+}

--- a/app/utils/scout/oracle/oracle_test.go
+++ b/app/utils/scout/oracle/oracle_test.go
@@ -1,0 +1,402 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package oracle
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// validOCIMetadataResponse is a representative subset of the JSON returned
+	// by the OCI Instance Metadata Service v2 (/opc/v2/instance/).
+	validOCIMetadataResponse = `{
+		"availabilityDomain": "Uocm:US-ASHBURN-AD-1",
+		"canonicalRegionName": "us-ashburn-1",
+		"region": "iad",
+		"compartmentId": "ocid1.tenancy.oc1..aaaaaaaacompartment",
+		"tenantId": "ocid1.tenancy.oc1..aaaaaaaatenancy",
+		"id": "ocid1.instance.oc1.iad.aaaaaaaainstance",
+		"displayName": "oke-test-cirrus-evan-node-0"
+	}`
+
+	// phoenixRegionResponse exercises a different region.
+	phoenixRegionResponse = `{
+		"canonicalRegionName": "us-phoenix-1",
+		"region": "phx",
+		"tenantId": "ocid1.tenancy.oc1..aaaaaaaatenancy"
+	}`
+)
+
+func TestNewScout(t *testing.T) {
+	scout := NewScout()
+	assert.NotNil(t, scout)
+	assert.NotNil(t, scout.client)
+	assert.Equal(t, requestTimeout, scout.client.Timeout)
+}
+
+func TestScout_Detect_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// OCI IMDSv2 requires the Bearer Oracle authorization header.
+		assert.Equal(t, authorizationHeaderValue, r.Header.Get(authorizationHeader))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(validOCIMetadataResponse))
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURL(server.URL)
+	result, err := scout.Detect(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, types.CloudProviderOCI, result)
+}
+
+func TestScout_Detect_NotOCI(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "not found", statusCode: http.StatusNotFound, body: ""},
+		{name: "server error", statusCode: http.StatusInternalServerError, body: ""},
+		{name: "unauthorized", statusCode: http.StatusUnauthorized, body: ""},
+		{name: "ok but not OCI metadata", statusCode: http.StatusOK, body: `{"foo": "bar"}`},
+		{name: "ok but invalid json", statusCode: http.StatusOK, body: `{not json`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if tt.body != "" {
+					_, _ = w.Write([]byte(tt.body))
+				}
+			}))
+			defer server.Close()
+
+			scout := createScoutWithCustomURL(server.URL)
+			result, err := scout.Detect(context.Background())
+
+			assert.NoError(t, err)
+			assert.Equal(t, types.CloudProviderUnknown, result)
+		})
+	}
+}
+
+func TestScout_Detect_NetworkError(t *testing.T) {
+	scout := &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+			Transport: &customTransport{
+				baseURL: "http://192.0.2.1", // RFC 5737 TEST-NET-1 - guaranteed unreachable
+			},
+		},
+	}
+
+	result, err := scout.Detect(context.Background())
+
+	// Network errors should not return an error, just unknown provider
+	assert.NoError(t, err)
+	assert.Equal(t, types.CloudProviderUnknown, result)
+}
+
+func TestScout_Detect_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(validOCIMetadataResponse))
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURL(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result, err := scout.Detect(ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, types.CloudProviderUnknown, result)
+}
+
+func TestScout_EnvironmentInfo_Success(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseBody string
+		expectedInfo *types.EnvironmentInfo
+	}{
+		{
+			name:         "ashburn region",
+			responseBody: validOCIMetadataResponse,
+			expectedInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderOCI,
+				Region:        "us-ashburn-1",
+				// AccountID is intentionally empty: OCI's metadata service exposes
+				// the tenancy OCID, not the numeric account ID CloudZero expects, so
+				// it must be configured manually. ClusterName is not exposed either
+				// (consistent with the AWS scout).
+				AccountID:   "",
+				ClusterName: "",
+			},
+		},
+		{
+			name:         "phoenix region",
+			responseBody: phoenixRegionResponse,
+			expectedInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderOCI,
+				Region:        "us-phoenix-1",
+				AccountID:     "",
+				ClusterName:   "",
+			},
+		},
+		{
+			name:         "trims whitespace in region",
+			responseBody: `{"canonicalRegionName": "  us-ashburn-1  ", "tenantId": "ocid1.tenancy.oc1..aaaa"}`,
+			expectedInfo: &types.EnvironmentInfo{
+				CloudProvider: types.CloudProviderOCI,
+				Region:        "us-ashburn-1",
+				AccountID:     "",
+				ClusterName:   "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, authorizationHeaderValue, r.Header.Get(authorizationHeader))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			scout := createScoutWithCustomURL(server.URL)
+			result, err := scout.EnvironmentInfo(context.Background())
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedInfo, result)
+		})
+	}
+}
+
+func TestScout_EnvironmentInfo_Errors(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		responseBody  string
+		errorContains string
+	}{
+		{
+			name:          "error on non-200 status",
+			statusCode:    http.StatusInternalServerError,
+			responseBody:  "",
+			errorContains: "failed to get OCI metadata, status: 500",
+		},
+		{
+			name:          "error on invalid JSON",
+			statusCode:    http.StatusOK,
+			responseBody:  `{invalid json`,
+			errorContains: "failed to parse OCI metadata JSON",
+		},
+		{
+			name:          "error on missing region",
+			statusCode:    http.StatusOK,
+			responseBody:  `{"tenantId": "ocid1.tenancy.oc1..aaaa"}`,
+			errorContains: "canonicalRegionName not found in OCI metadata",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if tt.responseBody != "" {
+					_, _ = w.Write([]byte(tt.responseBody))
+				}
+			}))
+			defer server.Close()
+
+			scout := createScoutWithCustomURL(server.URL)
+			result, err := scout.EnvironmentInfo(context.Background())
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errorContains)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestScout_EnvironmentInfo_NetworkError(t *testing.T) {
+	scout := &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+			Transport: &customTransport{
+				baseURL: "http://192.0.2.1", // RFC 5737 TEST-NET-1 - guaranteed unreachable
+			},
+		},
+	}
+
+	result, err := scout.EnvironmentInfo(context.Background())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get OCI metadata")
+	assert.Nil(t, result)
+}
+
+func TestScout_EnvironmentInfo_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(validOCIMetadataResponse))
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURL(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	result, err := scout.EnvironmentInfo(ctx)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.Nil(t, result)
+}
+
+// TestScout_Detect_PositiveSignals confirms Detect fires on ANY single OCI
+// signal field, locking in the documented "any positive OCI signal confirms
+// OCI" contract (each field is the sole reason detection succeeds).
+func TestScout_Detect_PositiveSignals(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "tenantId only", body: `{"tenantId":"ocid1.tenancy.oc1..aaaa"}`},
+		{name: "canonicalRegionName only", body: `{"canonicalRegionName":"us-ashburn-1"}`},
+		{name: "short region key only", body: `{"region":"iad"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			scout := createScoutWithCustomURL(server.URL)
+			result, err := scout.Detect(context.Background())
+
+			assert.NoError(t, err)
+			assert.Equal(t, types.CloudProviderOCI, result)
+		})
+	}
+}
+
+// TestScout_EnvironmentInfo_ReadError covers the response-body read-error path,
+// mirroring the Azure scout's equivalent test, by hijacking the connection and
+// closing it after headers are sent.
+func TestScout_EnvironmentInfo_ReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		if conn, ok := w.(http.Hijacker); ok {
+			if c, _, err := conn.Hijack(); err == nil {
+				_ = c.Close()
+			}
+		}
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURL(server.URL)
+	result, err := scout.EnvironmentInfo(context.Background())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read OCI metadata response")
+	assert.Nil(t, result)
+}
+
+// TestScout_RealCapturedMetadata runs the scout against a REAL OCI IMDSv2
+// /opc/v2/instance/ response captured from a live OCI compute instance (us-ashburn-1)
+// during CP-40907 end-to-end validation. Resource identifiers (tenancy/compartment/
+// instance OCIDs) have been redacted in the fixture. This proves the scout parses an
+// actual response — not just hand-written fixtures — and confirms the deliberate empty
+// AccountID (OCI's metadata exposes the tenancy OCID, not a numeric account ID).
+func TestScout_RealCapturedMetadata(t *testing.T) {
+	body, err := os.ReadFile("testdata/real-imds-us-ashburn-1.json")
+	if err != nil {
+		t.Fatalf("failed to read captured fixture: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, authorizationHeaderValue, r.Header.Get(authorizationHeader))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	scout := createScoutWithCustomURL(server.URL)
+	ctx := context.Background()
+
+	provider, err := scout.Detect(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, types.CloudProviderOCI, provider)
+
+	info, err := scout.EnvironmentInfo(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, &types.EnvironmentInfo{
+		CloudProvider: types.CloudProviderOCI,
+		Region:        "us-ashburn-1",
+		AccountID:     "", // tenantId is the tenancy OCID, not the numeric account ID -> must be configured manually
+		ClusterName:   "",
+	}, info)
+}
+
+func TestConstants(t *testing.T) {
+	assert.Equal(t, "http://169.254.169.254/opc/v2/instance/", ociMetadataURL)
+	assert.Equal(t, "Authorization", authorizationHeader)
+	assert.Equal(t, "Bearer Oracle", authorizationHeaderValue)
+	assert.Equal(t, 5*time.Second, requestTimeout)
+}
+
+// Helper functions
+
+// createScoutWithCustomURL creates a scout for testing with a custom URL
+func createScoutWithCustomURL(baseURL string) *Scout {
+	return &Scout{
+		client: &http.Client{
+			Timeout: requestTimeout,
+			Transport: &customTransport{
+				baseURL: baseURL,
+			},
+		},
+	}
+}
+
+// customTransport redirects OCI metadata requests to a test server
+type customTransport struct {
+	baseURL string
+}
+
+func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	newURL := strings.Replace(req.URL.String(), "http://169.254.169.254", t.baseURL, 1)
+
+	newReq := req.Clone(req.Context())
+	var err error
+	newReq.URL, err = newReq.URL.Parse(newURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.DefaultTransport.RoundTrip(newReq)
+}

--- a/app/utils/scout/oracle/testdata/real-imds-us-ashburn-1.json
+++ b/app/utils/scout/oracle/testdata/real-imds-us-ashburn-1.json
@@ -1,0 +1,42 @@
+{
+  "agentConfig": {
+    "allPluginsDisabled": false,
+    "managementDisabled": false,
+    "monitoringDisabled": false
+  },
+  "availabilityDomain": "zGze:US-ASHBURN-AD-1",
+  "canonicalRegionName": "us-ashburn-1",
+  "compartmentId": "ocid1.tenancy.oc1..aaaaaaaaexampletenancyexampletenancyexampletenancyexampl",
+  "definedTags": {
+    "Oracle-Tags": {
+      "CreatedBy": "REDACTED",
+      "CreatedOn": "REDACTED"
+    }
+  },
+  "displayName": "cz-imds-probe-DELETE",
+  "faultDomain": "FAULT-DOMAIN-1",
+  "hostname": "cz-imds-probe-delete",
+  "id": "ocid1.instance.oc1.iad.anexampleinstanceocidexampleinstanceocidexamplexx",
+  "image": "ocid1.image.oc1.iad.aaaaaaaaexampleimageocidexampleimageocidexampleimagexx",
+  "metadata": {
+    "user_data": "<elided>"
+  },
+  "ociAdName": "iad-ad-1",
+  "region": "iad",
+  "regionInfo": {
+    "realmDomainComponent": "oraclecloud.com",
+    "realmKey": "oc1",
+    "regionIdentifier": "us-ashburn-1",
+    "regionKey": "IAD"
+  },
+  "shape": "VM.Standard.E3.Flex",
+  "shapeConfig": {
+    "maxVnicAttachments": 2,
+    "memoryInGBs": 8.0,
+    "networkingBandwidthInGbps": 1.0,
+    "ocpus": 1.0
+  },
+  "state": "Running",
+  "tenantId": "ocid1.tenancy.oc1..aaaaaaaaexampletenancyexampletenancyexampletenancyexampl",
+  "timeCreated": 1782188949730
+}

--- a/app/utils/scout/scout.go
+++ b/app/utils/scout/scout.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/aws"
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/azure"
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/google"
+	"github.com/cloudzero/cloudzero-agent/app/utils/scout/oracle"
 	"github.com/cloudzero/cloudzero-agent/app/utils/scout/types"
 )
 
@@ -19,5 +20,6 @@ func NewScout() types.Scout {
 		aws.NewScout(),
 		azure.NewScout(),
 		google.NewScout(),
+		oracle.NewScout(),
 	)
 }

--- a/app/utils/scout/types/types.go
+++ b/app/utils/scout/types/types.go
@@ -15,6 +15,8 @@ const (
 	CloudProviderGoogle CloudProvider = "google"
 	// CloudProviderAzure represents Microsoft Azure
 	CloudProviderAzure CloudProvider = "azure"
+	// CloudProviderOCI represents Oracle Cloud Infrastructure (OCI/OKE)
+	CloudProviderOCI CloudProvider = "oracle"
 	// CloudProviderUnknown represents an undetected or unsupported cloud provider
 	CloudProviderUnknown CloudProvider = "unknown"
 	// CloudProviderMock represents a mock provider for testing

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -307,15 +307,28 @@ required:
 properties:
   cloudAccountId:
     type: "string"
-    # Empty string or numeric string or UUID
+    # The alternations below intentionally cover every supported CSP account-ID
+    # shape; keep them in sync with the `description` block. In order:
+    #   ^$                       -> empty (use the auto-detected value)
+    #   ^[0-9]+$                 -> numeric account ID: AWS account ID, Google
+    #                               Cloud project number, AND Oracle Cloud (OCI)
+    #                               account ID (all numeric, so no OCI-specific
+    #                               branch is needed)
+    #   ^[0-9a-fA-F]{8}-...{12}$ -> UUID: Azure subscription ID
+    #   ^'...'$ (x2)             -> the numeric/UUID forms wrapped in single
+    #                               quotes, since Helm/YAML may quote values that
+    #                               look numeric
     pattern: "^$|^[0-9]+$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$|^'[0-9]+'$|^'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'$"
     description: |
       *WARNING*: use of this property is generally discouraged as in most cases
-      it can be detected automatically.
+      it can be detected automatically. The exception is Oracle Cloud (OCI),
+      where the numeric account ID is not exposed by the instance metadata
+      service and so must always be set explicitly.
 
       The cloud account ID. Must be either:
         - Empty string (use auto-detected value)
-        - Numeric string (AWS account ID or Google Cloud project number)
+        - Numeric string (AWS account ID, Google Cloud project number, or Oracle
+          Cloud (OCI) account ID)
         - UUID (Azure subscription ID)
         - Any of the above enclosed in balanced single quotes (e.g., '1234567890')
   clusterName:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,10 +8,14 @@ host: api.cloudzero.com
 # value will be used instead of the detected value. If you wish to use the
 # detected value, leave this property set to null.
 #
-# Note also that this must be a string value, even where the account ID may be
-# numeric (e.g., an AWS account ID). i.e., `"123456789012"` not `123456789012`.
-# If you are passing this as a parameter to the Helm CLI, you should generally
-# use --set-string (e.g., "cloudAccountId=123456789012").
+# On Oracle Cloud (OKE) the account ID cannot be auto-detected: the instance
+# metadata service exposes the tenancy OCID, not the numeric account ID that
+# CloudZero uses, so on OCI this property must be specified explicitly.
+#
+# Note also that this must be a string value, even where the account ID is
+# numeric (e.g., an AWS or Oracle Cloud account ID). i.e., `"123456789012"` not
+# `123456789012`. If you are passing this as a parameter to the Helm CLI, you
+# should generally use --set-string (e.g., "cloudAccountId=123456789012").
 cloudAccountId: ""
 
 # Name of the Kubernetes cluster.
@@ -30,9 +34,10 @@ clusterName: ""
 # Region the cluster is running in.
 #
 # This value can be automatically detected by the CloudZero Agent on AWS (EKS),
-# Google Cloud (GKE), and Azure (AKS), but if specified explicitly the specified
-# value will be used instead of the detected value. If you wish to use the
-# detected value, leave this property set to null.
+# Google Cloud (GKE), Azure (AKS), and Oracle Cloud (OKE). When a value is
+# auto-detected it takes precedence over an explicitly-provided one (a warning is
+# logged if they differ), so set this explicitly only when auto-detection is
+# unavailable. Leave it null to use the detected value.
 region: null
 
 # -- CloudZero API key. Required if existingSecretName is null.


### PR DESCRIPTION
## Summary

Adds Oracle Cloud Infrastructure (OCI/OKE) as a recognized cloud provider so the CloudZero Agent can run on Oracle Kubernetes Engine and report the correct provider + region for cost allocation. Previously the agent auto-detected its environment on AWS (EKS), Google Cloud (GKE), and Azure (AKS) only.

## What changed

- **New `oracle` scout** (`app/utils/scout/oracle/`) implementing the `Scout` interface via the OCI Instance Metadata Service v2 (`http://169.254.169.254/opc/v2/instance/`, header `Authorization: Bearer Oracle`). `Detect` fires on any positive OCI signal; `EnvironmentInfo` returns the canonical region name.
- **`CloudProviderOCI = "oracle"`** added to the provider enum and registered in `scout.NewScout()`. The value flows through the existing string `cloud_provider` field, so no other component required changes.
- **Account ID:** OCI account IDs are numeric and already accepted by the `cloudAccountId` schema pattern (`^[0-9]+$`) — no pattern change. The schema source and `values.yaml` now document each branch of the pattern and note that on OCI the account ID must be set manually.
- **Docs/cleanup:** de-AWS-ified the validator env-descriptions (→ "CSP …"), refreshed the scout `README` to list all four providers, and documented that region is auto-detected on OKE.

### Design note — empty `AccountID` on OCI

The OCI scout deliberately returns an empty `AccountID`. OCI's IMDS exposes the tenancy OCID, not the numeric account ID CloudZero uses, and `DetectConfiguration` treats detected values as authoritative over configured ones — so returning the OCID would clobber a correctly-configured `cloudAccountId`. On OCI the account ID is therefore configured manually, consistent with how the AWS scout leaves cluster name unset.

## Testing

- Unit tests for the OCI scout (Detect incl. per-signal detection; EnvironmentInfo; error, body-read-error, network-failure, and context-cancellation paths) mirroring the AWS/Azure scouts. Oracle package at ~97% statement coverage.
- **Validated against real OCI metadata:** captured a real IMDSv2 response from a live OCI compute instance (us-ashburn-1), added it as a redacted test fixture, and `TestScout_RealCapturedMetadata` runs the scout against it — confirming `Detect → oracle` and `EnvironmentInfo → {cloudProvider: oracle, region: us-ashburn-1, accountId: ""}`. Separately confirmed from a running OKE node that its bootstrap uses the same IMDSv2 endpoint + Bearer header the scout relies on.
- `make format` / `lint` (0 issues) / `build` pass; the scout, config, and cluster-config package tests pass; the generated `values.schema.json` is unchanged (the account-ID changes are comment-only).
- Reviewed via an iterative multi-lens panel (code quality, tests, comments, error-handling, type-design) to convergence.

## Not included / follow-ups

- A full `helm install` on a **joined** OKE node was not exercised: OKE node-join requires a security-list rule the test environment's IAM role cannot add, plus a from-branch image in OCIR. The scout itself is validated against real OCI metadata as above.
- **Pre-existing (out of scope):** the `cloudAccountId` and `clusterName` value-comments state "the specified value will be used instead of the detected value," which is the inverse of `DetectConfiguration`'s actual precedence (a detected value wins, with a warning on mismatch). The `region` comment is corrected in this PR; the other two are left to a follow-up to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
