### PR TITLE
CP-43967: fix webhook pod anti-affinity selector

### DIFF
--- a/helm/templates/webhook-deploy.yaml
+++ b/helm/templates/webhook-deploy.yaml
@@ -103,7 +103,21 @@ spec:
             (.Values.defaults.securityContext | default (dict))
             (.Values.components.webhookServer.securityContext | default (dict))
           ) | nindent 6 }}
-      {{ $podAntiAffinity := dict "podAntiAffinity" (dict "preferredDuringSchedulingIgnoredDuringExecution" (list (dict "weight" 100 "podAffinityTerm" (dict "labelSelector" (dict "matchLabels" (dict "app" "webhook-server")) "topologyKey" "kubernetes.io/hostname")))) }}
+      {{ $podAntiAffinity := dict
+        "podAntiAffinity" (dict
+          "preferredDuringSchedulingIgnoredDuringExecution" (list
+            (dict
+              "weight" 100
+              "podAffinityTerm" (dict
+                "labelSelector" (dict
+                  "matchLabels" (dict "app.kubernetes.io/name" "webhook-server")
+                )
+                "topologyKey" "kubernetes.io/hostname"
+              )
+            )
+          )
+        )
+      }}
       {{- $userAffinity := deepCopy .Values.insightsController.server.affinity }}
       {{- include "cloudzero-agent.generateAffinity" (dict "default" .Values.defaults.affinity "affinity" (merge $userAffinity $podAntiAffinity)) | nindent 6 }}
       {{- include "cloudzero-agent.generateDNSInfo" (dict "defaults" .Values.defaults.dns) | nindent 6 }}

--- a/helm/tests/webhook_antiaffinity_selector_test.yaml
+++ b/helm/tests/webhook_antiaffinity_selector_test.yaml
@@ -1,0 +1,28 @@
+suite: test webhook server pod anti-affinity selector (CP-43967)
+# Regression guard for CP-43967: the hardcoded webhook podAntiAffinity must
+# select on the label the pods actually carry (app.kubernetes.io/name, emitted
+# by cloudzero-agent.generateLabels), not the bare `app` key — which no pod has,
+# making the rule a silent no-op that never spread replicas across nodes.
+templates:
+  - templates/webhook-deploy.yaml
+tests:
+  - it: should select webhook pods by their real app.kubernetes.io/name label
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels
+          value:
+            app.kubernetes.io/name: webhook-server
+
+  - it: should not select on a bare app label that no webhook pod carries
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels.app
+
+  - it: should keep the rule soft (preferred, weight 100) across hostnames
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: kubernetes.io/hostname

--- a/tests/helm/template/alloy.yaml
+++ b/tests/helm/template/alloy.yaml
@@ -2996,7 +2996,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: webhook-server
+                  app.kubernetes.io/name: webhook-server
               topologyKey: kubernetes.io/hostname
             weight: 100
       

--- a/tests/helm/template/cert-manager.yaml
+++ b/tests/helm/template/cert-manager.yaml
@@ -2905,7 +2905,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: webhook-server
+                  app.kubernetes.io/name: webhook-server
               topologyKey: kubernetes.io/hostname
             weight: 100
       

--- a/tests/helm/template/federated.yaml
+++ b/tests/helm/template/federated.yaml
@@ -3192,7 +3192,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: webhook-server
+                  app.kubernetes.io/name: webhook-server
               topologyKey: kubernetes.io/hostname
             weight: 100
       

--- a/tests/helm/template/istio.yaml
+++ b/tests/helm/template/istio.yaml
@@ -2921,7 +2921,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: webhook-server
+                  app.kubernetes.io/name: webhook-server
               topologyKey: kubernetes.io/hostname
             weight: 100
       

--- a/tests/helm/template/kubestate.yaml
+++ b/tests/helm/template/kubestate.yaml
@@ -2446,7 +2446,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: webhook-server
+                  app.kubernetes.io/name: webhook-server
               topologyKey: kubernetes.io/hostname
             weight: 100
       

--- a/tests/helm/template/manifest.yaml
+++ b/tests/helm/template/manifest.yaml
@@ -2920,7 +2920,7 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: webhook-server
+                  app.kubernetes.io/name: webhook-server
               topologyKey: kubernetes.io/hostname
             weight: 100
       


### PR DESCRIPTION
## What

The webhook server Deployment hardcodes a soft `podAntiAffinity` intended to spread replicas across nodes for high availability. Its selector matched on a bare `app: webhook-server` label that no webhook pod actually carries — pods are labeled `app.kubernetes.io/name: webhook-server` (via the chart's `generateLabels` helper), and the chart never emits a bare `app:` label anywhere.

As a result the rule matched zero pods and was a silent no-op: the default 3 webhook replicas could all be scheduled onto a single node, despite the template advertising *"High availability: Multiple replicas with anti-affinity for fault tolerance."*

## Fix

Correct the selector key to `app.kubernetes.io/name: webhook-server` so the existing soft rule (`preferred`, weight 100, `topologyKey: kubernetes.io/hostname`) actually spreads replicas across nodes. It remains a *preferred* constraint, so it never blocks scheduling on small or single-node clusters. Operator-supplied affinity via `insightsController.server.affinity` continues to take precedence (the merge behavior is unchanged), and the template's HA claim is now accurate.

The `$podAntiAffinity` dict literal is also reformatted across multiple lines, matching the chart's existing style, for readability — no behavior change.

## Tests

- New helm unit test asserting the anti-affinity selector matches the real pod label, the dead bare `app` key is gone, and the rule stays soft (weight 100 / hostname topology).
- Full helm unit suite passes (626 tests); `helm lint` clean.
- Regenerated `tests/helm/template/` baselines — the only rendered change across all topologies is the selector key flip.