### PR TITLE
CP-43357: ship prometheus-config-reloader in the agent image

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -158,6 +158,29 @@ For detailed Alloy documentation, see:
 - `helm/docs/alloy-migration-guide.md` - Migration from Prometheus
 - `helm/docs/troubleshooting-guide.md` - Alloy-specific troubleshooting
 
+### Updating prometheus-config-reloader
+
+The `prometheus-config-reloader` binary is built from upstream source during the
+image build (see the `reloader` stage in `docker/Dockerfile`) and shipped inside
+the agent image, rather than pulled as a separate external image. The chart runs
+it both as the Prometheus reload sidecar and, in federated mode, as the
+`config-subst` init container that substitutes `$(NODE_NAME)` into the Prometheus
+config (it uses Thanos-style `$(VAR)` syntax, so Prometheus relabel
+back-references like `${1}` are left untouched).
+
+The version is pinned by the `RELOADER_VERSION` build arg in `docker/Dockerfile`.
+**This is a git tag, which Dependabot does not track** (it only watches
+`Chart.yaml` and Dockerfile `FROM` lines), so it must be bumped by hand:
+
+1. Pick a new tag from
+   <https://github.com/prometheus-operator/prometheus-operator/releases>.
+2. Update `RELOADER_VERSION` in `docker/Dockerfile`.
+3. Rebuild and run the image scan (`grype`, see `.github/workflows/scan-images.yml`).
+   If new High/Critical CVEs appear in transitive dependencies, bump them in the
+   `reloader` stage's `go get` line (currently `golang.org/x/crypto` and
+   `golang.org/x/net`). These are carried slightly ahead of upstream's pins; drop
+   the override once upstream pins versions at least as new.
+
 ## Go Development Patterns
 
 ### Package Organization

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -698,15 +698,17 @@ components:
       repository: quay.io/prometheus/prometheus
       tag:  # This will fall back on .Chart.AppVersion if not set.
 
-  # prometheusReloader contains details about where to find the Prometheus
-  # reloader image.
-  #
-  # prometheus-config-reloader will watch the Prometheus configuration for
-  # changes and restart the Prometheus pod as necessary.
+  # DEPRECATED. The prometheus-config-reloader binary is now built from upstream
+  # source and shipped inside the CloudZero Agent image (see docker/Dockerfile),
+  # so the chart no longer pulls a separate reloader image by default. This block
+  # is retained as a tombstone for forward-compatibility and is no longer wired
+  # into any container. To pin the reloader to an external image (e.g. when
+  # mirroring into a private registry), set configmapReload.prometheus.image
+  # instead, which still overrides the in-image binary.
   prometheusReloader:
     image:
-      repository: quay.io/prometheus-operator/prometheus-config-reloader
-      tag: "v0.91.0"
+      repository:
+      tag:
 
   # Settings for the aggregator component. This is the piece which accepts
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
@@ -1553,6 +1555,12 @@ configmapReload:
     # Whether to enable the Prometheus ConfigMap reloader.
     enabled: true
     # Container image configuration for the Prometheus ConfigMap reloader.
+    #
+    # By default the reloader runs the prometheus-config-reloader binary shipped
+    # in the CloudZero Agent image (built from source, see docker/Dockerfile).
+    # Set this to pull the reloader from an external image instead (e.g. when
+    # mirroring into a private registry); these values override the in-image
+    # binary for both the config-subst init container and the reload sidecar.
     image:
       repository:
       tag:

--- a/app/functions/helmless/default-values.yaml
+++ b/app/functions/helmless/default-values.yaml
@@ -698,18 +698,6 @@ components:
       repository: quay.io/prometheus/prometheus
       tag:  # This will fall back on .Chart.AppVersion if not set.
 
-  # DEPRECATED. The prometheus-config-reloader binary is now built from upstream
-  # source and shipped inside the CloudZero Agent image (see docker/Dockerfile),
-  # so the chart no longer pulls a separate reloader image by default. This block
-  # is retained as a tombstone for forward-compatibility and is no longer wired
-  # into any container. To pin the reloader to an external image (e.g. when
-  # mirroring into a private registry), set configmapReload.prometheus.image
-  # instead, which still overrides the in-image binary.
-  prometheusReloader:
-    image:
-      repository:
-      tag:
-
   # Settings for the aggregator component. This is the piece which accepts
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
   # after some processing.
@@ -1554,18 +1542,6 @@ configmapReload:
   prometheus:
     # Whether to enable the Prometheus ConfigMap reloader.
     enabled: true
-    # Container image configuration for the Prometheus ConfigMap reloader.
-    #
-    # By default the reloader runs the prometheus-config-reloader binary shipped
-    # in the CloudZero Agent image (built from source, see docker/Dockerfile).
-    # Set this to pull the reloader from an external image instead (e.g. when
-    # mirroring into a private registry); these values override the in-image
-    # binary for both the config-subst init container and the reload sidecar.
-    image:
-      repository:
-      tag:
-      digest:
-      pullPolicy:
     # Resource requirements and limits for the Prometheus ConfigMap reloader.
     #
     # For details, see the Kubernetes documentation on resource management:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,6 +82,7 @@ FROM ghcr.io/cloudzero/alloy:v1.17.0 AS alloy
 # (not copy the prebuilt image) to control the toolchain and bump vulnerable
 # deps; only the binary is copied out, no source is vendored.
 FROM base-tools AS reloader
+ARG TARGETPLATFORM
 ARG TARGETOS TARGETARCH
 ARG RELOADER_VERSION
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,19 @@
 ARG DEPLOY_IMAGE=scratch
 
+# prometheus-config-reloader version, built from upstream source (see the
+# "reloader" stage below). This is a git tag, which Dependabot does NOT track
+# (it only watches Chart.yaml and Dockerfile FROM lines), so it must be bumped
+# by hand. See DEVELOPMENT.md ("prometheus-config-reloader") for the procedure.
+ARG RELOADER_VERSION=v0.91.0
+
 # Multi-stage Docker build with platform-specific cache optimization:
 # 1. base-tools: Install system packages and tools (cached per platform)
 # 2. dependencies: Download Go modules (cached per platform)
 # 3. builder: Build Go binaries (cached per platform)
 # 4. certs: Extract certificates from distroless image
 # 5. alloy: Extract Alloy binary from CloudZero Alloy image
-# 6. final: Minimal runtime image with compiled binaries
+# 6. reloader: Build prometheus-config-reloader from upstream source
+# 7. final: Minimal runtime image with compiled binaries
 
 # Stage 1: Base tools installation
 FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS base-tools
@@ -73,7 +80,36 @@ FROM gcr.io/distroless/static-debian12:debug@sha256:46fcf1fa44d251b0944ba4b98ef4
 # Stage 5: Extract Alloy binary from CloudZero Alloy image
 FROM ghcr.io/cloudzero/alloy:v1.17.0 AS alloy
 
-# Stage 6: Final runtime image
+# Stage 6: Build prometheus-config-reloader from upstream source
+#
+# We build the binary ourselves rather than copying the prebuilt upstream image
+# so that (a) we control the Go toolchain, and (b) we can bump vulnerable
+# transitive dependencies. Building the v0.91.0 tag with our toolchain clears
+# all but a handful of the High/Critical CVEs grype finds in the prebuilt image;
+# bumping x/crypto and x/net below clears the rest so the image scan passes.
+#
+# Only the resulting binary is copied into the final image; no upstream source
+# is vendored into this repository.
+FROM base-tools AS reloader
+ARG TARGETOS TARGETARCH
+ARG RELOADER_VERSION
+
+WORKDIR /reloader-src
+RUN git clone --depth 1 --branch "${RELOADER_VERSION}" \
+        https://github.com/prometheus-operator/prometheus-operator.git .
+
+# Carry these two deps slightly ahead of upstream's pins to clear the remaining
+# grype findings. Remove once upstream pins versions at least this new.
+RUN --mount=type=cache,target=/go/pkg/mod,id=gomod-reloader-$TARGETPLATFORM \
+    go get golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0
+
+RUN --mount=type=cache,target=/go/pkg/mod,id=gomod-reloader-$TARGETPLATFORM \
+    --mount=type=cache,target=/root/.cache/go-build,id=gobuild-reloader-$TARGETPLATFORM \
+    CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" \
+    go build -trimpath -ldflags="-s -w" \
+        -o /bin/prometheus-config-reloader ./cmd/prometheus-config-reloader
+
+# Stage 7: Final runtime image
 # Note: For debugging, you can temporarily change the image used for building by
 # passing in something like this to 'docker build':
 #
@@ -119,6 +155,9 @@ COPY --from=builder /go/bin/cloudzero-certifik8s /app/cloudzero-certifik8s
 
 # Copy the Alloy binary from the alloy stage
 COPY --from=alloy /bin/cloudzero-alloy /app/cloudzero-alloy
+
+# Copy the prometheus-config-reloader binary built from upstream source
+COPY --from=reloader /bin/prometheus-config-reloader /app/prometheus-config-reloader
 
 # Allow the default ENTRYPOINT from busybox to be the default,
 # however run the app as the default command

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,7 @@
 ARG DEPLOY_IMAGE=scratch
 
-# prometheus-config-reloader version, built from upstream source (see the
-# "reloader" stage below). This is a git tag, which Dependabot does NOT track
-# (it only watches Chart.yaml and Dockerfile FROM lines), so it must be bumped
-# by hand. See DEVELOPMENT.md ("prometheus-config-reloader") for the procedure.
+# prometheus-config-reloader version, built from source in the "reloader" stage.
+# Git tag — Dependabot can't track it, so bump by hand (see DEVELOPMENT.md).
 ARG RELOADER_VERSION=v0.91.0
 
 # Multi-stage Docker build with platform-specific cache optimization:
@@ -80,16 +78,9 @@ FROM gcr.io/distroless/static-debian12:debug@sha256:46fcf1fa44d251b0944ba4b98ef4
 # Stage 5: Extract Alloy binary from CloudZero Alloy image
 FROM ghcr.io/cloudzero/alloy:v1.17.0 AS alloy
 
-# Stage 6: Build prometheus-config-reloader from upstream source
-#
-# We build the binary ourselves rather than copying the prebuilt upstream image
-# so that (a) we control the Go toolchain, and (b) we can bump vulnerable
-# transitive dependencies. Building the v0.91.0 tag with our toolchain clears
-# all but a handful of the High/Critical CVEs grype finds in the prebuilt image;
-# bumping x/crypto and x/net below clears the rest so the image scan passes.
-#
-# Only the resulting binary is copied into the final image; no upstream source
-# is vendored into this repository.
+# Stage 6: Build prometheus-config-reloader from upstream source. We build it
+# (not copy the prebuilt image) to control the toolchain and bump vulnerable
+# deps; only the binary is copied out, no source is vendored.
 FROM base-tools AS reloader
 ARG TARGETOS TARGETARCH
 ARG RELOADER_VERSION
@@ -98,8 +89,7 @@ WORKDIR /reloader-src
 RUN git clone --depth 1 --branch "${RELOADER_VERSION}" \
         https://github.com/prometheus-operator/prometheus-operator.git .
 
-# Carry these two deps slightly ahead of upstream's pins to clear the remaining
-# grype findings. Remove once upstream pins versions at least this new.
+# Bump vulnerable deps ahead of upstream's pins so the scan passes; drop when upstream catches up.
 RUN --mount=type=cache,target=/go/pkg/mod,id=gomod-reloader-$TARGETPLATFORM \
     go get golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0
 

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -509,12 +509,9 @@ Usage: {{ include "cloudzero-agent.prometheus.scrapeCAdvisor" (dict "root" . "sc
       target_label: node_name
 
     # Filter to only the local node
-    # NOTE: $(NODE_NAME) is a placeholder replaced by an init container with the
-    # actual node name. The prometheus-config-reloader binary performs the
-    # substitution (Thanos-style $(VAR) syntax) when it writes the processed
-    # config; Prometheus itself does not support env var substitution. Note the
-    # parentheses: Prometheus relabel back-references like ${1} use braces and
-    # are deliberately left untouched by the reloader.
+    # NOTE: $(NODE_NAME) is substituted with the node name by the reloader init
+    # container (Thanos-style $(VAR) syntax; relabel refs like ${1} use braces
+    # and are left untouched). Prometheus has no env var substitution of its own.
     - source_labels: [__meta_kubernetes_node_name]
       regex: $(NODE_NAME)
       action: keep

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -411,7 +411,7 @@ TWO SCRAPING MODES:
    - Scrapes kubelet directly: <node-ip>:10250
    - Path: /metrics/cadvisor
    - Used in DaemonSet (federated) mode
-   - Requires ${NODE_NAME} substitution via init container
+   - Requires $(NODE_NAME) substitution via init container
 
 Data flow:
   kubernetes_sd    -->   relabel_configs     -->   SCRAPE
@@ -458,7 +458,7 @@ Usage: {{ include "cloudzero-agent.prometheus.scrapeCAdvisor" (dict "root" . "sc
 # Mode: FEDERATED (DaemonSet)
 # - Each Prometheus instance scrapes only its local node's kubelet
 # - Uses direct kubelet access at <node-ip>:{{ $kubeletPort }}/metrics/cadvisor
-# - ${NODE_NAME} is replaced by init container with actual node name
+# - $(NODE_NAME) is replaced by init container with actual node name
 {{- else if $directNodeAccess }}
 # Mode: DIRECT NODE ACCESS
 # - Single Prometheus scrapes all nodes directly via kubelet
@@ -509,11 +509,14 @@ Usage: {{ include "cloudzero-agent.prometheus.scrapeCAdvisor" (dict "root" . "sc
       target_label: node_name
 
     # Filter to only the local node
-    # NOTE: ${NODE_NAME} is a placeholder replaced by an init container
-    # with the actual node name using sed. This is necessary because
-    # Prometheus doesn't support environment variable substitution.
+    # NOTE: $(NODE_NAME) is a placeholder replaced by an init container with the
+    # actual node name. The prometheus-config-reloader binary performs the
+    # substitution (Thanos-style $(VAR) syntax) when it writes the processed
+    # config; Prometheus itself does not support env var substitution. Note the
+    # parentheses: Prometheus relabel back-references like ${1} use braces and
+    # are deliberately left untouched by the reloader.
     - source_labels: [__meta_kubernetes_node_name]
-      regex: ${NODE_NAME}
+      regex: $(NODE_NAME)
       action: keep
 
     # Set target address to node's internal IP on kubelet port

--- a/helm/templates/_cm_helpers.tpl
+++ b/helm/templates/_cm_helpers.tpl
@@ -411,7 +411,7 @@ TWO SCRAPING MODES:
    - Scrapes kubelet directly: <node-ip>:10250
    - Path: /metrics/cadvisor
    - Used in DaemonSet (federated) mode
-   - Requires $(NODE_NAME) substitution via init container
+   - Requires NODE_NAME placeholder substitution via init container
 
 Data flow:
   kubernetes_sd    -->   relabel_configs     -->   SCRAPE
@@ -458,7 +458,7 @@ Usage: {{ include "cloudzero-agent.prometheus.scrapeCAdvisor" (dict "root" . "sc
 # Mode: FEDERATED (DaemonSet)
 # - Each Prometheus instance scrapes only its local node's kubelet
 # - Uses direct kubelet access at <node-ip>:{{ $kubeletPort }}/metrics/cadvisor
-# - $(NODE_NAME) is replaced by init container with actual node name
+# - the NODE_NAME placeholder is replaced by the init container with the actual node name
 {{- else if $directNodeAccess }}
 # Mode: DIRECT NODE ACCESS
 # - Single Prometheus scrapes all nodes directly via kubelet
@@ -509,9 +509,9 @@ Usage: {{ include "cloudzero-agent.prometheus.scrapeCAdvisor" (dict "root" . "sc
       target_label: node_name
 
     # Filter to only the local node
-    # NOTE: $(NODE_NAME) is substituted with the node name by the reloader init
-    # container (Thanos-style $(VAR) syntax; relabel refs like ${1} use braces
-    # and are left untouched). Prometheus has no env var substitution of its own.
+    # NOTE: the NODE_NAME placeholder below is replaced with the actual node name
+    # by the reloader init container. Relabel back-references such as ${1} use
+    # braces and are left untouched; Prometheus has no env var substitution.
     - source_labels: [__meta_kubernetes_node_name]
       regex: $(NODE_NAME)
       action: keep

--- a/helm/templates/agent-daemonset.yaml
+++ b/helm/templates/agent-daemonset.yaml
@@ -55,18 +55,13 @@ spec:
       {{- include "cloudzero-agent.generatePriorityClassName" (.Values.defaults.priorityClassName | default .Values.server.priorityClassName) | nindent 6 }}
       serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}
       initContainers:
-        # Prometheus doesn't support environment variables where we need them in
-        # the prometheus.yml file, so we use the prometheus-config-reloader
-        # binary (shipped in the agent image) to substitute $(NODE_NAME) in the
-        # prometheus.yml.in file with the actual node name, writing the processed
-        # file used by the Prometheus container. --watch-interval=0 makes the
-        # reloader run the substitution once and exit, which is what an init
-        # container needs.
+        # Prometheus doesn't support env vars in prometheus.yml, so the reloader
+        # binary substitutes $(NODE_NAME) into the processed config consumed by
+        # the server. --watch-interval=0 runs the substitution once and exits.
         - name: config-subst
           {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
-          {{- /* Run the in-image binary by path. When overridden to an external
-                 reloader image (configmapReload.prometheus.image), the reloader is
-                 that image's entrypoint, so let it run and pass only args. */}}
+          {{- /* In-image binary runs by path; an external override image runs via
+                 its own entrypoint, so omit command when the override is set. */}}
           {{- if not .Values.configmapReload.prometheus.image.repository }}
           command:
             - /app/prometheus-config-reloader

--- a/helm/templates/agent-daemonset.yaml
+++ b/helm/templates/agent-daemonset.yaml
@@ -59,13 +59,9 @@ spec:
         # binary substitutes $(NODE_NAME) into the processed config consumed by
         # the server. --watch-interval=0 runs the substitution once and exits.
         - name: config-subst
-          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
-          {{- /* In-image binary runs by path; an external override image runs via
-                 its own entrypoint, so omit command when the override is set. */}}
-          {{- if not .Values.configmapReload.prometheus.image.repository }}
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image) | nindent 10 }}
           command:
             - /app/prometheus-config-reloader
-          {{- end }}
           args:
             - --config-file=/etc/config/prometheus/configmaps/unprocessed/prometheus.yml.in
             - --config-envsubst-file=/etc/config/prometheus/configmaps/processed/prometheus.yml
@@ -92,11 +88,9 @@ spec:
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}
         - name: {{ template "cloudzero-agent.name" . }}-{{ .Values.server.name }}-configmap-reload
-          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
-          {{- if not .Values.configmapReload.prometheus.image.repository }}
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image) | nindent 10 }}
           command:
             - /app/prometheus-config-reloader
-          {{- end }}
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/helm/templates/agent-daemonset.yaml
+++ b/helm/templates/agent-daemonset.yaml
@@ -56,15 +56,25 @@ spec:
       serviceAccountName: {{ template "cloudzero-agent.serviceAccountName" . }}
       initContainers:
         # Prometheus doesn't support environment variables where we need them in
-        # the prometheus.yml file so we use this job to replace the ${NODE_NAME}
-        # in the prometheus.yml.in file with the actual node name, then use that
-        # processed file in the container.
+        # the prometheus.yml file, so we use the prometheus-config-reloader
+        # binary (shipped in the agent image) to substitute $(NODE_NAME) in the
+        # prometheus.yml.in file with the actual node name, writing the processed
+        # file used by the Prometheus container. --watch-interval=0 makes the
+        # reloader run the substitution once and exit, which is what an init
+        # container needs.
         - name: config-subst
-          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.prometheusReloader.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
+          {{- /* Run the in-image binary by path. When overridden to an external
+                 reloader image (configmapReload.prometheus.image), the reloader is
+                 that image's entrypoint, so let it run and pass only args. */}}
+          {{- if not .Values.configmapReload.prometheus.image.repository }}
           command:
-            - /bin/sh
-            - -c
-            - sed "s/\${NODE_NAME}/$NODE_NAME/g" /etc/config/prometheus/configmaps/unprocessed/prometheus.yml.in > /etc/config/prometheus/configmaps/processed/prometheus.yml
+            - /app/prometheus-config-reloader
+          {{- end }}
+          args:
+            - --config-file=/etc/config/prometheus/configmaps/unprocessed/prometheus.yml.in
+            - --config-envsubst-file=/etc/config/prometheus/configmaps/processed/prometheus.yml
+            - --watch-interval=0
           {{- include "cloudzero-agent.generateEnv" (dict
               "env" (list
                 .Values.defaults.env
@@ -87,7 +97,11 @@ spec:
       containers:
         {{- if .Values.configmapReload.prometheus.enabled }}
         - name: {{ template "cloudzero-agent.name" . }}-{{ .Values.server.name }}-configmap-reload
-          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.prometheusReloader.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
+          {{- if not .Values.configmapReload.prometheus.image.repository }}
+          command:
+            - /app/prometheus-config-reloader
+          {{- end }}
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -118,13 +118,9 @@ spec:
         {{- if .Values.configmapReload.prometheus.enabled }}
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: {{ template "cloudzero-agent.name" . }}-{{ .Values.server.name }}-configmap-reload
-          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
-          {{- /* In-image binary runs by path; an external override image runs via
-                 its own entrypoint, so omit command when the override is set. */}}
-          {{- if not .Values.configmapReload.prometheus.image.repository }}
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image) | nindent 10 }}
           command:
             - /app/prometheus-config-reloader
-          {{- end }}
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -118,7 +118,14 @@ spec:
         {{- if .Values.configmapReload.prometheus.enabled }}
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: {{ template "cloudzero-agent.name" . }}-{{ .Values.server.name }}-configmap-reload
-          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.prometheusReloader.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
+          {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
+          {{- /* Run the in-image binary by path. When overridden to an external
+                 reloader image (configmapReload.prometheus.image), the reloader is
+                 that image's entrypoint, so let it run and pass only args. */}}
+          {{- if not .Values.configmapReload.prometheus.image.repository }}
+          command:
+            - /app/prometheus-config-reloader
+          {{- end }}
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/helm/templates/agent-deploy.yaml
+++ b/helm/templates/agent-deploy.yaml
@@ -119,9 +119,8 @@ spec:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: {{ template "cloudzero-agent.name" . }}-{{ .Values.server.name }}-configmap-reload
           {{- include "cloudzero-agent.generateImage" (dict "defaults" .Values.defaults.image "image" .Values.components.agent.image "compat" .Values.configmapReload.prometheus.image) | nindent 10 }}
-          {{- /* Run the in-image binary by path. When overridden to an external
-                 reloader image (configmapReload.prometheus.image), the reloader is
-                 that image's entrypoint, so let it run and pass only args. */}}
+          {{- /* In-image binary runs by path; an external override image runs via
+                 its own entrypoint, so omit command when the override is set. */}}
           {{- if not .Values.configmapReload.prometheus.image.repository }}
           command:
             - /app/prometheus-config-reloader

--- a/helm/tests/configmap_reloader_image_test.yaml
+++ b/helm/tests/configmap_reloader_image_test.yaml
@@ -1,0 +1,70 @@
+suite: test prometheus-config-reloader uses the in-image binary
+templates:
+  - templates/agent-deploy.yaml
+  - templates/agent-daemonset.yaml
+tests:
+  # By default the reload sidecar runs the prometheus-config-reloader binary
+  # shipped in the agent image, invoked by path.
+  - it: reload sidecar uses the agent image and runs the in-image binary (deploy)
+    template: templates/agent-deploy.yaml
+    set:
+      configmapReload.prometheus.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: cloudzero-agent/cloudzero-agent
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: /app/prometheus-config-reloader
+
+  # Forward-compat tombstone: setting configmapReload.prometheus.image pins the
+  # reloader to an external image, where the reloader is the entrypoint, so the
+  # in-image command must NOT be set.
+  - it: external image override drops the in-image command (deploy)
+    template: templates/agent-deploy.yaml
+    set:
+      configmapReload.prometheus.enabled: true
+      configmapReload.prometheus.image.repository: quay.io/prometheus-operator/prometheus-config-reloader
+      configmapReload.prometheus.image.tag: v0.91.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0
+      - notExists:
+          path: spec.template.spec.containers[0].command
+
+  # The config-subst init container performs $(NODE_NAME) substitution with the
+  # reloader binary in one-shot mode (--watch-interval=0) instead of a shell.
+  - it: config-subst init container runs the reloader binary one-shot (daemonset)
+    template: templates/agent-daemonset.yaml
+    set:
+      components.agent.mode: federated
+      configmapReload.prometheus.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].image
+          pattern: cloudzero-agent/cloudzero-agent
+      - equal:
+          path: spec.template.spec.initContainers[0].command[0]
+          value: /app/prometheus-config-reloader
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --watch-interval=0
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --config-envsubst-file=/etc/config/prometheus/configmaps/processed/prometheus.yml
+
+  # Override path also applies to the daemonset config-subst init container.
+  - it: external image override drops the in-image command on config-subst (daemonset)
+    template: templates/agent-daemonset.yaml
+    set:
+      components.agent.mode: federated
+      configmapReload.prometheus.enabled: true
+      configmapReload.prometheus.image.repository: quay.io/prometheus-operator/prometheus-config-reloader
+      configmapReload.prometheus.image.tag: v0.91.0
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0
+      - notExists:
+          path: spec.template.spec.initContainers[0].command

--- a/helm/tests/configmap_reloader_image_test.yaml
+++ b/helm/tests/configmap_reloader_image_test.yaml
@@ -17,22 +17,6 @@ tests:
           path: spec.template.spec.containers[0].command[0]
           value: /app/prometheus-config-reloader
 
-  # Forward-compat tombstone: setting configmapReload.prometheus.image pins the
-  # reloader to an external image, where the reloader is the entrypoint, so the
-  # in-image command must NOT be set.
-  - it: external image override drops the in-image command (deploy)
-    template: templates/agent-deploy.yaml
-    set:
-      configmapReload.prometheus.enabled: true
-      configmapReload.prometheus.image.repository: quay.io/prometheus-operator/prometheus-config-reloader
-      configmapReload.prometheus.image.tag: v0.91.0
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].image
-          value: quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0
-      - notExists:
-          path: spec.template.spec.containers[0].command
-
   # The config-subst init container performs $(NODE_NAME) substitution with the
   # reloader binary in one-shot mode (--watch-interval=0) instead of a shell.
   - it: config-subst init container runs the reloader binary one-shot (daemonset)
@@ -53,18 +37,3 @@ tests:
       - contains:
           path: spec.template.spec.initContainers[0].args
           content: --config-envsubst-file=/etc/config/prometheus/configmaps/processed/prometheus.yml
-
-  # Override path also applies to the daemonset config-subst init container.
-  - it: external image override drops the in-image command on config-subst (daemonset)
-    template: templates/agent-daemonset.yaml
-    set:
-      components.agent.mode: federated
-      configmapReload.prometheus.enabled: true
-      configmapReload.prometheus.image.repository: quay.io/prometheus-operator/prometheus-config-reloader
-      configmapReload.prometheus.image.tag: v0.91.0
-    asserts:
-      - equal:
-          path: spec.template.spec.initContainers[0].image
-          value: quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0
-      - notExists:
-          path: spec.template.spec.initContainers[0].command

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -6357,15 +6357,6 @@
           },
           "type": "object"
         },
-        "prometheusReloader": {
-          "additionalProperties": false,
-          "properties": {
-            "image": {
-              "$ref": "#/$defs/com.cloudzero.agent.image"
-            }
-          },
-          "type": "object"
-        },
         "validator": {
           "additionalProperties": false,
           "properties": {
@@ -6506,9 +6497,6 @@
             "enabled": {
               "default": true,
               "type": "boolean"
-            },
-            "image": {
-              "$ref": "#/$defs/com.cloudzero.agent.image"
             },
             "resources": {
               "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -1200,17 +1200,6 @@ properties:
               Container image configuration for Prometheus.
             $ref: "#/$defs/com.cloudzero.agent.image"
 
-      prometheusReloader:
-        description: |
-          Configuration for the Prometheus reloader component.
-        additionalProperties: false
-        type: object
-        properties:
-          image:
-            description: |
-              Container image configuration for the Prometheus reloader.
-            $ref: "#/$defs/com.cloudzero.agent.image"
-
       webhookServer:
         description: |
           Configuration for the webhook server component.
@@ -1859,8 +1848,6 @@ properties:
           enabled:
             type: boolean
             default: true
-          image:
-            $ref: "#/$defs/com.cloudzero.agent.image"
           resources:
             $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -698,15 +698,17 @@ components:
       repository: quay.io/prometheus/prometheus
       tag:  # This will fall back on .Chart.AppVersion if not set.
 
-  # prometheusReloader contains details about where to find the Prometheus
-  # reloader image.
-  #
-  # prometheus-config-reloader will watch the Prometheus configuration for
-  # changes and restart the Prometheus pod as necessary.
+  # DEPRECATED. The prometheus-config-reloader binary is now built from upstream
+  # source and shipped inside the CloudZero Agent image (see docker/Dockerfile),
+  # so the chart no longer pulls a separate reloader image by default. This block
+  # is retained as a tombstone for forward-compatibility and is no longer wired
+  # into any container. To pin the reloader to an external image (e.g. when
+  # mirroring into a private registry), set configmapReload.prometheus.image
+  # instead, which still overrides the in-image binary.
   prometheusReloader:
     image:
-      repository: quay.io/prometheus-operator/prometheus-config-reloader
-      tag: "v0.91.0"
+      repository:
+      tag:
 
   # Settings for the aggregator component. This is the piece which accepts
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
@@ -1553,6 +1555,12 @@ configmapReload:
     # Whether to enable the Prometheus ConfigMap reloader.
     enabled: true
     # Container image configuration for the Prometheus ConfigMap reloader.
+    #
+    # By default the reloader runs the prometheus-config-reloader binary shipped
+    # in the CloudZero Agent image (built from source, see docker/Dockerfile).
+    # Set this to pull the reloader from an external image instead (e.g. when
+    # mirroring into a private registry); these values override the in-image
+    # binary for both the config-subst init container and the reload sidecar.
     image:
       repository:
       tag:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -698,18 +698,6 @@ components:
       repository: quay.io/prometheus/prometheus
       tag:  # This will fall back on .Chart.AppVersion if not set.
 
-  # DEPRECATED. The prometheus-config-reloader binary is now built from upstream
-  # source and shipped inside the CloudZero Agent image (see docker/Dockerfile),
-  # so the chart no longer pulls a separate reloader image by default. This block
-  # is retained as a tombstone for forward-compatibility and is no longer wired
-  # into any container. To pin the reloader to an external image (e.g. when
-  # mirroring into a private registry), set configmapReload.prometheus.image
-  # instead, which still overrides the in-image binary.
-  prometheusReloader:
-    image:
-      repository:
-      tag:
-
   # Settings for the aggregator component. This is the piece which accepts
   # metrics from the agent, webhook, etc., and sends them to the CloudZero API
   # after some processing.
@@ -1554,18 +1542,6 @@ configmapReload:
   prometheus:
     # Whether to enable the Prometheus ConfigMap reloader.
     enabled: true
-    # Container image configuration for the Prometheus ConfigMap reloader.
-    #
-    # By default the reloader runs the prometheus-config-reloader binary shipped
-    # in the CloudZero Agent image (built from source, see docker/Dockerfile).
-    # Set this to pull the reloader from an external image instead (e.g. when
-    # mirroring into a private registry); these values override the in-image
-    # binary for both the config-subst init container and the reload sidecar.
-    image:
-      repository:
-      tag:
-      digest:
-      pullPolicy:
     # Resource requirements and limits for the Prometheus ConfigMap reloader.
     #
     # For details, see the Kubernetes documentation on resource management:

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -1115,8 +1115,8 @@ data:
           tag: null
       prometheusReloader:
         image:
-          repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.91.0
+          repository: null
+          tag: null
       validator:
         annotations: {}
         checks:
@@ -2618,8 +2618,10 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.12"
           imagePullPolicy: "IfNotPresent"
+          command:
+            - /app/prometheus-config-reloader
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -1113,10 +1113,6 @@ data:
         image:
           repository: quay.io/prometheus/prometheus
           tag: null
-      prometheusReloader:
-        image:
-          repository: null
-          tag: null
       validator:
         annotations: {}
         checks:
@@ -1180,11 +1176,6 @@ data:
     configmapReload:
       prometheus:
         enabled: true
-        image:
-          digest: null
-          pullPolicy: null
-          repository: null
-          tag: null
         resources:
           limits:
             cpu: 200m

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -1030,8 +1030,8 @@ data:
           tag: null
       prometheusReloader:
         image:
-          repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.91.0
+          repository: null
+          tag: null
       validator:
         annotations: {}
         checks:
@@ -2533,8 +2533,10 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.12"
           imagePullPolicy: "IfNotPresent"
+          command:
+            - /app/prometheus-config-reloader
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -1028,10 +1028,6 @@ data:
         image:
           repository: quay.io/prometheus/prometheus
           tag: null
-      prometheusReloader:
-        image:
-          repository: null
-          tag: null
       validator:
         annotations: {}
         checks:
@@ -1095,11 +1091,6 @@ data:
     configmapReload:
       prometheus:
         enabled: true
-        image:
-          digest: null
-          pullPolicy: null
-          repository: null
-          tag: null
         resources:
           limits:
             cpu: 200m

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -413,7 +413,7 @@ data:
       # Mode: FEDERATED (DaemonSet)
       # - Each Prometheus instance scrapes only its local node's kubelet
       # - Uses direct kubelet access at <node-ip>:10250/metrics/cadvisor
-      # - ${NODE_NAME} is replaced by init container with actual node name
+      # - $(NODE_NAME) is replaced by init container with actual node name
       #
       # CRITICAL: The node label must be added in relabel_configs (not
       # metric_relabel_configs) because __meta_kubernetes_node_name is only
@@ -450,11 +450,14 @@ data:
             target_label: node_name
       
           # Filter to only the local node
-          # NOTE: ${NODE_NAME} is a placeholder replaced by an init container
-          # with the actual node name using sed. This is necessary because
-          # Prometheus doesn't support environment variable substitution.
+          # NOTE: $(NODE_NAME) is a placeholder replaced by an init container with the
+          # actual node name. The prometheus-config-reloader binary performs the
+          # substitution (Thanos-style $(VAR) syntax) when it writes the processed
+          # config; Prometheus itself does not support env var substitution. Note the
+          # parentheses: Prometheus relabel back-references like ${1} use braces and
+          # are deliberately left untouched by the reloader.
           - source_labels: [__meta_kubernetes_node_name]
-            regex: ${NODE_NAME}
+            regex: $(NODE_NAME)
             action: keep
       
           # Set target address to node's internal IP on kubelet port
@@ -1118,8 +1121,8 @@ data:
           tag: null
       prometheusReloader:
         image:
-          repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.91.0
+          repository: null
+          tag: null
       validator:
         annotations: {}
         checks:
@@ -2440,16 +2443,21 @@ spec:
       serviceAccountName: cz-agent-cz-server
       initContainers:
         # Prometheus doesn't support environment variables where we need them in
-        # the prometheus.yml file so we use this job to replace the ${NODE_NAME}
-        # in the prometheus.yml.in file with the actual node name, then use that
-        # processed file in the container.
+        # the prometheus.yml file, so we use the prometheus-config-reloader
+        # binary (shipped in the agent image) to substitute $(NODE_NAME) in the
+        # prometheus.yml.in file with the actual node name, writing the processed
+        # file used by the Prometheus container. --watch-interval=0 makes the
+        # reloader run the substitution once and exit, which is what an init
+        # container needs.
         - name: config-subst
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.12"
           imagePullPolicy: "IfNotPresent"
           command:
-            - /bin/sh
-            - -c
-            - sed "s/\${NODE_NAME}/$NODE_NAME/g" /etc/config/prometheus/configmaps/unprocessed/prometheus.yml.in > /etc/config/prometheus/configmaps/processed/prometheus.yml
+            - /app/prometheus-config-reloader
+          args:
+            - --config-file=/etc/config/prometheus/configmaps/unprocessed/prometheus.yml.in
+            - --config-envsubst-file=/etc/config/prometheus/configmaps/processed/prometheus.yml
+            - --watch-interval=0
           env:
             - name: NODE_NAME
               valueFrom:
@@ -2473,8 +2481,10 @@ spec:
               mountPath: /etc/config/prometheus/configmaps/processed/
       containers:
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.12"
           imagePullPolicy: "IfNotPresent"
+          command:
+            - /app/prometheus-config-reloader
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload
@@ -2817,8 +2827,10 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.12"
           imagePullPolicy: "IfNotPresent"
+          command:
+            - /app/prometheus-config-reloader
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -450,12 +450,9 @@ data:
             target_label: node_name
       
           # Filter to only the local node
-          # NOTE: $(NODE_NAME) is a placeholder replaced by an init container with the
-          # actual node name. The prometheus-config-reloader binary performs the
-          # substitution (Thanos-style $(VAR) syntax) when it writes the processed
-          # config; Prometheus itself does not support env var substitution. Note the
-          # parentheses: Prometheus relabel back-references like ${1} use braces and
-          # are deliberately left untouched by the reloader.
+          # NOTE: $(NODE_NAME) is substituted with the node name by the reloader init
+          # container (Thanos-style $(VAR) syntax; relabel refs like ${1} use braces
+          # and are left untouched). Prometheus has no env var substitution of its own.
           - source_labels: [__meta_kubernetes_node_name]
             regex: $(NODE_NAME)
             action: keep
@@ -2442,13 +2439,9 @@ spec:
       
       serviceAccountName: cz-agent-cz-server
       initContainers:
-        # Prometheus doesn't support environment variables where we need them in
-        # the prometheus.yml file, so we use the prometheus-config-reloader
-        # binary (shipped in the agent image) to substitute $(NODE_NAME) in the
-        # prometheus.yml.in file with the actual node name, writing the processed
-        # file used by the Prometheus container. --watch-interval=0 makes the
-        # reloader run the substitution once and exit, which is what an init
-        # container needs.
+        # Prometheus doesn't support env vars in prometheus.yml, so the reloader
+        # binary substitutes $(NODE_NAME) into the processed config consumed by
+        # the server. --watch-interval=0 runs the substitution once and exits.
         - name: config-subst
           image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.12"
           imagePullPolicy: "IfNotPresent"

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -413,7 +413,7 @@ data:
       # Mode: FEDERATED (DaemonSet)
       # - Each Prometheus instance scrapes only its local node's kubelet
       # - Uses direct kubelet access at <node-ip>:10250/metrics/cadvisor
-      # - $(NODE_NAME) is replaced by init container with actual node name
+      # - the NODE_NAME placeholder is replaced by the init container with the actual node name
       #
       # CRITICAL: The node label must be added in relabel_configs (not
       # metric_relabel_configs) because __meta_kubernetes_node_name is only
@@ -450,9 +450,9 @@ data:
             target_label: node_name
       
           # Filter to only the local node
-          # NOTE: $(NODE_NAME) is substituted with the node name by the reloader init
-          # container (Thanos-style $(VAR) syntax; relabel refs like ${1} use braces
-          # and are left untouched). Prometheus has no env var substitution of its own.
+          # NOTE: the NODE_NAME placeholder below is replaced with the actual node name
+          # by the reloader init container. Relabel back-references such as ${1} use
+          # braces and are left untouched; Prometheus has no env var substitution.
           - source_labels: [__meta_kubernetes_node_name]
             regex: $(NODE_NAME)
             action: keep
@@ -1116,10 +1116,6 @@ data:
         image:
           repository: quay.io/prometheus/prometheus
           tag: null
-      prometheusReloader:
-        image:
-          repository: null
-          tag: null
       validator:
         annotations: {}
         checks:
@@ -1183,11 +1179,6 @@ data:
     configmapReload:
       prometheus:
         enabled: true
-        image:
-          digest: null
-          pullPolicy: null
-          repository: null
-          tag: null
         resources:
           limits:
             cpu: 200m

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -1045,8 +1045,8 @@ data:
           tag: null
       prometheusReloader:
         image:
-          repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.91.0
+          repository: null
+          tag: null
       validator:
         annotations: {}
         checks:
@@ -2548,8 +2548,10 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.12"
           imagePullPolicy: "IfNotPresent"
+          command:
+            - /app/prometheus-config-reloader
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -1043,10 +1043,6 @@ data:
         image:
           repository: quay.io/prometheus/prometheus
           tag: null
-      prometheusReloader:
-        image:
-          repository: null
-          tag: null
       validator:
         annotations: {}
         checks:
@@ -1110,11 +1106,6 @@ data:
     configmapReload:
       prometheus:
         enabled: true
-        image:
-          digest: null
-          pullPolicy: null
-          repository: null
-          tag: null
         resources:
           limits:
             cpu: 200m

--- a/tests/helm/template/kubestate.yaml
+++ b/tests/helm/template/kubestate.yaml
@@ -1080,10 +1080,6 @@ data:
         image:
           repository: quay.io/prometheus/prometheus
           tag: null
-      prometheusReloader:
-        image:
-          repository: null
-          tag: null
       validator:
         annotations: {}
         checks:
@@ -1147,11 +1143,6 @@ data:
     configmapReload:
       prometheus:
         enabled: true
-        image:
-          digest: null
-          pullPolicy: null
-          repository: null
-          tag: null
         resources:
           limits:
             cpu: 200m

--- a/tests/helm/template/kubestate.yaml
+++ b/tests/helm/template/kubestate.yaml
@@ -1082,8 +1082,8 @@ data:
           tag: null
       prometheusReloader:
         image:
-          repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.91.0
+          repository: null
+          tag: null
       validator:
         annotations: {}
         checks:
@@ -2067,8 +2067,10 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.12"
           imagePullPolicy: "IfNotPresent"
+          command:
+            - /app/prometheus-config-reloader
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1045,8 +1045,8 @@ data:
           tag: null
       prometheusReloader:
         image:
-          repository: quay.io/prometheus-operator/prometheus-config-reloader
-          tag: v0.91.0
+          repository: null
+          tag: null
       validator:
         annotations: {}
         checks:
@@ -2548,8 +2548,10 @@ spec:
       containers:
         # ConfigMap reloader sidecar for Prometheus/Alloy
         - name: cloudzero-agent-server-configmap-reload
-          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0"
+          image: "ghcr.io/cloudzero/cloudzero-agent/cloudzero-agent:1.2.12"
           imagePullPolicy: "IfNotPresent"
+          command:
+            - /app/prometheus-config-reloader
           args:
             - --watched-dir=/etc/config
             - --reload-url=http://127.0.0.1:9090/-/reload

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -1043,10 +1043,6 @@ data:
         image:
           repository: quay.io/prometheus/prometheus
           tag: null
-      prometheusReloader:
-        image:
-          repository: null
-          tag: null
       validator:
         annotations: {}
         checks:
@@ -1110,11 +1106,6 @@ data:
     configmapReload:
       prometheus:
         enabled: true
-        image:
-          digest: null
-          pullPolicy: null
-          repository: null
-          tag: null
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
## What & why

Ships the `prometheus-config-reloader` executable **inside** the CloudZero Agent image so the chart no longer pulls it as a separate external image. This removes one of the few external images a default install still pulls — each of which customers in controlled-supply-chain / air-gapped environments must mirror, scan, and maintain.

Implements **CP-43357** (sub-task of CP-28669).

## Approach

- **Built from source**, not copied from the prebuilt upstream image (which ships with known High/Critical CVEs). A new `reloader` stage in `docker/Dockerfile` clones the pinned tag, bumps two vulnerable transitive deps (`x/crypto`, `x/net`), cross-compiles for amd64/arm64, and `COPY`s only the binary into the final image. No upstream source is vendored into the repo.
- **Chart rewired** to the in-image binary for the reload sidecar (deploy + daemonset) and the federated-mode `config-subst` init container. The external image override is **removed entirely** (no tombstones): the agent image and the `/app/prometheus-config-reloader` command are always used. This is a breaking change — `components.prometheusReloader.image` and `configmapReload.prometheus.image` are gone, and because the values schema is strict (`additionalProperties: false`), a values file still setting either key will fail validation on upgrade and must drop those keys first.
- **No shell needed** for `config-subst`: the reloader runs one-shot (`--watch-interval=0`) using its built-in `$(VAR)` substitution. The config placeholder changed `${NODE_NAME}` → `$(NODE_NAME)`; Prometheus relabel back-references like `${1}` are left untouched. Config comments avoid the literal `$(...)` form so the reloader's envsubst doesn't rewrite them or emit spurious "unset variable" warnings.

## Validation

- `grype --fail-on high` on the built binary's SBOM: **0 High/Critical**.
- Built/extracted the binary for **linux/amd64 and linux/arm64** (static, stripped); confirmed the dep bumps are embedded.
- Ran the binary one-shot: `$(NODE_NAME)` substituted, `${1}` preserved, **exit 0 even when the reload target is down** (init-container safe).
- **Live federated install on a dev EKS cluster** (built image, DaemonSet mode): `config-subst` exits 0 with no envsubst warnings; the live Prometheus config shows `$(NODE_NAME)` resolved to each pod's node name with `${1}` relabel refs preserved; reload sidecar reaches `last_reload_successful=1` with 0 apply failures.
- New helm unit test: default reload sidecar (deploy) and `config-subst` (daemonset) both use the agent image + in-image command.
- `helm-lint` passes; golden template renders regenerated.

## Acceptance criteria

- [x] Reloader executable shipped in the agent image; chart no longer pulls it separately
- [x] No upstream source vendored (no submodule, no checked-in source)
- [x] Chart uses in-image binary; external reloader override removed
- [x] CI image scan passes — 0 High/Critical introduced by the reloader binary
- [x] Builds for linux/amd64 and linux/arm64
- [x] Pin + bump procedure documented (`docker/Dockerfile`, `DEVELOPMENT.md`)
- [ ] **kuttl/helm test asserting a real reload — follow-up PR** (intentionally split out)

## Notes for reviewers

- External reloader override is removed rather than retained as a tombstone (`configmapReload.prometheus.image` and `components.prometheusReloader.image` both gone); see the breaking-change note under Approach.
- The reload e2e test (kuttl/helm) lands in a follow-up PR.
