### PR TITLE
CP-45935: Bump Alloy to v1.18.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN --mount=type=cache,target=/go/pkg/mod,id=gomod-$TARGETPLATFORM \
 FROM gcr.io/distroless/static-debian12:debug@sha256:46fcf1fa44d251b0944ba4b98ef4bbd266e33034e46489dbf92f680ca4917451 AS certs
 
 # Stage 5: Extract Alloy binary from CloudZero Alloy image
-FROM ghcr.io/cloudzero/alloy:v1.17.0 AS alloy
+FROM ghcr.io/cloudzero/alloy:v1.18.1 AS alloy
 
 # Stage 6: Build prometheus-config-reloader from upstream source. We build it
 # (not copy the prebuilt image) to control the toolchain and bump vulnerable


### PR DESCRIPTION
Updates the Alloy stage in `docker/Dockerfile` from v1.17.0 to v1.18.1. The agent image copies the CloudZero Alloy binary out of that image, so this is what determines the Alloy version the agent actually ships.

## Why

Clears four high-severity advisories that Grype flags against the v1.17.0 image:

| Advisory | Package | Change |
| --- | --- | --- |
| GHSA-hrxh-6v49-42gf | `google.golang.org/grpc` | v1.80.0 → v1.82.1 |
| GO-2026-5970 | `golang.org/x/text` | v0.38.0 → v0.40.0 |
| GO-2026-4970 | `stdlib` | go1.26.4 → go1.26.5 |
| CVE-2026-71556 / GHSA-hc8v-wwc9-vgxm | `github.com/go-git/go-git/v5` | v5.19.1 → v5.19.2 |

Grype against the released v1.18.1 image reports **0 critical / 0 high / 1 medium**. The remaining medium is cel-go GHSA-gcjh-h69q-9w9g, transitive from upstream Grafana Alloy with no fix available short of a fork.

## Upstream

The corresponding cloudzero-alloy release rebases the fork onto upstream Grafana Alloy v1.18.1. Its full test suite passes: 578 packages, 0 failures.

## Verification

Built via `make package-debug` and deployed to the berlioz cluster in clustered mode with the kubeState plugin enabled, standalone kube-state-metrics disabled, and the collector at debug level.

All seven expected KSM metrics were observed arriving at the collector, with zero drops:

| Metric | Count |
| --- | --- |
| `kube_pod_container_resource_requests` | 926 |
| `kube_pod_container_resource_limits` | 818 |
| `kube_pod_info` | 278 |
| `kube_pod_labels` | 278 |
| `kube_node_status_capacity` | 228 |
| `kube_node_info` | 38 |
| `kube_namespace_labels` | 27 |

Alloy re-sharded 80 pods across the clustered replicas; all pods reached Ready on the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)