### PR TITLE
CP-29639: fix govulncheck duplicate Authorization header on checkout v6+

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -80,6 +80,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # govulncheck-action runs its own internal actions/checkout@v4.1.1.
+          # actions/checkout v6+ persists credentials via a global includeIf
+          # gitconfig; the inner v4.1.1 checkout then adds its own auth header,
+          # so git sends two Authorization headers and the fetch fails with
+          # "Duplicate header: Authorization" (HTTP 400). This job never pushes,
+          # so skip credential persistence to avoid the conflict.
+          persist-credentials: false
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:


### PR DESCRIPTION
## Problem

The `govulncheck` CI job fails the moment we move `actions/checkout` to v6 or v7 (e.g. dependabot PR #873). The failure looks unrelated to the bump — it dies during checkout with:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/Cloudzero/cloudzero-agent/': The requested URL returned error: 400
```

## Root cause

- `actions/checkout` **v6+** changed credential persistence ([actions/checkout#2286](https://github.com/actions/checkout/pull/2286)): it now writes the auth token via a **global `includeIf` gitconfig** instead of the old local `http.extraheader`.
- `golang/govulncheck-action@v1` runs its **own internal, pinned `actions/checkout@v4.1.1`** (`repo-checkout` defaults to `true` — we don't control that pin), which adds a local `extraheader` auth header on top.
- Result: git sends **two** `Authorization` headers → `Duplicate header: "Authorization"` → HTTP 400 → fetch fails before govulncheck ever scans.

This is a documented upstream regression ([actions/checkout#2299](https://github.com/actions/checkout/issues/2299), [peter-evans/create-pull-request#4272](https://github.com/peter-evans/create-pull-request/issues/4272)).

## Fix

Set `persist-credentials: false` on the `govulncheck` job's outer checkout. That job never pushes, so it doesn't need persisted credentials, and dropping them removes the conflicting global header while the inner v4.1.1 checkout keeps its single header.

## Why this lands on develop (not just on #873)

- It's a **no-op on v5**, so it's safe to merge now.
- Once it's on develop, the checkout v5→v7 bump (#873) inherits the fix on its next dependabot rebase — it stays green without a manual commit on the bot-owned branch.
- Without it, develop's own `govulncheck` job would start failing the instant any checkout ≥ v6 bump merges.

Verified: the same change on the #873 branch turned the previously-failing `govulncheck` job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)