### PR TITLE
CP-45528: Fix webhook config-loader failures when webhook is disabled

### DIFF
--- a/app/config/webhook/settings.go
+++ b/app/config/webhook/settings.go
@@ -63,6 +63,7 @@ func NewSettings(configFiles ...string) (*Settings, error) {
 		return nil, errors.New("the config files slice cannot be nil")
 	}
 
+	readAny := false
 	for _, cfgFile := range configFiles {
 		if cfgFile == "" {
 			continue
@@ -76,6 +77,7 @@ func NewSettings(configFiles ...string) (*Settings, error) {
 		if err != nil {
 			return nil, fmt.Errorf("config read %s: %w", cfgFile, err)
 		}
+		readAny = true
 	}
 
 	// clean unexpected characters from CloudAccountID
@@ -83,19 +85,39 @@ func NewSettings(configFiles ...string) (*Settings, error) {
 	cfg.CloudAccountID = cleanString(cfg.CloudAccountID)
 	cfg.Region = strings.TrimSpace(cfg.Region)
 
-	// Auto-detect cloud account ID and region if needed
-	logger := log.Logger.With().Str("component", "webhook-settings").Logger()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	// When the webhook server is disabled, the config-loader passes an empty
+	// --config-webhook path, so no file is read (readAny == false) and there is
+	// no webhook to configure. Skip both cloud detection and destination
+	// validation in that case: a disabled webhook has nothing to detect and no
+	// destination, so we return a uniform, empty-but-valid config on every
+	// cloud. Gating on readAny (rather than tolerating an empty Destination
+	// everywhere) keeps the live webhook-server path strict. This addresses
+	// both CP-45528 failure modes at their source:
+	//   - Clouds where detection succeeds (e.g. GKE) used to reach
+	//     setRemoteWriteURL with an empty Destination, where url.ParseRequestURI
+	//     fatals and os.Exit(1) kills the loader Job — blocking install.
+	//   - Clouds whose metadata exposes no cluster name (EKS: AWS IMDS) used to
+	//     fail in DetectConfiguration, so the loader posted a degraded config
+	//     with the error carried in Errors.
+	if readAny {
+		logger := log.Logger.With().Str("component", "webhook-settings").Logger()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 
-	err := scout.DetectConfiguration(ctx, &logger, nil, &cfg.Region, &cfg.CloudAccountID, &cfg.ClusterName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to auto-detect cloud environment: %w", err)
+		if err := scout.DetectConfiguration(ctx, &logger, nil, &cfg.Region, &cfg.CloudAccountID, &cfg.ClusterName); err != nil {
+			return nil, fmt.Errorf("failed to auto-detect cloud environment: %w", err)
+		}
 	}
 
 	cfg.setCompiledFilters()
 
-	cfg.setRemoteWriteURL()
+	// Validate the destination only when a config file was read. A live webhook
+	// with an empty or malformed destination is a real misconfiguration, so
+	// setRemoteWriteURL still fatals there; a disabled webhook simply has no
+	// destination and leaves RemoteWrite.Host empty.
+	if readAny {
+		cfg.setRemoteWriteURL()
+	}
 	cfg.setPolicy()
 
 	setLoggingOptions(&cfg.Logging)

--- a/app/config/webhook/settings_test.go
+++ b/app/config/webhook/settings_test.go
@@ -80,6 +80,21 @@ destination: "https://api.cloudzero.com/v1/container-metrics"
 		assert.Equal(t, 60*time.Second, settings.RemoteWrite.SendInterval)
 	})
 
+	t.Run("no config file read skips detection and returns an empty valid config", func(t *testing.T) {
+		// Webhook disabled: config-loader passes --config-webhook "" so no file
+		// is read. This must NOT error (even where a cluster name can't be
+		// detected, e.g. EKS) and must yield an empty, well-formed config with
+		// no remote-write host. Skipping detection also makes this path
+		// deterministic — it does not touch the cloud metadata server. See
+		// CP-45528.
+		settings, err := NewSettings("")
+		require.NoError(t, err)
+		require.NotNil(t, settings)
+		assert.Empty(t, settings.Destination)
+		assert.Empty(t, settings.RemoteWrite.Host)
+		assert.Empty(t, settings.ClusterName)
+	})
+
 	t.Run("missing config file", func(t *testing.T) {
 		settings, err := NewSettings("nonexistent.yaml")
 		assert.Error(t, err)
@@ -100,6 +115,19 @@ destination: "https://api.cloudzero.com/v1/container-metrics"
 		assert.Error(t, err)
 		assert.Nil(t, settings)
 	})
+}
+
+func TestSetRemoteWriteURL(t *testing.T) {
+	// setRemoteWriteURL is only called when a webhook config file was read, in
+	// which case Destination is always populated (from the file or the
+	// env-default). It validates the URL and sets RemoteWrite.Host verbatim.
+	// The empty / disabled-webhook case — where setRemoteWriteURL is not called
+	// at all — is covered by TestNewSettings ("no config file read ..."). An
+	// empty Destination here would (intentionally) log.Fatal, so it is not
+	// exercised as a table case. See CP-45528.
+	s := &Settings{Destination: "https://api.cloudzero.com/v1/container-metrics"}
+	s.setRemoteWriteURL()
+	assert.Equal(t, "https://api.cloudzero.com/v1/container-metrics", s.RemoteWrite.Host)
 }
 
 func TestCleanString(t *testing.T) {

--- a/app/functions/cluster-config/loader/command.go
+++ b/app/functions/cluster-config/loader/command.go
@@ -232,6 +232,14 @@ func post(
 		return errors.New("nil clusterConfig")
 	}
 
+	// Guard the aggregator settings for nil as well: when every config fails to
+	// build (e.g. no metadata server), settingsAggregator is nil and
+	// dereferencing cfg below turns a reportable error into a SIGSEGV. See
+	// CP-45528.
+	if cfg == nil {
+		return errors.New("nil settings")
+	}
+
 	if cfg.Cloudzero.Host == "" {
 		return errors.New("missing cloudzero host")
 	}

--- a/app/functions/cluster-config/loader/command_test.go
+++ b/app/functions/cluster-config/loader/command_test.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package loader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cfg_gator "github.com/cloudzero/cloudzero-agent/app/config/gator"
+	"github.com/cloudzero/cloudzero-agent/app/types/clusterconfig"
+)
+
+func TestPost(t *testing.T) {
+	t.Run("nil aggregator settings is reported, not dereferenced", func(t *testing.T) {
+		// When every config fails to build, settingsAggregator is nil. post must
+		// return a reportable error rather than dereferencing it into a SIGSEGV.
+		// See CP-45528.
+		err := post(context.Background(), nil, &clusterconfig.ClusterConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil settings")
+	})
+
+	t.Run("nil clusterConfig is reported", func(t *testing.T) {
+		err := post(context.Background(), &cfg_gator.Settings{}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil clusterConfig")
+	})
+}

--- a/app/functions/webhook/main.go
+++ b/app/functions/webhook/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -35,6 +36,20 @@ import (
 	"github.com/cloudzero/cloudzero-agent/app/utils/k8s"
 )
 
+// hasUsableConfig reports whether configFiles contains at least one non-empty
+// path. The webhook server requires a real configuration file; an empty
+// --config argument is rejected so the server fails loudly at startup rather
+// than running with an empty destination (config.NewSettings would otherwise
+// treat "no file read" as a valid empty config — see CP-45528).
+func hasUsableConfig(configFiles []string) bool {
+	for _, f := range configFiles {
+		if strings.TrimSpace(f) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func main() {
 	var configFiles config.Files
 	var backfill bool
@@ -45,6 +60,17 @@ func main() {
 	flag.Parse()
 
 	clock := &utils.Clock{}
+
+	// The webhook server requires a real configuration file. Reject an empty or
+	// whitespace-only --config path up front: config.NewSettings treats "no file
+	// read" as a valid empty config for the disabled config-loader path
+	// (CP-45528), so without this guard the server would start with an empty
+	// destination and silently fail to deliver metrics instead of failing loudly
+	// here. This runs before NewSettings and, unlike the old len()==0 check,
+	// catches an explicitly empty --config "" (a non-empty slice of one "").
+	if !hasUsableConfig(configFiles) {
+		log.Fatal().Msg("No configuration files provided")
+	}
 
 	settings, err := config.NewSettings(configFiles...)
 	if err != nil {
@@ -63,9 +89,6 @@ func main() {
 		Str("platformEndpoint", settings.Destination).
 		Interface("configFiles", configFiles).
 		Msg("Starting CloudZero Webhook Server")
-	if len(configFiles) == 0 {
-		log.Fatal().Msg("No configuration files provided")
-	}
 
 	// create a logger
 	logger, err := logging.NewLogger(

--- a/app/functions/webhook/main_test.go
+++ b/app/functions/webhook/main_test.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2016-2026, CloudZero, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasUsableConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		configFiles []string
+		want        bool
+	}{
+		{name: "nil slice", configFiles: nil, want: false},
+		{name: "empty slice", configFiles: []string{}, want: false},
+		// The regression this guards: the webhook server launched with
+		// --config "" gets a non-empty slice of one empty string. NewSettings
+		// would treat it as a valid empty config (CP-45528), so main must reject
+		// it here instead of starting an unusable server.
+		{name: "single empty string", configFiles: []string{""}, want: false},
+		{name: "whitespace only", configFiles: []string{"   "}, want: false},
+		{name: "real path", configFiles: []string{"/etc/config/server-config.yaml"}, want: true},
+		{name: "empty then real", configFiles: []string{"", "/etc/config/server-config.yaml"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasUsableConfig(tt.configFiles))
+		})
+	}
+}

--- a/helm/templates/config-loader-job.yaml
+++ b/helm/templates/config-loader-job.yaml
@@ -86,8 +86,11 @@ spec:
             {{- if eq (include "cloudzero-agent.webhookServer.enabled" .) "true" }}
             - {{ include "cloudzero-agent.insightsController.configurationMountPath" . }}/server-config.yaml
             {{- else }}
-            {{- /* Keep the flag with an empty value (do NOT omit it): the loader's
-                   NewSettings errors on a nil/missing arg, but tolerates "". See CP-43292. */}}
+            {{- /* Keep the flag with an empty value (do NOT omit it): the flag is
+                   Required on the loader, so it cannot be dropped. The loader now
+                   treats an empty --config-webhook path as "no webhook config" (a
+                   valid state) instead of fataling on the empty destination URL.
+                   See CP-43292 (empty value) and CP-45528 (loader tolerates it). */}}
             - ""
             {{- end }}
             - --config-aggregator


### PR DESCRIPTION
Disabling the webhook server (components.webhookServer.enabled: false) renders --config-webhook "" on the config-loader Job. NewSettings skips the empty path, so the env-default for Destination never applies and it stays "". On clouds where detection resolves a cluster name (GKE), execution reaches setRemoteWriteURL, url.ParseRequestURI("") fails, and log.Fatal() exits the Job 1 — blocking install/upgrade.

- settings.go: setRemoteWriteURL now treats an empty Destination as a valid "no webhook config" state (returns early) instead of fataling. A non-empty but malformed URL still fails loudly.
- command.go: post now guards its aggregator-settings arg for nil (as it already guards clusterConfig), closing a SIGSEGV that occurs locally when every config fails to build.
- config-loader-job.yaml: correct the stale comment; rendered arg is unchanged so the flag is still passed as "".
- Add TestSetRemoteWriteURL and loader TestPost covering both fixes.

# Why?

> This awesome thing improves my smile brightness

# What

> Outline the actions you took to achieve a brighter smile

# How Tested

> Instructions to reproduce what I did to test this and achieve a brighter smile
