### PR TITLE
CP-46909: Bump Go toolchain to 1.26.7

### DIFF
--- a/.tools/go.mod
+++ b/.tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudzero/cloudzero-agent/.tools
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/homeport/dyff v1.12.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ARG RELOADER_VERSION=v0.91.0
 # 7. final: Minimal runtime image with compiled binaries
 
 # Stage 1: Base tools installation
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS base-tools
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS base-tools
 ARG TARGETPLATFORM
 ARG TARGETOS TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudzero/cloudzero-agent
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/tests/docker/Dockerfile.smoke-tests
+++ b/tests/docker/Dockerfile.smoke-tests
@@ -8,7 +8,7 @@
 # components, avoiding the need to build and coordinate multiple images.
 
 # Stage 1: Base tools installation
-FROM golang:1.26.5-alpine AS base-tools
+FROM golang:1.26.7-alpine AS base-tools
 WORKDIR /app
 
 # Install system packages needed for building

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudzero/cloudzero-agent/tests
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/andybalholm/brotli v1.2.2

--- a/tests/integration/test_server/Dockerfile
+++ b/tests/integration/test_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5
+FROM golang:1.26.7
 
 WORKDIR /app
 

--- a/tests/integration/test_server/go.mod
+++ b/tests/integration/test_server/go.mod
@@ -1,5 +1,5 @@
 module main
 
-go 1.26.5
+go 1.26.7
 
 require github.com/golang/snappy v1.0.0


### PR DESCRIPTION
Bumps the Go toolchain 1.26.5 → 1.26.7 across all 7 references: 4 `go.mod` directives and 3 Dockerfiles.

One commit, because `scripts/ci-checks.sh` requires the version to agree everywhere. Staying on 1.26.x keeps this patch-level.

Grype flags six High Go stdlib CVEs (`GO-2026-5026`, `5942`, `5972`, `6088`, `6089`, `6090` — all fixed in 1.26.6) against the go1.26.5 stdlib compiled into our binaries, failing `Merge Docker manifests`.

This does not fully resolve the Grype failure on its own.

Supersedes #967.
