### PR TITLE
CP-43805: tolerate deprecated reloader image values

### DIFF
--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -6357,6 +6357,17 @@
           },
           "type": "object"
         },
+        "prometheusReloader": {
+          "additionalProperties": false,
+          "deprecated": true,
+          "properties": {
+            "image": {
+              "$ref": "#/$defs/com.cloudzero.agent.image",
+              "deprecated": true
+            }
+          },
+          "type": "object"
+        },
         "validator": {
           "additionalProperties": false,
           "properties": {
@@ -6497,6 +6508,10 @@
             "enabled": {
               "default": true,
               "type": "boolean"
+            },
+            "image": {
+              "$ref": "#/$defs/com.cloudzero.agent.image",
+              "deprecated": true
             },
             "resources": {
               "$ref": "#/$defs/io.k8s.api.core.v1.ResourceRequirements"

--- a/helm/values.schema.yaml
+++ b/helm/values.schema.yaml
@@ -523,6 +523,18 @@ properties:
     additionalProperties: false
     type: object
     properties:
+      prometheusReloader:
+        description: |
+          Configuration for the Prometheus reloader component.
+        deprecated: true
+        additionalProperties: false
+        type: object
+        properties:
+          image:
+            description: |
+              Container image configuration for the Prometheus reloader.
+            deprecated: true
+            $ref: "#/$defs/com.cloudzero.agent.image"
       apiKey:
         description: |
           API key CSI configuration. Takes effect only when both top-level
@@ -1861,6 +1873,9 @@ properties:
           enabled:
             type: boolean
             default: true
+          image:
+            deprecated: true
+            $ref: "#/$defs/com.cloudzero.agent.image"
           resources:
             $ref: "#/$defs/io.k8s.api.core.v1.ResourceRequirements"
 

--- a/tests/helm/schema/components.prometheusReloader.deprecated.pass.yaml
+++ b/tests/helm/schema/components.prometheusReloader.deprecated.pass.yaml
@@ -1,0 +1,10 @@
+# Test that the deprecated components.prometheusReloader section continues to
+# work without validation errors. This ensures backward compatibility for
+# existing configurations, though it should be noted that setting these values
+# has no impact on the chart as the reloader now ships inside the agent image.
+
+components:
+  prometheusReloader:
+    image:
+      repository: "quay.io/prometheus-operator/prometheus-config-reloader"
+      tag: "v0.87.0"

--- a/tests/helm/schema/configmapReload.prometheus.deprecated.pass.yaml
+++ b/tests/helm/schema/configmapReload.prometheus.deprecated.pass.yaml
@@ -1,0 +1,10 @@
+# Test that the deprecated configmapReload.prometheus.image section continues to
+# work without validation errors. This ensures backward compatibility for
+# existing configurations, though it should be noted that setting these values
+# has no impact on the chart as the reloader now ships inside the agent image.
+
+configmapReload:
+  prometheus:
+    image:
+      repository: "quay.io/prometheus-operator/prometheus-config-reloader"
+      tag: "v0.87.0"


### PR DESCRIPTION
# Why?

PR #872 moved `prometheus-config-reloader` into the agent image and removed the `components.prometheusReloader.image` and `configmapReload.prometheus.image` override keys. The values schema is strict (`additionalProperties: false`), so existing values files that still set either key now fail validation on `helm upgrade`.

# What

Restore both keys to the schema as deprecated, ignored tombstones (the forward-compat CP-43357 originally specified). They validate but have no effect — the in-image reloader is always used.

# How Tested

`make helm-lint` and the schema test suite pass. Added two `.pass` schema fixtures asserting both legacy keys validate.
